### PR TITLE
hap: recognise haplotype1/haplotype2 contigs; invalidate stale binned BEDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ones, so users can visually compare the effect of smoothing. Both
   variants are produced by ``karyoscope annotate``.
 
+### Fixed
+- Haplotype inference now recognises contig names of the form
+  ``haplotype1...`` / ``haplotype2...`` (e.g. ``haplotype1-0000001``,
+  as emitted by some long-read assemblers) and maps them to
+  ``hap1`` / ``hap2``. Previously these matched no built-in pattern, so
+  a single combined dual-haplotype FASTA collapsed to one haplotype and
+  the karyotype drew no h1/h2 split. The trailing boundary keeps
+  ``haplotype10`` from being misread as hap1.
+- The karyotype no longer reuses a **stale binned-scaffolded BED** when
+  the scaffold map has changed since that BED was built (for example
+  after the haplotype-inference fix above moves a contig from ``hap1``
+  to ``hap2``). The binned-scaffolded BED bakes the map's rename and
+  orientation into its contents, so each one now records a signature of
+  the scaffold map it was built from in a ``.mapsig`` sidecar; on a
+  later run the binned BED is rebuilt when that signature no longer
+  matches the current map (with ``--no-auto``, a clear error is raised
+  instead of silently rendering a stale layout). Without this, a user
+  picking up the inference fix would have had to manually delete the
+  derived ``*.scaffolded.binned*.bed.gz`` files to see the corrected
+  karyotype.
+
 ### Changed
 - Karyotype SVG filenames now include the annotation variant
   (``smoothed`` or ``presmoothed``) so both can coexist on disk:

--- a/src/karyoscope/core/hap_inference.py
+++ b/src/karyoscope/core/hap_inference.py
@@ -4,8 +4,9 @@ Real-world assemblies arrive in many shapes:
 
 * one file per haplotype (the pangenome convention) — easy.
 * one combined file with hap-tagged contig names (HG002 distributed as
-  one FASTA, with hifiasm ``h1tg...`` / ``h2tg...`` or verkko
-  ``MATERNAL`` / ``PATERNAL`` markings) — needs splitting.
+  one FASTA, with hifiasm ``h1tg...`` / ``h2tg...``, ``haplotype1...`` /
+  ``haplotype2...``, or verkko ``MATERNAL`` / ``PATERNAL`` markings) —
+  needs splitting.
 * one file for a haploid assembly (CHM13) — single label.
 * mixed: a hap1.fa.gz + hap2.fa.gz + unassigned.fa.gz triple — needs
   per-file labels.
@@ -80,6 +81,13 @@ def _compile(pat: str) -> re.Pattern[str]:
 _PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     # hifiasm dual/trio: h1tg..., h2tg...
     (_compile(r"^h([12])tg"), r"hap\1"),
+    # full word "haplotype1" / "haplotype2" (e.g. "haplotype1-0000001",
+    # as emitted by some long-read assemblers). Listed before the
+    # generic hap1/hap2 rule below because that rule's `hap([12])`
+    # cannot match here ("hap" is followed by "l"), so the full word
+    # needs its own pattern. Bounded by the trailing class so
+    # "haplotype10" is not read as "hap1".
+    (_compile(r"(?:^|[._\-/])haplotype([12])(?:[._\-/]|$)"), r"hap\1"),
     # explicit hap1/hap2 anywhere, bounded by word edges or .-_/
     (_compile(r"(?:^|[._\-/])hap([12])(?:[._\-/]|$)"), r"hap\1"),
     # h1/h2 alone (rare — accepts H1, H2 too)

--- a/src/karyoscope/core/io/scaffold_map.py
+++ b/src/karyoscope/core/io/scaffold_map.py
@@ -31,6 +31,7 @@ any script that consumed the old output. See
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -139,6 +140,41 @@ def read_map(path: Path) -> list[MapRow]:
                 )
             )
     return rows
+
+
+def map_signature(rows: list[MapRow]) -> str:
+    """Return a stable content signature of a scaffold map.
+
+    SHA-256 over every field of every row, so the digest captures the
+    full rename/orientation contract (and therefore any change to it:
+    a corrected hap label flips ``hap`` and the ``new_name`` it is
+    encoded into; a re-classified chromosome or re-decided orientation
+    likewise changes a field). Downstream caches that bake the map into
+    their output -- the binned-scaffolded BEDs -- record this signature
+    so they can detect when they were built from a now-superseded map
+    and rebuild instead of silently serving stale haplotype layouts.
+
+    Rows are sorted first, so the signature depends only on the mapping
+    content, not on the order rows happen to be written in.
+    """
+    h = hashlib.sha256()
+    for r in sorted(rows, key=lambda row: (row.original_name, row.new_name)):
+        h.update(
+            "\t".join(
+                (
+                    r.new_name,
+                    r.original_name,
+                    r.input_file,
+                    r.hap,
+                    r.chromosome,
+                    "yes" if r.flipped else "no",
+                    str(r.length),
+                    r.stats,
+                )
+            ).encode()
+        )
+        h.update(b"\n")
+    return h.hexdigest()
 
 
 def write_legacy_stats(rows: list[MapRow], path: Path) -> None:

--- a/src/karyoscope/core/karyotype_run.py
+++ b/src/karyoscope/core/karyotype_run.py
@@ -40,7 +40,7 @@ from karyoscope.core.bin import bin_features, leaves_for
 from karyoscope.core.centromeres import centromeres_run
 from karyoscope.core.io.colors import colors_for_set, parse_colors, validate_colors
 from karyoscope.core.io.hierarchy import parse_hierarchy
-from karyoscope.core.io.scaffold_map import MapRow, read_map
+from karyoscope.core.io.scaffold_map import MapRow, map_signature, read_map
 from karyoscope.core.karyotype import (
     DEFAULT_HUMAN_CHROMOSOMES,
     RenderInput,
@@ -136,6 +136,45 @@ def _binned_scaffolded_bed_path(
     return out_dir / f"{stem}.{db_id}.{fs}.{variant}.scaffolded.binned{bin_size}.bed.gz"
 
 
+def _binned_mapsig_path(binned: Path) -> Path:
+    """Sidecar path recording the scaffold-map signature a binned BED was built from."""
+    return binned.with_name(binned.name + ".mapsig")
+
+
+def _binned_bed_is_current(binned: Path, map_rows: list[MapRow] | None) -> bool:
+    """True if ``binned`` was built from the same scaffold map as ``map_rows``.
+
+    The binned-scaffolded BED bakes in the scaffold map's rename and
+    orientation (its sequence names are the encoded
+    ``<chrom>_<hap>_<contig>`` names, and coordinates may be flipped).
+    Reusing it after the map changed -- e.g. after hap inference was
+    corrected so a contig moved from ``hap1`` to ``hap2`` -- would serve
+    a stale haplotype layout. We compare the current map's signature
+    against the one recorded in the ``.mapsig`` sidecar when the binned
+    BED was written.
+
+    Fails closed: a missing or unreadable sidecar (e.g. a binned BED
+    from before this guard existed) is treated as not-current, so it is
+    rebuilt once. ``map_rows is None`` means the caller cannot supply a
+    map to check against; we preserve the legacy reuse-if-present
+    behaviour in that case rather than force an un-checkable rebuild.
+    """
+    if map_rows is None:
+        return True
+    try:
+        recorded = _binned_mapsig_path(binned).read_text().strip()
+    except OSError:
+        return False
+    return recorded == map_signature(map_rows)
+
+
+def _write_binned_mapsig(binned: Path, map_rows: list[MapRow] | None) -> None:
+    """Record the scaffold-map signature next to a freshly built binned BED."""
+    if map_rows is None:
+        return
+    _binned_mapsig_path(binned).write_text(map_signature(map_rows) + "\n")
+
+
 def _load_binned_bed(path: Path) -> OrderedDict[str, list[Interval]]:
     opener = gzip.open if path.suffix == ".gz" else open
     out: OrderedDict[str, list[Interval]] = OrderedDict()
@@ -190,7 +229,15 @@ def _ensure_binned_scaffolded(
     map_rows: list[MapRow] | None = None,
     variant: str = "smoothed",
 ) -> Path:
-    """Return the binned scaffolded BED path, building it if missing.
+    """Return the binned scaffolded BED path, building it if missing or stale.
+
+    An existing binned BED is reused only when it is also *current* with
+    respect to the scaffold map (see :func:`_binned_bed_is_current`): the
+    binned BED bakes the map's rename + orientation into its contents, so
+    a map that changed since it was built (e.g. corrected hap inference
+    moving a contig to a different haplotype) forces a rebuild rather
+    than serving a stale layout. Each freshly built binned BED records
+    the map signature it was built from in a ``.mapsig`` sidecar.
 
     Two construction paths:
 
@@ -205,13 +252,22 @@ def _ensure_binned_scaffolded(
     annotation BEDs and produce correspondingly named intermediates.
     """
     out = _binned_scaffolded_bed_path(out_dir, stem, db_id, fs, bin_size, variant=variant)
-    if out.is_file():
+    if out.is_file() and _binned_bed_is_current(out, map_rows):
         return out
     if not auto:
+        # File absent, or present but built from a superseded scaffold
+        # map (e.g. hap inference was corrected since). We were told not
+        # to auto-derive, so we can't fix it here -- but silently
+        # serving a stale haplotype layout is exactly the bug this guard
+        # exists to prevent, so fail loudly instead.
+        stale = out.is_file()
         raise KaryotypeError(
-            f"missing binned scaffolded BED for {input_name}, feature set "
-            f"{fs!r}, bin size {bin_size} (expected at {out}). Re-run with "
-            "auto-derive enabled."
+            f"{'stale' if stale else 'missing'} binned scaffolded BED for "
+            f"{input_name}, feature set {fs!r}, bin size {bin_size} "
+            f"(at {out}). "
+            + ("The scaffold map changed since it was built. " if stale else "")
+            + "Re-run with auto-derive enabled"
+            + (f" (or delete {out.name} and its .mapsig)." if stale else ".")
         )
     scaffolded_src = _scaffolded_bed_path(out_dir, stem, db_id, fs, variant=variant)
     if scaffolded_src.is_file():
@@ -222,6 +278,7 @@ def _ensure_binned_scaffolded(
             leaf_set=leaf_set or None,
             threads=threads,
         )
+        _write_binned_mapsig(out, map_rows)
         return out
 
     # Fallback: bin the annotation BED, then apply the scaffold map.
@@ -250,6 +307,7 @@ def _ensure_binned_scaffolded(
         rewrite_bed(tmp_binned, out, map_rows=map_rows)
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
+    _write_binned_mapsig(out, map_rows)
     return out
 
 

--- a/tests/test_hap_inference.py
+++ b/tests/test_hap_inference.py
@@ -28,6 +28,23 @@ class TestInferFromContig:
     def test_explicit_hap2_case_insensitive(self) -> None:
         assert infer_hap_from_contig("chr1.HAP2.001") == "hap2"
 
+    def test_full_word_haplotype1(self) -> None:
+        # Some long-read assemblers emit contig names like
+        # "haplotype1-0000001"; the bare "hap([12])" rule can't catch
+        # these ("hap" is followed by "l"), so they need the full-word
+        # pattern.
+        assert infer_hap_from_contig("haplotype1-0000001") == "hap1"
+
+    def test_full_word_haplotype2(self) -> None:
+        assert infer_hap_from_contig("haplotype2-0000029") == "hap2"
+
+    def test_full_word_haplotype_case_insensitive(self) -> None:
+        assert infer_hap_from_contig("HAPLOTYPE2-5") == "hap2"
+
+    def test_full_word_haplotype_does_not_overmatch(self) -> None:
+        # "haplotype10" must not be read as hap1 (trailing boundary).
+        assert infer_hap_from_contig("haplotype10-0001") is None
+
     def test_maternal_short(self) -> None:
         assert infer_hap_from_contig("chr1_MAT_contig01") == "maternal"
 
@@ -162,6 +179,21 @@ class TestClassifyContigsSingleInput:
             "h1tg000002l": "hap1",
             "h2tg000003l": "hap2",
             "h2tg000004l": "hap2",
+        }
+
+    def test_packed_diploid_split_full_word_haplotype(self) -> None:
+        # Combined file whose contigs are named "haplotype1-..." /
+        # "haplotype2-..." (the case that previously collapsed to a
+        # single hap1, so the karyotype drew no h1/h2 split).
+        result = classify_contigs(
+            ["haplotype1-0000001", "haplotype1-0000002", "haplotype2-0000029"],
+            file_level_label="hap1",
+            is_only_input=True,
+        )
+        assert result == {
+            "haplotype1-0000001": "hap1",
+            "haplotype1-0000002": "hap1",
+            "haplotype2-0000029": "hap2",
         }
 
     def test_packed_diploid_with_unmatched_gets_default(self) -> None:

--- a/tests/test_karyotype_run.py
+++ b/tests/test_karyotype_run.py
@@ -1,0 +1,88 @@
+"""Unit tests for :mod:`karyoscope.core.karyotype_run` helpers.
+
+These cover the pure-Python staleness guard for binned-scaffolded BEDs
+(no cairo / rendering needed). The end-to-end rendering tests live in
+``test_karyotype.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from karyoscope.core.io.scaffold_map import MapRow, map_signature
+from karyoscope.core.karyotype_run import (
+    _binned_bed_is_current,
+    _binned_mapsig_path,
+    _write_binned_mapsig,
+)
+
+
+def _row(new_name: str, *, hap: str, flipped: bool = False) -> MapRow:
+    return MapRow(
+        new_name=new_name,
+        original_name=new_name.split("_")[-1],
+        input_file="x.fa",
+        hap=hap,
+        chromosome=new_name.split("_")[0],
+        flipped=flipped,
+        length=1000,
+        stats="PCQ",
+    )
+
+
+def _binned(tmp_path: Path) -> Path:
+    # The helpers only touch the sidecar, not the binned BED's bytes, so
+    # an empty placeholder file is enough to stand in for a built BED.
+    p = tmp_path / "s.db.region.smoothed.scaffolded.binned100000.bed.gz"
+    p.write_bytes(b"")
+    return p
+
+
+def test_mapsig_path_is_sidecar(tmp_path: Path) -> None:
+    binned = _binned(tmp_path)
+    assert _binned_mapsig_path(binned) == binned.with_name(binned.name + ".mapsig")
+
+
+def test_fresh_sidecar_is_current(tmp_path: Path) -> None:
+    binned = _binned(tmp_path)
+    rows = [_row("chr1_hap1_a", hap="hap1"), _row("chr1_hap2_b", hap="hap2")]
+    _write_binned_mapsig(binned, rows)
+    assert _binned_bed_is_current(binned, rows)
+
+
+def test_changed_map_is_not_current(tmp_path: Path) -> None:
+    binned = _binned(tmp_path)
+    # Built when both contigs were hap1 (the pre-fix collapse) ...
+    _write_binned_mapsig(binned, [_row("chr1_hap1_a", hap="hap1"), _row("chr1_hap1_b", hap="hap1")])
+    # ... now hap inference is corrected: the second contig is hap2.
+    corrected = [_row("chr1_hap1_a", hap="hap1"), _row("chr1_hap2_b", hap="hap2")]
+    assert not _binned_bed_is_current(binned, corrected)
+
+
+def test_missing_sidecar_is_not_current(tmp_path: Path) -> None:
+    # A binned BED from before the guard existed has no sidecar; it must
+    # be treated as stale (rebuilt once) rather than trusted.
+    binned = _binned(tmp_path)
+    assert not _binned_bed_is_current(binned, [_row("chr1_hap1_a", hap="hap1")])
+
+
+def test_empty_sidecar_is_not_current(tmp_path: Path) -> None:
+    binned = _binned(tmp_path)
+    _binned_mapsig_path(binned).write_text("")
+    assert not _binned_bed_is_current(binned, [_row("chr1_hap1_a", hap="hap1")])
+
+
+def test_none_map_rows_preserves_legacy_reuse(tmp_path: Path) -> None:
+    # When the caller can't supply a map to check against, fall back to
+    # the historical reuse-if-present behaviour.
+    binned = _binned(tmp_path)
+    assert _binned_bed_is_current(binned, None)
+    _write_binned_mapsig(binned, None)  # no-op, must not raise or create a file
+    assert not _binned_mapsig_path(binned).exists()
+
+
+def test_sidecar_contents_match_signature(tmp_path: Path) -> None:
+    binned = _binned(tmp_path)
+    rows = [_row("chr1_hap1_a", hap="hap1")]
+    _write_binned_mapsig(binned, rows)
+    assert _binned_mapsig_path(binned).read_text().strip() == map_signature(rows)

--- a/tests/test_scaffold_map.py
+++ b/tests/test_scaffold_map.py
@@ -8,6 +8,7 @@ import pytest
 
 from karyoscope.core.io.scaffold_map import (
     MapRow,
+    map_signature,
     read_map,
     write_legacy_stats,
     write_map,
@@ -114,3 +115,38 @@ class TestLegacyStats:
         p = tmp_path / "stats.tsv"
         write_legacy_stats(rows, p)
         assert p.read_text() == "chr1_hap1_ctg1\tTPCQT\nchr2_hap2_ctg2_rc\tQC\n"
+
+
+class TestMapSignature:
+    """The signature backs binned-scaffolded BED cache invalidation:
+    same map content -> same digest; any change -> a different digest."""
+
+    def test_identical_maps_match(self) -> None:
+        a = [_row(), _row(new_name="chr2_hap1_ctg3", original_name="ctg3", chromosome="chr2")]
+        b = [_row(), _row(new_name="chr2_hap1_ctg3", original_name="ctg3", chromosome="chr2")]
+        assert map_signature(a) == map_signature(b)
+
+    def test_row_order_does_not_matter(self) -> None:
+        r1 = _row()
+        r2 = _row(new_name="chr2_hap1_ctg3", original_name="ctg3", chromosome="chr2")
+        assert map_signature([r1, r2]) == map_signature([r2, r1])
+
+    def test_changed_hap_changes_signature(self) -> None:
+        # The exact scenario the guard protects: a contig moves from
+        # hap1 to hap2 (which also flips its encoded new_name).
+        before = [_row(new_name="chr1_hap1_ctg1", hap="hap1")]
+        after = [_row(new_name="chr1_hap2_ctg1", hap="hap2")]
+        assert map_signature(before) != map_signature(after)
+
+    def test_changed_orientation_changes_signature(self) -> None:
+        before = [_row(flipped=False)]
+        after = [_row(flipped=True)]
+        assert map_signature(before) != map_signature(after)
+
+    def test_added_contig_changes_signature(self) -> None:
+        one = [_row()]
+        two = [_row(), _row(new_name="chr2_hap1_ctg3", original_name="ctg3", chromosome="chr2")]
+        assert map_signature(one) != map_signature(two)
+
+    def test_empty_map_is_stable(self) -> None:
+        assert map_signature([]) == map_signature([])


### PR DESCRIPTION
## Summary

Fixes a combined dual-haplotype FASTA being drawn as a single haplotype in the karyotype (no h1/h2 split), reported for contigs named `haplotype1-0000001` / `haplotype2-0000029`. Two coupled changes:

### 1. Recognise `haplotype1` / `haplotype2` contig names

The karyotype's h1/h2 split is driven by the hap label assigned at scaffold time (`hap_inference` → `scaffold_map.tsv` → `row.hap` → `karyotype.py`). The pattern library matched `h1tg…`, `hap1`, `MATERNAL/PATERNAL`, etc., but **not the full word** `haplotype1`/`haplotype2` — and the generic `hap([12])` rule can't catch it because in `haplotype1` the `hap` is followed by `l`. So those contigs matched nothing → single-input inference collapsed everything to the `hap1` fallback → one haplotype.

Added one bounded, case-insensitive pattern. `haplotype1-…` → `hap1`, `haplotype2-…` → `hap2`; the trailing boundary keeps `haplotype10` from being misread as hap1.

### 2. Invalidate stale binned-scaffolded BEDs when the scaffold map changes

`scaffold_map.tsv` is regenerated every run, but the **binned-scaffolded BEDs** (`*.scaffolded.binned<N>.bed.gz`) — which bake the map's rename + orientation into their sequence names and coordinates — were reused purely on `is_file()` (`karyotype_run.py`). So picking up the inference fix above would have required the user to manually delete those derived files; otherwise the karyotype keeps rendering the old (collapsed) layout.

Now each binned BED records a SHA-256 signature of the scaffold map it was built from in a `.mapsig` sidecar (mirroring the combined-BED `.done` marker pattern). On a later run it's rebuilt when the signature no longer matches the current map. Fails closed: a missing/unreadable sidecar (pre-guard BEDs) is treated as stale and rebuilt once. Under `--no-auto` (derivation disabled), a stale binned BED raises a clear, actionable error instead of silently rendering an outdated layout.

## Effect for the reporting user

After this, re-running the karyotype (default auto-derive) on the same output dir transparently rebuilds the stale binned BEDs with the corrected haplotypes — no manual file deletion, and the expensive hap-independent annotation outputs are still reused.

## Tests

- `infer_hap_from_contig`/`classify_contigs`: full-word `haplotype1/2`, case-insensitivity, `haplotype10` non-match, and a single-input split using the exact reported naming.
- `map_signature`: identical maps match; row order irrelevant; changed hap / orientation / added contig each change the digest.
- New `test_karyotype_run.py`: sidecar round-trip is current; changed map / missing sidecar / empty sidecar are not current; `map_rows=None` preserves legacy reuse.
- Full suite green: 39 integration + 499 unit (2 pre-existing libcairo skips); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)