### PR TITLE
scaffold: add --combine-chromosomes (concatenate contigs into chromos…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- ``karyoscope scaffold`` can now concatenate the contigs of each
+  chromosome+haplotype into a single sequence, producing a less
+  fragmented assembly. New flags (FASTA output only, i.e. ``--mode
+  fasta`` / ``--mode both``):
+  - ``--combine-chromosomes`` (default off): join all contigs of one
+    ``(chromosome, hap)`` into one ``<chrom>_<hap>`` record.
+  - ``--scaffold-gap-size`` (default 100000): number of ``N`` bases
+    inserted between concatenated contigs.
+  - ``--combine-acrocentrics`` (default off): also combine the
+    acrocentric chromosomes. Off by default because acrocentric p-arms
+    recombine and KaryoScope's chromosome assignment there is less
+    certain, so their contigs stay as separate records unless this is
+    set. The acrocentric set is the same one ``--acrocentric`` controls.
+
+  Combined outputs carry a ``combined_chromosomes`` filename tag so a
+  user can run with and without combining in the same directory:
+  ``<stem>.<db>.scaffolded.combined_chromosomes.fa[.gz]`` and, in
+  ``--mode both``, ``<stem>.<db>.<fs>.smoothed.scaffolded.combined_chromosomes.bed[.gz]``
+  (the plain per-contig scaffolded BEDs are not written in a combine
+  run). An AGP 2.1 file,
+  ``<stem>.<db>.scaffolded.combined_chromosomes.agp``, documents every
+  component placement and gap (``gap_type=scaffold``, ``linkage=yes``,
+  ``linkage_evidence=align_genus`` -- KaryoScope is alignment-free, but
+  the contig order/orientation is asserted from each contig's k-mer
+  feature profile against a same-genus human reference). The AGP fully
+  describes the output FASTA, including kept unscaffolded leftovers as
+  singleton objects.
+
+  The combined BEDs share the FASTA's coordinate system exactly. Each
+  per-contig annotation BED tiles ``[0, E)`` where ``E = L - k + 1``
+  (``L`` = true contig length, ``k`` = k-mer size); the map's ``length``
+  field is ``E``. When contigs are concatenated as ``seq + N*gap + seq``,
+  each contig's intervals shift by its true-base offset and a ``novel``
+  interval fills ``[offset + E, next_offset)`` between contigs -- the
+  literal N gap **plus** the contig's own untiled ``k-1`` tail, whose
+  k-mers in the concatenated assembly overlap the Ns. This is
+  byte-identical to re-annotating the combined FASTA (smoothing never
+  bridges the gap, which is far larger than ``max_gap=1000``). The
+  implementation reads true lengths from the FASTA and tiling ends from
+  each BED, so it hardcodes no ``k`` and stays correct for a future
+  variable-k database (designed-for but, lacking such a database, not
+  yet exercised in tests). ``karyotype`` awareness of the
+  ``combined_chromosomes`` files is a separate follow-up.
 - ``karyoscope annotate`` is now resumable across the expensive
   ``get_featureIDs`` (k-mer query) step. On success that step writes a
   small ``<input>.<dbid>.combined.presmoothed.featureIDs.bed.done``

--- a/src/karyoscope/commands/scaffold.py
+++ b/src/karyoscope/commands/scaffold.py
@@ -165,6 +165,33 @@ def _split_comma(value: str) -> list[str]:
     "chromosome) at the end of the output under their original names. Disable to drop them entirely.",
 )
 @click.option(
+    "--combine-chromosomes/--no-combine-chromosomes",
+    default=False,
+    show_default=True,
+    help="Concatenate all contigs of each chromosome+haplotype into a single "
+    "'<chrom>_<hap>' sequence separated by N gaps, producing a less fragmented "
+    "assembly. FASTA modes only. Adds a 'combined_chromosomes' tag to output "
+    "filenames and writes an AGP file documenting the placements. In --mode both, "
+    "the per-feature-set BEDs are written in the combined coordinate system.",
+)
+@click.option(
+    "--scaffold-gap-size",
+    type=int,
+    default=100_000,
+    show_default=True,
+    help="Number of N bases to insert between concatenated contigs when "
+    "--combine-chromosomes is set.",
+)
+@click.option(
+    "--combine-acrocentrics/--no-combine-acrocentrics",
+    default=False,
+    show_default=True,
+    help="Also combine acrocentric chromosomes (chr13/14/15/21/22 by default). Off by "
+    "default: acrocentric p-arms recombine and chromosome assignment there is less "
+    "certain, so their contigs stay as separate records unless this is set. Only "
+    "has effect with --combine-chromosomes.",
+)
+@click.option(
     "--bgzip/--no-bgzip",
     default=True,
     show_default=True,
@@ -196,6 +223,9 @@ def cmd(
     acrocentrics_raw: tuple[str, ...],
     mode: str,
     keep_unscaffolded: bool,
+    combine_chromosomes: bool,
+    scaffold_gap_size: int,
+    combine_acrocentrics: bool,
     threads: int,
     bgzip: bool,
     auto: bool,
@@ -283,6 +313,16 @@ def cmd(
             "Use --mode bed or --mode both, or drop --feature-set."
         )
 
+    if combine_chromosomes and mode_normalised == "bed":
+        raise click.UsageError(
+            "--combine-chromosomes requires a FASTA output; use --mode fasta or --mode both "
+            "(it has no meaning with --mode bed)."
+        )
+    if scaffold_gap_size < 0:
+        raise click.BadParameter("--scaffold-gap-size must be >= 0")
+    if not combine_chromosomes and combine_acrocentrics:
+        logger.warning("--combine-acrocentrics has no effect without --combine-chromosomes")
+
     db_root = paths.ensure_db_root(db_root_arg)
     try:
         results = scaffold_run(
@@ -298,6 +338,9 @@ def cmd(
             threads=threads,
             bgzip=bgzip,
             keep_unscaffolded=keep_unscaffolded,
+            combine_chromosomes=combine_chromosomes,
+            scaffold_gap_size=scaffold_gap_size,
+            combine_acrocentrics=combine_acrocentrics,
             auto=auto,
             output_dir=output_dir,
         )
@@ -320,5 +363,7 @@ def cmd(
         click.echo(f"    stats:  {result.stats_path}")
         if result.scaffolded_fasta is not None:
             click.echo(f"    fasta:  {result.scaffolded_fasta}")
+        if result.agp_path is not None:
+            click.echo(f"    agp:    {result.agp_path}")
         for fs, p in result.scaffolded_beds.items():
             click.echo(f"    {fs}:  {p}")

--- a/src/karyoscope/core/io/agp.py
+++ b/src/karyoscope/core/io/agp.py
@@ -1,0 +1,145 @@
+"""AGP (A Golden Path) writer for combined-chromosome scaffolds.
+
+When ``karyoscope scaffold --combine-chromosomes`` concatenates the
+contigs of one ``(chromosome, haplotype)`` into a single sequence, the
+simplified record name (``chr4_hap2``) drops the per-contig provenance
+that the encoded ``chr4_hap2_<contig>[_rc]`` name carried. The AGP file
+restores it: it describes, for every sequence in the output FASTA, the
+exact placement of each original contig and the coordinates of the N
+gaps inserted between them.
+
+We emit AGP version 2.1. The format is tab-separated, 1-based, with two
+row kinds distinguished by column 5 (``component_type``):
+
+* **component rows** (``W`` -- WGS contig)::
+
+      object  obj_beg  obj_end  part_num  W  component_id  comp_beg  comp_end  orientation
+
+  ``comp_beg``/``comp_end`` span the full original contig (``1`` ..
+  ``length``); ``orientation`` is ``+`` for a contig used as-is and
+  ``-`` for one that scaffold reverse-complemented (the ``_rc``
+  contigs).
+
+* **gap rows** (``N`` -- gap of known length)::
+
+      object  obj_beg  obj_end  part_num  N  gap_length  gap_type  linkage  linkage_evidence
+
+  KaryoScope writes ``gap_type=scaffold``, ``linkage=yes``,
+  ``linkage_evidence=align_genus``. The evidence value reflects that,
+  although KaryoScope is alignment-free, the contig order and
+  orientation are asserted from each contig's k-mer feature profile
+  against a human reference database (a reference within the same
+  genus).
+
+An AGP is meant to reconstruct its FASTA exactly: every sequence and
+every base must be accounted for. The writer therefore expects the
+caller to pass one :class:`AgpObject` per output FASTA record,
+including singleton (uncombined) contigs and any unscaffolded
+leftovers, each as a one-component object with no gaps.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+#: Gap metadata KaryoScope writes for every inserted scaffold gap.
+#: See the module docstring for the rationale behind ``align_genus``.
+GAP_TYPE = "scaffold"
+GAP_LINKAGE = "yes"
+GAP_LINKAGE_EVIDENCE = "align_genus"
+
+
+@dataclass(frozen=True)
+class AgpComponent:
+    """One placed original contig (an AGP ``W`` row).
+
+    ``object_start`` / ``object_end`` are 0-based, half-open, in the
+    coordinate system of the combined output sequence; the writer
+    converts them to AGP's 1-based inclusive convention. ``length`` is
+    the full length of the original contig in bp. ``orientation`` is
+    ``"+"`` or ``"-"``.
+    """
+
+    component_id: str
+    object_start: int
+    object_end: int
+    length: int
+    orientation: str
+
+
+@dataclass(frozen=True)
+class AgpGap:
+    """One inserted N gap (an AGP ``N`` row).
+
+    ``object_start`` / ``object_end`` are 0-based half-open in the
+    combined sequence; ``length`` equals ``object_end - object_start``
+    and is the number of N bases.
+    """
+
+    object_start: int
+    object_end: int
+    length: int
+
+
+@dataclass(frozen=True)
+class AgpObject:
+    """One output FASTA record and the parts (components + gaps) it is built from.
+
+    ``parts`` is the ordered list of :class:`AgpComponent` and
+    :class:`AgpGap` that tile the object from base 0 to its end with no
+    gaps or overlaps. A singleton contig is a single-component object
+    with an empty-of-gaps part list of length one.
+    """
+
+    name: str
+    parts: list[AgpComponent | AgpGap]
+
+
+def write_agp(objects: list[AgpObject], path: Path) -> None:
+    """Write ``objects`` to ``path`` as an AGP 2.1 file.
+
+    Part numbers restart at 1 for each object and increment across both
+    component and gap rows (the AGP spec numbers every part, gaps
+    included). Coordinates are emitted 1-based inclusive.
+    """
+    with path.open("w") as h:
+        h.write("##agp-version\t2.1\n")
+        for obj in objects:
+            for part_num, part in enumerate(obj.parts, start=1):
+                obj_beg = part.object_start + 1
+                obj_end = part.object_end
+                if isinstance(part, AgpComponent):
+                    h.write(
+                        "\t".join(
+                            (
+                                obj.name,
+                                str(obj_beg),
+                                str(obj_end),
+                                str(part_num),
+                                "W",
+                                part.component_id,
+                                "1",
+                                str(part.length),
+                                part.orientation,
+                            )
+                        )
+                        + "\n"
+                    )
+                else:
+                    h.write(
+                        "\t".join(
+                            (
+                                obj.name,
+                                str(obj_beg),
+                                str(obj_end),
+                                str(part_num),
+                                "N",
+                                str(part.length),
+                                GAP_TYPE,
+                                GAP_LINKAGE,
+                                GAP_LINKAGE_EVIDENCE,
+                            )
+                        )
+                        + "\n"
+                    )

--- a/src/karyoscope/core/scaffold.py
+++ b/src/karyoscope/core/scaffold.py
@@ -34,6 +34,7 @@ from itertools import groupby
 from pathlib import Path
 from typing import IO
 
+from karyoscope.core.io.agp import AgpComponent, AgpGap, AgpObject
 from karyoscope.core.io.fasta import (
     read_fasta_records,
     reverse_complement,
@@ -42,6 +43,12 @@ from karyoscope.core.io.fasta import (
 from karyoscope.core.io.scaffold_map import MapRow
 from karyoscope.core.io.telo import TeloFlags
 from karyoscope.exceptions import ScaffoldError
+
+#: Default number of N bases inserted between concatenated contigs when
+#: ``--combine-chromosomes`` is on. Matches the scaffold subcommand
+#: default; large enough that the per-contig smoothing's ``max_gap``
+#: (1000) never bridges it, so each gap stays a clean ``novel`` run.
+DEFAULT_SCAFFOLD_GAP_SIZE = 100_000
 
 logger = logging.getLogger(__name__)
 
@@ -745,3 +752,349 @@ def rewrite_fasta(
             out_records[name] = seq
 
     write_fasta_records(out_records, output_path, gzip_out=gzip_out, line_width=line_width)
+
+
+# --- combined-chromosome scaffolding --------------------------------
+#
+# When ``--combine-chromosomes`` is on, every contig of one
+# ``(chromosome, haplotype)`` group is concatenated into a single output
+# sequence named ``<chrom>_<hap>``, with ``gap_size`` N bases between
+# adjacent contigs. The FASTA, the per-feature-set BEDs, and the AGP all
+# derive from one shared layout (:func:`plan_combined_layout`) so their
+# coordinate systems agree exactly.
+#
+# Coordinate model (see the scaffold subcommand's design notes): each
+# per-contig BED tiles ``[0, E)`` where ``E = L - k + 1`` (``L`` = true
+# sequence length, ``k`` = k-mer size). The map's ``length`` field is
+# ``E``. We never hardcode ``k``: object offsets come from true
+# sequence lengths (read from the FASTA), and each contig's tiling end
+# comes from its own ``E``. The ``novel`` gap interval between two
+# contigs therefore spans ``[offset_i + E_i, offset_{i+1})`` -- the
+# literal N gap plus the ``k-1`` untiled tail of contig ``i`` whose
+# k-mers, in the concatenated assembly, would overlap the Ns. This is
+# byte-identical to re-annotating the combined FASTA, and stays correct
+# for a future variable-k database with no special case.
+
+
+@dataclass(frozen=True)
+class PlacedComponent:
+    """One contig placed inside a combined object.
+
+    ``object_start`` is the 0-based offset (in true bp) of the contig
+    within its output object. ``true_length`` is the contig's full
+    sequence length; ``bed_extent`` is ``E`` (where the per-contig BED
+    tiling stops, i.e. the map's ``length``).
+    """
+
+    row: MapRow
+    object_start: int
+    true_length: int
+    bed_extent: int
+
+
+@dataclass(frozen=True)
+class ScaffoldObject:
+    """One output FASTA record: a renamed singleton or a combined chromosome.
+
+    ``combined`` is True when the object concatenates a whole
+    ``(chromosome, hap)`` group under a simplified ``<chrom>_<hap>``
+    name; False for a singleton emitted under its encoded
+    ``<chrom>_<hap>_<contig>[_rc]`` name (an acrocentric group left
+    uncombined). ``gap_size`` is the N-run length between components
+    (irrelevant when there is only one).
+    """
+
+    name: str
+    components: list[PlacedComponent]
+    gap_size: int
+    combined: bool
+
+
+def plan_combined_layout(
+    map_rows: list[MapRow],
+    true_lengths: dict[str, int],
+    *,
+    gap_size: int = DEFAULT_SCAFFOLD_GAP_SIZE,
+    acrocentrics: set[str] = DEFAULT_HUMAN_ACROCENTRICS,
+    combine_acrocentrics: bool = False,
+) -> list[ScaffoldObject]:
+    """Plan the combined-chromosome output layout for one input.
+
+    Groups ``map_rows`` by ``(chromosome, hap)`` in map order (which is
+    already the canonical chromosome x hap x category x length order),
+    and turns each group into one or more :class:`ScaffoldObject`:
+
+    * A non-acrocentric group -- or an acrocentric group when
+      ``combine_acrocentrics`` is True -- becomes a single combined
+      object named ``<chrom>_<hap>`` whose components are placed at
+      cumulative offsets ``Σ(true_length + gap_size)``.
+    * An acrocentric group left uncombined becomes one singleton object
+      per contig, each under its encoded ``new_name``.
+
+    Rows whose ``original_name`` is absent from ``true_lengths`` (the
+    contig was not in the source FASTA) are skipped, mirroring the
+    forgiving semantics of :func:`rewrite_fasta` / :func:`rewrite_bed`.
+    """
+    # Group preserving first-seen order; map_rows already arrive grouped.
+    groups: dict[tuple[str, str], list[MapRow]] = {}
+    for row in map_rows:
+        groups.setdefault((row.chromosome, row.hap), []).append(row)
+
+    objects: list[ScaffoldObject] = []
+    for (chrom, hap), rows in groups.items():
+        present = [r for r in rows if r.original_name in true_lengths]
+        if not present:
+            continue
+        is_acro = chrom in acrocentrics
+        combine = not (is_acro and not combine_acrocentrics)
+
+        if combine:
+            components: list[PlacedComponent] = []
+            offset = 0
+            for r in present:
+                length = true_lengths[r.original_name]
+                components.append(
+                    PlacedComponent(
+                        row=r,
+                        object_start=offset,
+                        true_length=length,
+                        bed_extent=r.length,
+                    )
+                )
+                offset += length + gap_size
+            objects.append(
+                ScaffoldObject(
+                    name=f"{chrom}_{hap}",
+                    components=components,
+                    gap_size=gap_size,
+                    combined=True,
+                )
+            )
+        else:
+            for r in present:
+                length = true_lengths[r.original_name]
+                objects.append(
+                    ScaffoldObject(
+                        name=r.new_name,
+                        components=[
+                            PlacedComponent(
+                                row=r,
+                                object_start=0,
+                                true_length=length,
+                                bed_extent=r.length,
+                            )
+                        ],
+                        gap_size=gap_size,
+                        combined=False,
+                    )
+                )
+    return objects
+
+
+def _to_agp_objects(
+    objects: list[ScaffoldObject],
+    leftovers: list[tuple[str, int]],
+) -> list[AgpObject]:
+    """Build AGP objects from the layout plus any unscaffolded leftovers.
+
+    ``leftovers`` is ``[(name, length)]`` for contigs kept in the output
+    FASTA under their original names (``keep_unscaffolded``). Each is a
+    one-component object so the AGP fully describes the output FASTA.
+    """
+    agp: list[AgpObject] = []
+    for obj in objects:
+        parts: list[AgpComponent | AgpGap] = []
+        for i, comp in enumerate(obj.components):
+            parts.append(
+                AgpComponent(
+                    component_id=comp.row.original_name,
+                    object_start=comp.object_start,
+                    object_end=comp.object_start + comp.true_length,
+                    length=comp.true_length,
+                    orientation="-" if comp.row.flipped else "+",
+                )
+            )
+            if i + 1 < len(obj.components):
+                gap_start = comp.object_start + comp.true_length
+                gap_end = obj.components[i + 1].object_start
+                parts.append(
+                    AgpGap(
+                        object_start=gap_start,
+                        object_end=gap_end,
+                        length=gap_end - gap_start,
+                    )
+                )
+        agp.append(AgpObject(name=obj.name, parts=parts))
+
+    for name, length in leftovers:
+        agp.append(
+            AgpObject(
+                name=name,
+                parts=[
+                    AgpComponent(
+                        component_id=name,
+                        object_start=0,
+                        object_end=length,
+                        length=length,
+                        orientation="+",
+                    )
+                ],
+            )
+        )
+    return agp
+
+
+def write_combined_fasta(
+    records: dict[str, str],
+    objects: list[ScaffoldObject],
+    output_path: Path,
+    *,
+    keep_unscaffolded: bool = True,
+    gzip_out: bool | None = None,
+    line_width: int | None = None,
+) -> list[tuple[str, int]]:
+    """Write the combined-chromosome FASTA and return the leftover list.
+
+    Each :class:`ScaffoldObject` is emitted under its name as the
+    concatenation of its (oriented) component sequences joined by
+    ``gap_size`` Ns. Singleton objects join one sequence, so no gap is
+    inserted. Contigs kept by ``keep_unscaffolded`` are appended under
+    their original names.
+
+    Returns ``[(name, length)]`` for the appended leftovers, so the
+    caller can hand them to :func:`_to_agp_objects` and keep the AGP a
+    complete description of the FASTA.
+    """
+    placed: set[str] = set()
+    out_records: dict[str, str] = {}
+
+    for obj in objects:
+        gap = "N" * obj.gap_size
+        seqs: list[str] = []
+        for comp in obj.components:
+            seq = records.get(comp.row.original_name)
+            if seq is None:
+                continue
+            if comp.row.flipped:
+                seq = reverse_complement(seq)
+            seqs.append(seq)
+            placed.add(comp.row.original_name)
+        if not seqs:
+            continue
+        out_records[obj.name] = gap.join(seqs)
+
+    leftovers: list[tuple[str, int]] = []
+    if keep_unscaffolded:
+        for name, seq in records.items():
+            if name in placed:
+                continue
+            out_records[name] = seq
+            leftovers.append((name, len(seq)))
+
+    write_fasta_records(out_records, output_path, gzip_out=gzip_out, line_width=line_width)
+    return leftovers
+
+
+def _merge_adjacent(intervals: list[tuple[int, int, str]]) -> list[tuple[int, int, str]]:
+    """Coalesce abutting intervals that carry the same 4th-column payload.
+
+    Concatenating per-contig BEDs only creates new adjacencies at the
+    junctions (e.g. a contig ending in ``novel``, the inserted ``novel``
+    gap, and the next contig starting in ``novel``). Merging them keeps
+    the combined BED identical to what annotate would emit for the
+    concatenated sequence, which merges adjacent same-name records.
+    """
+    merged: list[tuple[int, int, str]] = []
+    for start, end, rest in intervals:
+        if merged and merged[-1][1] == start and merged[-1][2] == rest:
+            ps, _, prest = merged[-1]
+            merged[-1] = (ps, end, prest)
+        else:
+            merged.append((start, end, rest))
+    return merged
+
+
+def rewrite_bed_combined(
+    input_path: Path,
+    output_path: Path,
+    *,
+    objects: list[ScaffoldObject],
+    gzip_out: bool | None = None,
+) -> None:
+    """Rewrite a per-feature-set BED into combined-chromosome coordinates.
+
+    For each :class:`ScaffoldObject`, every component's intervals are
+    shifted by the component's ``object_start`` (flipped contigs are
+    mirrored within ``[0, E)`` first, as in :func:`rewrite_bed`), and a
+    ``novel`` interval is inserted between consecutive components to
+    fill the N gap plus the untiled ``k-1`` boundary. The result tiles
+    ``[0, object_extent)`` per object with no gaps, then adjacent
+    same-label intervals are coalesced.
+
+    A component whose contig is absent from the input BED has its whole
+    ``[object_start, object_start + E)`` extent filled with ``novel`` so
+    the tiling stays complete (this does not happen for real annotate
+    output, which tiles every contig fully).
+    """
+    if gzip_out is None:
+        gzip_out = str(output_path).endswith(".gz")
+
+    by_contig: dict[str, list[tuple[int, int, str]]] = defaultdict(list)
+    with _open_bed_in(input_path) as h:
+        for i, raw in enumerate(h, start=1):
+            line = raw.rstrip("\n")
+            if not line:
+                continue
+            parts = line.split("\t")
+            if len(parts) < 3:
+                raise ScaffoldError(
+                    f"{input_path}:{i}: expected 3+ tab-separated columns, got {len(parts)}"
+                )
+            seq = parts[0]
+            try:
+                start = int(parts[1])
+                end = int(parts[2])
+            except ValueError as e:
+                raise ScaffoldError(f"{input_path}:{i}: non-integer coordinates: {raw!r}") from e
+            rest = "\t".join(parts[3:])
+            by_contig[seq].append((start, end, rest))
+
+    with _open_bed_out(output_path, gzip_out=gzip_out) as out:
+        for obj in objects:
+            emitted: list[tuple[int, int, str]] = []
+            n = len(obj.components)
+            for idx, comp in enumerate(obj.components):
+                off = comp.object_start
+                recs = by_contig.get(comp.row.original_name)
+                if recs is None:
+                    # No records for this contig in this feature set: fill
+                    # its extent with novel to keep the tiling complete.
+                    logger.warning(
+                        "contig %r has no records in %s; filling its %d bp "
+                        "with novel in the combined BED",
+                        comp.row.original_name,
+                        input_path.name,
+                        comp.bed_extent,
+                    )
+                    emitted.append((off, off + comp.bed_extent, "novel"))
+                else:
+                    if comp.row.flipped:
+                        oriented = [
+                            (comp.bed_extent - stop, comp.bed_extent - start, rest)
+                            for start, stop, rest in reversed(recs)
+                        ]
+                    else:
+                        oriented = recs
+                    for start, end, rest in oriented:
+                        emitted.append((off + start, off + end, rest))
+                if idx + 1 < n:
+                    gap_start = off + comp.bed_extent
+                    gap_end = obj.components[idx + 1].object_start
+                    if gap_end > gap_start:
+                        emitted.append((gap_start, gap_end, "novel"))
+
+            for start, end, rest in _merge_adjacent(emitted):
+                if rest:
+                    out.write(f"{obj.name}\t{start}\t{end}\t{rest}\n")
+                else:
+                    out.write(f"{obj.name}\t{start}\t{end}\n")

--- a/src/karyoscope/core/scaffold_run.py
+++ b/src/karyoscope/core/scaffold_run.py
@@ -51,16 +51,23 @@ from karyoscope.core.hap_inference import (
     classify_contigs,
     read_fasta_contig_names,
 )
+from karyoscope.core.io.agp import write_agp
+from karyoscope.core.io.fasta import read_fasta_records
 from karyoscope.core.io.hierarchy import parse_hierarchy
 from karyoscope.core.io.scaffold_map import MapRow, write_legacy_stats, write_map
 from karyoscope.core.io.telo import TeloFlags, parse_telo_file, run_seqtk_telo
 from karyoscope.core.scaffold import (
     DEFAULT_HUMAN_ACROCENTRICS,
     DEFAULT_MIN_SCAFFOLD_LENGTH,
+    DEFAULT_SCAFFOLD_GAP_SIZE,
     ContigInput,
+    _to_agp_objects,
     classify_and_orient,
+    plan_combined_layout,
     rewrite_bed,
+    rewrite_bed_combined,
     rewrite_fasta,
+    write_combined_fasta,
 )
 from karyoscope.exceptions import ScaffoldError
 from karyoscope.manifest import validate_database_layout
@@ -161,6 +168,8 @@ class ScaffoldResult:
     stats_path: Path
     scaffolded_beds: dict[str, Path] = field(default_factory=dict)
     scaffolded_fasta: Path | None = None
+    agp_path: Path | None = None
+    combined: bool = False
 
 
 # --- helpers --------------------------------------------------------
@@ -355,6 +364,109 @@ def _load_binned_bed(path: Path) -> dict[str, list[tuple[int, int, str]]]:
     return out
 
 
+#: Filename tag distinguishing combined-chromosome outputs from the
+#: per-contig scaffolded outputs, so a user can run with and without
+#: ``--combine-chromosomes`` in the same directory without collisions.
+_COMBINED_TAG = "combined_chromosomes"
+
+
+def _write_combined_outputs(
+    r: _ResolvedInput,
+    *,
+    per_input_rows: list[MapRow],
+    db_id: str,
+    requested: list[str],
+    mode: str,
+    acrocentrics: set[str],
+    combine_acrocentrics: bool,
+    scaffold_gap_size: int,
+    keep_unscaffolded: bool,
+    annotation_variant: str,
+    bgzip: bool,
+    threads: int,
+) -> ScaffoldResult:
+    """Write combined-chromosome FASTA, AGP, and (mode 'both') BEDs for one input.
+
+    The FASTA is read once and shared: true sequence lengths drive the
+    layout offsets, and the in-memory records feed the FASTA writer. The
+    same :func:`plan_combined_layout` result drives the BED rewrite and
+    the AGP, so all three agree exactly on coordinates.
+    """
+    map_path = r.out_dir / f"{r.stem}.{db_id}.scaffold_map.tsv"
+    stats_path = r.out_dir / f"{r.stem}.{db_id}.scaffold_stats.tsv"
+
+    records = read_fasta_records(r.spec.path)
+    true_lengths = {name: len(seq) for name, seq in records.items()}
+    layout = plan_combined_layout(
+        per_input_rows,
+        true_lengths,
+        gap_size=scaffold_gap_size,
+        acrocentrics=acrocentrics,
+        combine_acrocentrics=combine_acrocentrics,
+    )
+
+    # Combined BEDs (mode 'both' only): rewrite each per-feature-set
+    # smoothed BED into the combined coordinate system. Only these
+    # (combined-tagged) BEDs are written -- not the plain scaffolded ones.
+    scaffolded_beds: dict[str, Path] = {}
+    if mode == "both":
+        for fs in requested:
+            src = _annotation_bed_path(r.out_dir, r.stem, db_id, fs, variant=annotation_variant)
+            if not src.is_file():
+                logger.warning(
+                    "%s BED for %s / %s not found at %s; skipping",
+                    annotation_variant,
+                    r.spec.path.name,
+                    fs,
+                    src,
+                )
+                continue
+            out_plain = (
+                r.out_dir
+                / f"{r.stem}.{db_id}.{fs}.{annotation_variant}.scaffolded.{_COMBINED_TAG}.bed"
+            )
+            logger.info(
+                "rewriting combined-chromosome BED for %s / %s -> %s",
+                r.spec.path.name,
+                fs,
+                out_plain.name,
+            )
+            t_rb = time.perf_counter()
+            rewrite_bed_combined(src, out_plain, objects=layout, gzip_out=False)
+            logger.info("wrote %s in %.1fs", out_plain.name, time.perf_counter() - t_rb)
+            scaffolded_beds[fs] = _bgzip_file(out_plain, threads=threads) if bgzip else out_plain
+
+    # Combined FASTA.
+    fasta_plain = r.out_dir / f"{r.stem}.{db_id}.scaffolded.{_COMBINED_TAG}.fa"
+    logger.info("writing combined-chromosome FASTA for %s -> %s", r.spec.path.name, fasta_plain)
+    t_rf = time.perf_counter()
+    leftovers = write_combined_fasta(
+        records,
+        layout,
+        fasta_plain,
+        keep_unscaffolded=keep_unscaffolded,
+        gzip_out=False,
+    )
+    logger.info("wrote %s in %.1fs", fasta_plain.name, time.perf_counter() - t_rf)
+    scaffolded_fasta = _bgzip_file(fasta_plain, threads=threads) if bgzip else fasta_plain
+
+    # AGP: complete description of the FASTA, including kept leftovers.
+    agp_path = r.out_dir / f"{r.stem}.{db_id}.scaffolded.{_COMBINED_TAG}.agp"
+    write_agp(_to_agp_objects(layout, leftovers), agp_path)
+    logger.info("wrote %s", agp_path.name)
+
+    return ScaffoldResult(
+        input_path=r.spec.path,
+        hap_label=r.hap_label,
+        map_path=map_path,
+        stats_path=stats_path,
+        scaffolded_beds=scaffolded_beds,
+        scaffolded_fasta=scaffolded_fasta,
+        agp_path=agp_path,
+        combined=True,
+    )
+
+
 # --- main entry point -----------------------------------------------
 
 
@@ -372,6 +484,9 @@ def scaffold_run(
     threads: int = 0,
     bgzip: bool = True,
     keep_unscaffolded: bool = True,
+    combine_chromosomes: bool = False,
+    scaffold_gap_size: int = DEFAULT_SCAFFOLD_GAP_SIZE,
+    combine_acrocentrics: bool = False,
     auto: bool = True,
     output_dir: Path | None = None,
     write_scaffolded_beds: bool = True,
@@ -407,6 +522,21 @@ def scaffold_run(
         Threads for any auto-run ``annotate`` invocations.
     bgzip
         bgzip the scaffolded output BEDs (default: yes).
+    combine_chromosomes
+        Concatenate the contigs of each ``(chromosome, hap)`` into one
+        ``<chrom>_<hap>`` sequence, separated by ``scaffold_gap_size``
+        Ns. Only valid for ``mode`` ``"fasta"`` / ``"both"``. Outputs
+        carry a ``combined_chromosomes`` filename tag and an AGP file;
+        in ``"both"`` mode the per-feature-set BEDs are written in the
+        combined coordinate system (and the plain scaffolded BEDs are
+        not).
+    scaffold_gap_size
+        N bases between concatenated contigs (default 100000).
+    combine_acrocentrics
+        Also combine acrocentric chromosomes. Off by default: acrocentric
+        p-arms recombine and KaryoScope's chromosome assignment there is
+        less certain, so their contigs stay as separate records unless
+        this is set.
     auto
         Auto-derive missing inputs (annotate, seqtk telo, bin).
         Disable to require every input to exist.
@@ -420,6 +550,13 @@ def scaffold_run(
         raise ScaffoldError("at least one --input is required")
     if mode not in _VALID_MODES:
         raise ScaffoldError(f"unknown mode {mode!r}; expected one of {_VALID_MODES}")
+    if combine_chromosomes and mode == "bed":
+        raise ScaffoldError(
+            "combine_chromosomes requires a FASTA output (mode 'fasta' or 'both'); "
+            "it has no meaning in mode 'bed'"
+        )
+    if combine_chromosomes and scaffold_gap_size < 0:
+        raise ScaffoldError(f"scaffold_gap_size must be >= 0, got {scaffold_gap_size}")
 
     t_scaffold_start = time.perf_counter()
     db_id_resolved, db_dir = resolve_database(db_root, db_id)
@@ -601,6 +738,23 @@ def scaffold_run(
         stats_path = r.out_dir / f"{r.stem}.{db_id_resolved}.scaffold_stats.tsv"
         write_map(per_input_rows, map_path)
         write_legacy_stats(per_input_rows, stats_path)
+
+        if combine_chromosomes:
+            results[r.spec.path.name] = _write_combined_outputs(
+                r,
+                per_input_rows=per_input_rows,
+                db_id=db_id_resolved,
+                requested=requested,
+                mode=mode,
+                acrocentrics=acros_set,
+                combine_acrocentrics=combine_acrocentrics,
+                scaffold_gap_size=scaffold_gap_size,
+                keep_unscaffolded=keep_unscaffolded,
+                annotation_variant=annotation_variant,
+                bgzip=bgzip,
+                threads=threads,
+            )
+            continue
 
         scaffolded_beds: dict[str, Path] = {}
         if mode in ("bed", "both") and write_scaffolded_beds:

--- a/tests/test_agp.py
+++ b/tests/test_agp.py
@@ -1,0 +1,74 @@
+"""Unit tests for :mod:`karyoscope.core.io.agp`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from karyoscope.core.io.agp import (
+    GAP_LINKAGE,
+    GAP_LINKAGE_EVIDENCE,
+    GAP_TYPE,
+    AgpComponent,
+    AgpGap,
+    AgpObject,
+    write_agp,
+)
+
+
+def _lines(path: Path) -> list[str]:
+    return path.read_text().splitlines()
+
+
+class TestWriteAgp:
+    def test_header_first(self, tmp_path: Path) -> None:
+        out = tmp_path / "x.agp"
+        write_agp([], out)
+        assert _lines(out) == ["##agp-version\t2.1"]
+
+    def test_single_component_object(self, tmp_path: Path) -> None:
+        out = tmp_path / "x.agp"
+        obj = AgpObject(
+            name="ctgA",
+            parts=[AgpComponent("ctgA", 0, 100, 100, "+")],
+        )
+        write_agp([obj], out)
+        # 1-based inclusive: obj_beg=1, obj_end=100.
+        assert _lines(out)[1] == "ctgA\t1\t100\t1\tW\tctgA\t1\t100\t+"
+
+    def test_combined_object_with_gap(self, tmp_path: Path) -> None:
+        out = tmp_path / "x.agp"
+        # ctgA [0,10), gap [10,15), ctgB [15,23) in 0-based half-open.
+        obj = AgpObject(
+            name="chr1_hap1",
+            parts=[
+                AgpComponent("A", 0, 10, 10, "+"),
+                AgpGap(10, 15, 5),
+                AgpComponent("B", 15, 23, 8, "-"),
+            ],
+        )
+        write_agp([obj], out)
+        rows = _lines(out)[1:]
+        assert rows[0] == "chr1_hap1\t1\t10\t1\tW\tA\t1\t10\t+"
+        assert (
+            rows[1]
+            == f"chr1_hap1\t11\t15\t2\tN\t5\t{GAP_TYPE}\t{GAP_LINKAGE}\t{GAP_LINKAGE_EVIDENCE}"
+        )
+        assert rows[2] == "chr1_hap1\t16\t23\t3\tW\tB\t1\t8\t-"
+
+    def test_part_numbers_restart_per_object(self, tmp_path: Path) -> None:
+        out = tmp_path / "x.agp"
+        objs = [
+            AgpObject("o1", [AgpComponent("a", 0, 5, 5, "+")]),
+            AgpObject("o2", [AgpComponent("b", 0, 7, 7, "+")]),
+        ]
+        write_agp(objs, out)
+        rows = _lines(out)[1:]
+        assert rows[0].split("\t")[3] == "1"
+        assert rows[1].split("\t")[3] == "1"
+
+    def test_gap_constants(self) -> None:
+        # Lock the KaryoScope gap metadata: alignment-free, but ordering
+        # is asserted against a same-genus human reference.
+        assert GAP_TYPE == "scaffold"
+        assert GAP_LINKAGE == "yes"
+        assert GAP_LINKAGE_EVIDENCE == "align_genus"

--- a/tests/test_command_scaffold.py
+++ b/tests/test_command_scaffold.py
@@ -395,3 +395,161 @@ def test_drop_unscaffolded_omits_leftover_contigs(
     fa_out = read_fasta_records(out_dir / "asm.KS_dummy_test_v1.scaffolded.fa")
     # decoy_junk should not appear under its original name.
     assert "decoy_junk" not in fa_out
+
+
+# --- combine-chromosomes (Stage 5d) ---------------------------------
+
+
+def test_combine_chromosomes_mode_bed_rejected(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """--combine-chromosomes needs a FASTA output; --mode bed errors cleanly."""
+    fa = tmp_path / "x.fa"
+    fa.write_text(">a\nACGT\n")
+    result = cli_runner.invoke(
+        main,
+        ["scaffold", "-i", f"hap1={fa}", "--mode", "bed", "--combine-chromosomes"],
+    )
+    assert result.exit_code != 0
+    assert "combine-chromosomes" in result.output.lower()
+    assert "bed" in result.output.lower()
+
+
+def test_negative_scaffold_gap_size_rejected(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    fa = tmp_path / "x.fa"
+    fa.write_text(">a\nACGT\n")
+    result = cli_runner.invoke(
+        main,
+        ["scaffold", "-i", f"hap1={fa}", "--combine-chromosomes", "--scaffold-gap-size", "-1"],
+    )
+    assert result.exit_code != 0
+    assert "scaffold-gap-size" in result.output.lower()
+
+
+def test_help_lists_combine_flags(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(main, ["scaffold", "--help"])
+    assert result.exit_code == 0
+    assert "--combine-chromosomes" in result.output
+    assert "--scaffold-gap-size" in result.output
+    assert "--combine-acrocentrics" in result.output
+
+
+@pytest.fixture
+def two_chr1_assembly_fasta(tmp_path: Path) -> Path:
+    """A FASTA with two chr1 contigs and one chr2 contig.
+
+    Lets the combine path concatenate the two chr1 contigs into a single
+    ``chr1_hap1`` record with an N gap between them. 21-mer positions in
+    the dummy seed: pos 0 -> featureID 1 (chr1/rA), pos 1 -> featureID 2
+    (chr1/rB), pos 2 -> featureID 3 (chr2/rC).
+    """
+    seed = "ACGTGCTAGCTAGGCTATCGTAC"
+    fa = tmp_path / "asm.fa"
+    fa.write_text(
+        f">chr1_part_a\n{seed[0:21]}\n"  # chr1/rA
+        f">chr1_part_b\n{seed[1:22]}\n"  # chr1/rB
+        f">chr2_part\n{seed[2:23]}\n"  # chr2/rC
+    )
+    return fa
+
+
+@pytestmark_required
+@pytest.mark.integration
+def test_combine_chromosomes_fasta_and_agp(
+    cli_runner: CliRunner,
+    populated_db_root: Path,
+    two_chr1_assembly_fasta: Path,
+    tmp_path: Path,
+) -> None:
+    """--combine-chromosomes writes a combined FASTA + AGP, with N gaps."""
+    from karyoscope.core.io.fasta import read_fasta_records
+
+    out_dir = tmp_path / "out"
+    result = cli_runner.invoke(
+        main,
+        [
+            "scaffold",
+            "-i",
+            f"hap1={two_chr1_assembly_fasta}",
+            "--outdir",
+            str(out_dir),
+            "--mode",
+            "fasta",
+            "--combine-chromosomes",
+            "--scaffold-gap-size",
+            "10",
+            "--min-scaffold-length",
+            "1",
+            "--bin-size",
+            "10",
+            "--no-bgzip",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    base = "asm.KS_dummy_test_v1"
+    fa_out = out_dir / f"{base}.scaffolded.combined_chromosomes.fa"
+    agp_out = out_dir / f"{base}.scaffolded.combined_chromosomes.agp"
+    assert fa_out.is_file(), list(out_dir.iterdir())
+    assert agp_out.is_file()
+    # The plain (non-combined) scaffolded FASTA must NOT be written.
+    assert not (out_dir / f"{base}.scaffolded.fa").exists()
+
+    recs = read_fasta_records(fa_out)
+    # The two chr1 contigs combined into one chr1_hap1 record with an N run.
+    assert "chr1_hap1" in recs
+    assert "N" * 10 in recs["chr1_hap1"]
+    # chr2 is its own (single-contig) object, renamed, no N gap.
+    assert "chr2_hap1" in recs
+    assert "N" not in recs["chr2_hap1"]
+
+    agp = agp_out.read_text()
+    assert agp.startswith("##agp-version\t2.1")
+    # Exactly one N (gap) row, for the chr1 junction.
+    n_rows = [ln for ln in agp.splitlines() if ln.split("\t")[4:5] == ["N"]]
+    assert len(n_rows) == 1
+    assert n_rows[0].split("\t")[5] == "10"  # gap_length
+    assert n_rows[0].split("\t")[8] == "align_genus"
+
+
+@pytestmark_required
+@pytest.mark.integration
+def test_combine_both_writes_only_combined_beds(
+    cli_runner: CliRunner,
+    populated_db_root: Path,
+    two_chr1_assembly_fasta: Path,
+    tmp_path: Path,
+) -> None:
+    """--mode both --combine-chromosomes writes combined BEDs, not plain ones."""
+    out_dir = tmp_path / "out"
+    result = cli_runner.invoke(
+        main,
+        [
+            "scaffold",
+            "-i",
+            f"hap1={two_chr1_assembly_fasta}",
+            "--outdir",
+            str(out_dir),
+            "--mode",
+            "both",
+            "--combine-chromosomes",
+            "--scaffold-gap-size",
+            "10",
+            "--min-scaffold-length",
+            "1",
+            "--bin-size",
+            "10",
+            "--no-bgzip",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert list(out_dir.glob("*.smoothed.scaffolded.combined_chromosomes.bed"))
+    # The plain scaffolded BEDs must NOT be produced in a combine run.
+    plain = [
+        p for p in out_dir.glob("*.smoothed.scaffolded.bed") if "combined_chromosomes" not in p.name
+    ]
+    assert not plain

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -12,6 +12,7 @@ from karyoscope.core.io.telo import TeloFlags
 from karyoscope.core.scaffold import (
     ContigInput,
     Interval,
+    _to_agp_objects,
     assign_main_chromosome,
     category_index,
     chromosome_sort_key,
@@ -21,9 +22,12 @@ from karyoscope.core.scaffold import (
     get_simple_region,
     half_region_totals,
     need_to_flip,
+    plan_combined_layout,
     rewrite_bed,
+    rewrite_bed_combined,
     rewrite_fasta,
     scaffold_region_majority,
+    write_combined_fasta,
 )
 
 # --- pure helpers ---------------------------------------------------
@@ -545,3 +549,255 @@ class TestRewriteFasta:
         rows = [MapRow("chr1_h1_ctgA", "ctgA", "in.fa.gz", "h1", "chr1", False, 4, "P")]
         rewrite_fasta(src, dst, map_rows=rows, keep_unscaffolded=False)
         assert read_fasta_records(dst)["chr1_h1_ctgA"] == "ACGT"
+
+
+# --- combined-chromosome layout ------------------------------------
+
+
+def _row(
+    new_name: str,
+    original: str,
+    chrom: str,
+    hap: str,
+    *,
+    flipped: bool = False,
+    length: int = 100,
+) -> MapRow:
+    return MapRow(new_name, original, "in.fa", hap, chrom, flipped, length, "P")
+
+
+class TestPlanCombinedLayout:
+    def test_two_contigs_one_object_with_offsets(self) -> None:
+        # E_A=7 (L=10), E_B=5 (L=8), gap=5 -> B starts at 10+5=15.
+        rows = [
+            _row("chr1_hap1_A", "A", "chr1", "hap1", length=7),
+            _row("chr1_hap1_B", "B", "chr1", "hap1", length=5),
+        ]
+        true_lengths = {"A": 10, "B": 8}
+        objs = plan_combined_layout(
+            rows, true_lengths, gap_size=5, acrocentrics=set(), combine_acrocentrics=False
+        )
+        assert len(objs) == 1
+        obj = objs[0]
+        assert obj.name == "chr1_hap1"
+        assert obj.combined is True
+        assert [c.object_start for c in obj.components] == [0, 15]
+        assert [c.true_length for c in obj.components] == [10, 8]
+        assert [c.bed_extent for c in obj.components] == [7, 5]
+
+    def test_separate_haps_are_separate_objects(self) -> None:
+        rows = [
+            _row("chr1_hap1_A", "A", "chr1", "hap1"),
+            _row("chr1_hap2_B", "B", "chr1", "hap2"),
+        ]
+        objs = plan_combined_layout(rows, {"A": 100, "B": 100}, gap_size=10, acrocentrics=set())
+        assert [o.name for o in objs] == ["chr1_hap1", "chr1_hap2"]
+
+    def test_acrocentric_not_combined_by_default(self) -> None:
+        rows = [
+            _row("chr13_hap1_A", "A", "chr13", "hap1"),
+            _row("chr13_hap1_B", "B", "chr13", "hap1"),
+        ]
+        objs = plan_combined_layout(
+            rows,
+            {"A": 100, "B": 100},
+            gap_size=10,
+            acrocentrics={"chr13"},
+            combine_acrocentrics=False,
+        )
+        # Two singleton objects, each under its encoded name, no combining.
+        assert [o.name for o in objs] == ["chr13_hap1_A", "chr13_hap1_B"]
+        assert all(o.combined is False for o in objs)
+        assert all(len(o.components) == 1 for o in objs)
+
+    def test_acrocentric_combined_when_forced(self) -> None:
+        rows = [
+            _row("chr13_hap1_A", "A", "chr13", "hap1"),
+            _row("chr13_hap1_B", "B", "chr13", "hap1"),
+        ]
+        objs = plan_combined_layout(
+            rows,
+            {"A": 100, "B": 100},
+            gap_size=10,
+            acrocentrics={"chr13"},
+            combine_acrocentrics=True,
+        )
+        assert [o.name for o in objs] == ["chr13_hap1"]
+        assert objs[0].combined is True
+
+    def test_single_contig_group_renamed(self) -> None:
+        rows = [_row("chr2_hap1_A", "A", "chr2", "hap1")]
+        objs = plan_combined_layout(rows, {"A": 100}, gap_size=10, acrocentrics=set())
+        assert objs[0].name == "chr2_hap1"
+        assert objs[0].combined is True
+        assert len(objs[0].components) == 1
+
+    def test_contig_absent_from_fasta_skipped(self) -> None:
+        rows = [
+            _row("chr1_hap1_A", "A", "chr1", "hap1", length=7),
+            _row("chr1_hap1_Ghost", "Ghost", "chr1", "hap1", length=5),
+        ]
+        objs = plan_combined_layout(rows, {"A": 10}, gap_size=5, acrocentrics=set())
+        assert len(objs) == 1
+        assert [c.row.original_name for c in objs[0].components] == ["A"]
+
+
+# --- combined FASTA -------------------------------------------------
+
+
+class TestWriteCombinedFasta:
+    def _write_src(self, p: Path, records: dict[str, str]) -> None:
+        p.write_text("".join(f">{n}\n{s}\n" for n, s in records.items()))
+
+    def test_concatenates_with_gap(self, tmp_path: Path) -> None:
+        rows = [
+            _row("chr1_hap1_A", "A", "chr1", "hap1", length=7),
+            _row("chr1_hap1_B", "B", "chr1", "hap1", length=5),
+        ]
+        records = {"A": "ACGTACGTAC", "B": "GGGGCCCC"}  # len 10, 8
+        objs = plan_combined_layout(rows, {"A": 10, "B": 8}, gap_size=5, acrocentrics=set())
+        out = tmp_path / "out.fa"
+        leftovers = write_combined_fasta(records, objs, out, keep_unscaffolded=False)
+        res = read_fasta_records(out)
+        assert list(res.keys()) == ["chr1_hap1"]
+        assert res["chr1_hap1"] == "ACGTACGTAC" + "N" * 5 + "GGGGCCCC"
+        assert leftovers == []
+
+    def test_flipped_component_reverse_complemented(self, tmp_path: Path) -> None:
+        rows = [_row("chr1_hap1_A_rc", "A", "chr1", "hap1", flipped=True, length=3)]
+        records = {"A": "AATTCG"}  # RC = CGAATT
+        objs = plan_combined_layout(rows, {"A": 6}, gap_size=5, acrocentrics=set())
+        out = tmp_path / "out.fa"
+        write_combined_fasta(records, objs, out, keep_unscaffolded=False)
+        assert read_fasta_records(out)["chr1_hap1"] == "CGAATT"
+
+    def test_keep_unscaffolded_returns_leftovers(self, tmp_path: Path) -> None:
+        rows = [_row("chr1_hap1_A", "A", "chr1", "hap1", length=7)]
+        records = {"A": "ACGTACGTAC", "tiny": "TT"}
+        objs = plan_combined_layout(rows, {"A": 10}, gap_size=5, acrocentrics=set())
+        out = tmp_path / "out.fa"
+        leftovers = write_combined_fasta(records, objs, out, keep_unscaffolded=True)
+        res = read_fasta_records(out)
+        assert list(res.keys()) == ["chr1_hap1", "tiny"]
+        assert leftovers == [("tiny", 2)]
+
+    def test_acrocentric_singletons_kept_separate(self, tmp_path: Path) -> None:
+        rows = [
+            _row("chr13_hap1_A", "A", "chr13", "hap1", length=7),
+            _row("chr13_hap1_B", "B", "chr13", "hap1", length=5),
+        ]
+        records = {"A": "ACGTACGTAC", "B": "GGGGCCCC"}
+        objs = plan_combined_layout(rows, {"A": 10, "B": 8}, gap_size=5, acrocentrics={"chr13"})
+        out = tmp_path / "out.fa"
+        write_combined_fasta(records, objs, out, keep_unscaffolded=False)
+        res = read_fasta_records(out)
+        assert list(res.keys()) == ["chr13_hap1_A", "chr13_hap1_B"]
+        assert res["chr13_hap1_A"] == "ACGTACGTAC"
+
+
+# --- combined BED ---------------------------------------------------
+
+
+class TestRewriteBedCombined:
+    def _layout(self, gap_size: int = 5):
+        rows = [
+            _row("chr1_hap1_A", "A", "chr1", "hap1", length=7),
+            _row("chr1_hap1_B", "B", "chr1", "hap1", length=5),
+        ]
+        return plan_combined_layout(rows, {"A": 10, "B": 8}, gap_size=gap_size, acrocentrics=set())
+
+    def test_shift_and_novel_gap(self, tmp_path: Path) -> None:
+        # A tiles [0,7), B tiles [0,5). gap=5 -> B offset 15.
+        src = tmp_path / "in.bed"
+        src.write_text("A\t0\t7\tchr1\nB\t0\t5\tchr1\n")
+        out = tmp_path / "out.bed"
+        rewrite_bed_combined(src, out, objects=self._layout(), gzip_out=False)
+        lines = [tuple(x.split("\t")) for x in out.read_text().splitlines()]
+        assert lines == [
+            ("chr1_hap1", "0", "7", "chr1"),
+            ("chr1_hap1", "7", "15", "novel"),  # gap = G + (L-E) = 5 + 3 = 8
+            ("chr1_hap1", "15", "20", "chr1"),
+        ]
+
+    def test_gap_length_is_G_plus_k_minus_1(self, tmp_path: Path) -> None:
+        src = tmp_path / "in.bed"
+        src.write_text("A\t0\t7\tchr1\nB\t0\t5\tchr1\n")
+        out = tmp_path / "out.bed"
+        rewrite_bed_combined(src, out, objects=self._layout(gap_size=100), gzip_out=False)
+        gap = next(
+            x.split("\t") for x in out.read_text().splitlines() if x.split("\t")[3] == "novel"
+        )
+        # gap spans E_A(7)+offset0 .. offset_B; length = 100 + (10-7) = 103.
+        assert int(gap[2]) - int(gap[1]) == 103
+
+    def test_adjacent_novel_merges_across_junction(self, tmp_path: Path) -> None:
+        # A ends novel, B starts novel: the trailing novel, the gap, and
+        # the leading novel coalesce into a single run.
+        src = tmp_path / "in.bed"
+        src.write_text("A\t0\t4\tchr1\nA\t4\t7\tnovel\nB\t0\t2\tnovel\nB\t2\t5\tchr1\n")
+        out = tmp_path / "out.bed"
+        rewrite_bed_combined(src, out, objects=self._layout(), gzip_out=False)
+        lines = [tuple(x.split("\t")) for x in out.read_text().splitlines()]
+        assert lines == [
+            ("chr1_hap1", "0", "4", "chr1"),
+            ("chr1_hap1", "4", "17", "novel"),  # 4..7 + gap 7..15 + 15..17
+            ("chr1_hap1", "17", "20", "chr1"),
+        ]
+
+    def test_flipped_component_mirrored(self, tmp_path: Path) -> None:
+        rows = [_row("chr1_hap1_A_rc", "A", "chr1", "hap1", flipped=True, length=7)]
+        objs = plan_combined_layout(rows, {"A": 10}, gap_size=5, acrocentrics=set())
+        src = tmp_path / "in.bed"
+        # A: [0,2) p, [2,7) q. Flipped within [0,7): q->[0,5), p->[5,7).
+        src.write_text("A\t0\t2\tp\nA\t2\t7\tq\n")
+        out = tmp_path / "out.bed"
+        rewrite_bed_combined(src, out, objects=objs, gzip_out=False)
+        lines = [tuple(x.split("\t")) for x in out.read_text().splitlines()]
+        assert lines == [
+            ("chr1_hap1", "0", "5", "q"),
+            ("chr1_hap1", "5", "7", "p"),
+        ]
+
+    def test_missing_contig_filled_with_novel(self, tmp_path: Path) -> None:
+        # B has no records in this feature set: fill its extent with novel.
+        src = tmp_path / "in.bed"
+        src.write_text("A\t0\t7\tchr1\n")
+        out = tmp_path / "out.bed"
+        rewrite_bed_combined(src, out, objects=self._layout(), gzip_out=False)
+        lines = [tuple(x.split("\t")) for x in out.read_text().splitlines()]
+        # A [0,7) chr1 ; novel gap 7..15 ; B extent filled novel 15..20 -> merges to 7..20.
+        assert lines == [
+            ("chr1_hap1", "0", "7", "chr1"),
+            ("chr1_hap1", "7", "20", "novel"),
+        ]
+
+
+# --- AGP from layout ------------------------------------------------
+
+
+class TestToAgpObjects:
+    def test_combined_object_has_gap_rows(self) -> None:
+        rows = [
+            _row("chr1_hap1_A", "A", "chr1", "hap1", length=7),
+            _row("chr1_hap1_B", "B", "chr1", "hap1", flipped=True, length=5),
+        ]
+        objs = plan_combined_layout(rows, {"A": 10, "B": 8}, gap_size=5, acrocentrics=set())
+        agp = _to_agp_objects(objs, [])
+        assert len(agp) == 1
+        parts = agp[0].parts
+        # W(A) +, N gap, W(B) -.
+        assert parts[0].component_id == "A"
+        assert parts[0].orientation == "+"
+        assert parts[0].object_end == 10
+        assert parts[1].length == 5  # literal N gap, not G+k-1
+        assert parts[1].object_start == 10 and parts[1].object_end == 15
+        assert parts[2].component_id == "B"
+        assert parts[2].orientation == "-"
+        assert parts[2].object_start == 15 and parts[2].object_end == 23
+
+    def test_leftovers_become_singleton_objects(self) -> None:
+        rows = [_row("chr1_hap1_A", "A", "chr1", "hap1", length=7)]
+        objs = plan_combined_layout(rows, {"A": 10}, gap_size=5, acrocentrics=set())
+        agp = _to_agp_objects(objs, [("tiny", 2)])
+        assert [o.name for o in agp] == ["chr1_hap1", "tiny"]
+        assert agp[1].parts[0].length == 2


### PR DESCRIPTION
`karyoscope scaffold` can now concatenate the contigs of each chromosome+haplotype into a single sequence, producing a less fragmented assembly. FASTA output only (--mode fasta / both).

New flags:
- --combine-chromosomes (default off): join all contigs of one (chromosome, hap) into one \<chrom\>_\<hap\> record.
- --scaffold-gap-size (default 100000): N bases between concatenated contigs.
- --combine-acrocentrics (default off): also combine acrocentric chromosomes. Off by default because acrocentric p-arms recombine and chromosome assignment there is less certain; reuses the --acrocentric set.

Outputs carry a combined_chromosomes filename tag so combined and non-combined runs coexist:
- \<stem\>.\<db\>.scaffolded.combined_chromosomes.fa[.gz]
- \<stem\>.\<db\>.\<fs\>.smoothed.scaffolded.combined_chromosomes.bed[.gz] (--mode both only; plain scaffolded BEDs are not written in a combine run)
- \<stem\>.\<db\>.scaffolded.combined_chromosomes.agp (AGP 2.1) documenting every component placement and gap (gap_type=scaffold, linkage=yes, linkage_evidence=align_genus). The AGP fully describes the output FASTA, including kept unscaffolded leftovers as singleton objects.

The combined BEDs share the FASTA coordinate system exactly. Each per-contig annotation BED tiles [0, E) where E = L - k + 1 (L = true contig length, k = k-mer size); the map's length field is E. When contigs are concatenated as seq + N*gap + seq, each contig's intervals shift by its true-base offset and a novel interval fills [offset + E, next_offset) -- the literal N gap plus the contig's own untiled k-1 tail, whose k-mers in the concatenated assembly overlap the Ns. This is byte-identical to re-annotating the combined FASTA (smoothing never bridges the gap, far larger than max_gap=1000). The implementation reads true lengths from the FASTA and tiling ends from each BED, so it hardcodes no k and stays correct for a future variable-k database (designed-for, not yet exercised in tests).

New module core/io/agp.py; additions to core/scaffold.py (plan_combined_layout, write_combined_fasta, rewrite_bed_combined, _to_agp_objects), core/scaffold_run.py, commands/scaffold.py. New tests/test_agp.py plus combine tests in test_scaffold.py / test_command_scaffold.py.

karyotype awareness of the combined_chromosomes files is a separate follow-up.