### PR TITLE
karyotype: add --combine-chromosomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   implementation reads true lengths from the FASTA and tiling ends from
   each BED, so it hardcodes no ``k`` and stays correct for a future
   variable-k database (designed-for but, lacking such a database, not
-  yet exercised in tests). ``karyotype`` awareness of the
-  ``combined_chromosomes`` files is a separate follow-up.
+  yet exercised in tests).
+- ``karyoscope karyotype`` gained ``--combine-chromosomes`` (plus
+  ``--scaffold-gap-size`` and ``--combine-acrocentrics``, mirroring the
+  ``scaffold`` flags) to render combined-chromosome karyotypes. When
+  set, karyotype cascades ``scaffold`` in ``--mode both`` with
+  ``--combine-chromosomes`` so the ``combined_chromosomes`` BEDs (and
+  the combined FASTA + AGP side artifacts) are created, then lays out
+  the figure from those combined BEDs: each ``<chrom>_<hap>`` is one
+  ideogram cell instead of one cell per contig. The renderer is
+  unchanged -- karyotype bins the combined BEDs (keyed ``<chrom>_<hap>``)
+  and joins them to synthetic combined map rows (one per object, with
+  end-telomere flags taken from the first and last component). All three
+  modes work: ``genome`` / ``subtelomere`` consume the combined binned
+  BEDs directly; ``centromere`` detects centromere ranges in the
+  combined coordinate system (keyed ``<chrom>_<hap>``) and writes a
+  ``<stem>.<db>.centromeres.combined_chromosomes.bed[.gz]``. The
+  SVG / PDF / PNG filenames carry the ``combined_chromosomes`` tag so
+  combined and per-contig figures coexist in one directory. Acrocentric
+  groups left uncombined (the default) still render as their per-contig
+  cells.
 - ``karyoscope annotate`` is now resumable across the expensive
   ``get_featureIDs`` (k-mer query) step. On success that step writes a
   small ``<input>.<dbid>.combined.presmoothed.featureIDs.bed.done``

--- a/src/karyoscope/commands/karyotype.py
+++ b/src/karyoscope/commands/karyotype.py
@@ -154,6 +154,33 @@ logger = logging.getLogger(__name__)
     "Repeatable; accepts comma-separated lists. Default: human acrocentrics with a warning.",
 )
 @click.option(
+    "--combine-chromosomes/--no-combine-chromosomes",
+    default=False,
+    show_default=True,
+    help="Render combined chromosomes: cascade scaffold with "
+    "--combine-chromosomes so each chromosome+haplotype's contigs are "
+    "concatenated into a single '<chrom>_<hap>' sequence (separated by N "
+    "gaps), then lay out the karyotype from those combined BEDs. Produces "
+    "the combined scaffolded FASTA + AGP as a side artifact and tags the "
+    "SVG/PDF/PNG filenames with 'combined_chromosomes'.",
+)
+@click.option(
+    "--scaffold-gap-size",
+    type=int,
+    default=100_000,
+    show_default=True,
+    help="Number of N bases inserted between concatenated contigs when "
+    "--combine-chromosomes is set.",
+)
+@click.option(
+    "--combine-acrocentrics/--no-combine-acrocentrics",
+    default=False,
+    show_default=True,
+    help="Also combine acrocentric chromosomes (chr13/14/15/21/22 by default) "
+    "when --combine-chromosomes is set. Off by default: acrocentric p-arms "
+    "recombine and chromosome assignment there is less certain.",
+)
+@click.option(
     "--no-human-chroms",
     "no_human_chroms",
     is_flag=True,
@@ -268,6 +295,9 @@ def cmd(
     subtelomere_boundary: int,
     min_scaffold_length: int,
     acrocentrics_raw: tuple[str, ...],
+    combine_chromosomes: bool,
+    scaffold_gap_size: int,
+    combine_acrocentrics: bool,
     no_human_chroms: bool,
     formats_raw: tuple[str, ...],
     sample_label: str | None,
@@ -353,6 +383,11 @@ def cmd(
     if output_dir is not None and output_path is not None:
         raise click.UsageError("--outdir and --output cannot both be set")
 
+    if scaffold_gap_size < 0:
+        raise click.BadParameter("--scaffold-gap-size must be >= 0")
+    if not combine_chromosomes and combine_acrocentrics:
+        logger.warning("--combine-acrocentrics has no effect without --combine-chromosomes")
+
     sex_resolved: str | None = None if sex.lower() == "unknown" else sex.lower()
     feature_sets = list(feature_sets_arg) if feature_sets_arg else None
     modes = [m.lower() for m in modes_raw] if modes_raw else None
@@ -377,6 +412,9 @@ def cmd(
             subtelomere_boundary=subtelomere_boundary,
             min_scaffold_length=min_scaffold_length,
             acrocentrics=acrocentrics,
+            combine_chromosomes=combine_chromosomes,
+            scaffold_gap_size=scaffold_gap_size,
+            combine_acrocentrics=combine_acrocentrics,
             split_haps_regex=split_haps_regex,
             threads=threads,
             auto=auto,

--- a/src/karyoscope/core/karyotype_run.py
+++ b/src/karyoscope/core/karyotype_run.py
@@ -35,9 +35,15 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
-from karyoscope.core.annotate import resolve_database
+from karyoscope.core.annotate import _bgzip_file, resolve_database
 from karyoscope.core.bin import bin_features, leaves_for
-from karyoscope.core.centromeres import centromeres_run
+from karyoscope.core.centromeres import (
+    DEFAULT_COARSE_BIN_SIZE,
+    DEFAULT_FINE_BIN_SIZE,
+    _resolve_centromere_role,
+    centromeres_run,
+    find_centromere_ranges,
+)
 from karyoscope.core.io.colors import colors_for_set, parse_colors, validate_colors
 from karyoscope.core.io.hierarchy import parse_hierarchy
 from karyoscope.core.io.scaffold_map import MapRow, map_signature, read_map
@@ -50,7 +56,9 @@ from karyoscope.core.karyotype import (
 from karyoscope.core.scaffold import (
     DEFAULT_HUMAN_ACROCENTRICS,
     DEFAULT_MIN_SCAFFOLD_LENGTH,
+    DEFAULT_SCAFFOLD_GAP_SIZE,
     Interval,
+    combined_map_rows,
     rewrite_bed,
 )
 from karyoscope.core.scaffold_run import InputSpec, scaffold_run
@@ -134,6 +142,40 @@ def _binned_scaffolded_bed_path(
     variant: str = "smoothed",
 ) -> Path:
     return out_dir / f"{stem}.{db_id}.{fs}.{variant}.scaffolded.binned{bin_size}.bed.gz"
+
+
+#: Filename tag distinguishing combined-chromosome outputs from the
+#: per-contig scaffolded outputs. Must match
+#: ``scaffold_run._COMBINED_TAG`` so karyotype reads the combined BEDs
+#: that scaffold writes.
+_COMBINED_TAG = "combined_chromosomes"
+
+
+def _combined_scaffolded_bed_path(
+    out_dir: Path, stem: str, db_id: str, fs: str, variant: str = "smoothed"
+) -> Path:
+    """The combined-chromosome scaffolded BED scaffold writes (mode 'both')."""
+    gz = out_dir / f"{stem}.{db_id}.{fs}.{variant}.scaffolded.{_COMBINED_TAG}.bed.gz"
+    if gz.is_file():
+        return gz
+    plain = out_dir / f"{stem}.{db_id}.{fs}.{variant}.scaffolded.{_COMBINED_TAG}.bed"
+    if plain.is_file():
+        return plain
+    return gz
+
+
+def _binned_combined_scaffolded_bed_path(
+    out_dir: Path,
+    stem: str,
+    db_id: str,
+    fs: str,
+    bin_size: int,
+    variant: str = "smoothed",
+) -> Path:
+    return (
+        out_dir
+        / f"{stem}.{db_id}.{fs}.{variant}.scaffolded.{_COMBINED_TAG}.binned{bin_size}.bed.gz"
+    )
 
 
 def _binned_mapsig_path(binned: Path) -> Path:
@@ -228,8 +270,19 @@ def _ensure_binned_scaffolded(
     threads: int,
     map_rows: list[MapRow] | None = None,
     variant: str = "smoothed",
+    combined: bool = False,
 ) -> Path:
     """Return the binned scaffolded BED path, building it if missing or stale.
+
+    When ``combined`` is True, operates on the combined-chromosome
+    scaffolded BED (sequence names ``<chrom>_<hap>``) that
+    ``scaffold_run(combine_chromosomes=True, mode="both")`` always
+    materialises. The combined BED is binned directly; there is no
+    ``--no-scaffolding`` annotation fallback on this path, because the
+    combined coordinate transform only exists in the full-resolution
+    combined BED. ``map_rows`` here should be the *combined* map rows so
+    the ``.mapsig`` guard invalidates when the underlying scaffold map
+    changes.
 
     An existing binned BED is reused only when it is also *current* with
     respect to the scaffold map (see :func:`_binned_bed_is_current`): the
@@ -251,7 +304,12 @@ def _ensure_binned_scaffolded(
     ``variant`` selects whether we read the smoothed or presmoothed
     annotation BEDs and produce correspondingly named intermediates.
     """
-    out = _binned_scaffolded_bed_path(out_dir, stem, db_id, fs, bin_size, variant=variant)
+    if combined:
+        out = _binned_combined_scaffolded_bed_path(
+            out_dir, stem, db_id, fs, bin_size, variant=variant
+        )
+    else:
+        out = _binned_scaffolded_bed_path(out_dir, stem, db_id, fs, bin_size, variant=variant)
     if out.is_file() and _binned_bed_is_current(out, map_rows):
         return out
     if not auto:
@@ -269,6 +327,26 @@ def _ensure_binned_scaffolded(
             + "Re-run with auto-derive enabled"
             + (f" (or delete {out.name} and its .mapsig)." if stale else ".")
         )
+    if combined:
+        # The combined coordinate transform lives only in the
+        # full-resolution combined BED, which scaffold always writes in
+        # combine mode. Bin it directly; there is no annotation fallback.
+        combined_src = _combined_scaffolded_bed_path(out_dir, stem, db_id, fs, variant=variant)
+        if not combined_src.is_file():
+            raise KaryotypeError(
+                f"cannot bin combined {fs!r} for {input_name}: combined "
+                f"scaffolded BED missing at {combined_src} (scaffold should "
+                f"have produced it in combine mode)"
+            )
+        bin_features(
+            combined_src,
+            out,
+            bin_size=bin_size,
+            leaf_set=leaf_set or None,
+            threads=threads,
+        )
+        _write_binned_mapsig(out, map_rows)
+        return out
     scaffolded_src = _scaffolded_bed_path(out_dir, stem, db_id, fs, variant=variant)
     if scaffolded_src.is_file():
         bin_features(
@@ -321,6 +399,87 @@ def _centromeres_bed_path(out_dir: Path, stem: str, db_id: str) -> Path:
     return gz
 
 
+def _combined_centromeres_bed_path(out_dir: Path, stem: str, db_id: str) -> Path:
+    gz = out_dir / f"{stem}.{db_id}.centromeres.{_COMBINED_TAG}.bed.gz"
+    if gz.is_file():
+        return gz
+    plain = out_dir / f"{stem}.{db_id}.centromeres.{_COMBINED_TAG}.bed"
+    if plain.is_file():
+        return plain
+    return gz
+
+
+def _ensure_combined_centromeres(
+    *,
+    out_dir: Path,
+    stem: str,
+    db_id: str,
+    centromere_fs: str,
+    centromere_leaves: set[str],
+    map_rows: list[MapRow],
+    auto: bool,
+    input_name: str,
+    threads: int,
+    bgzip: bool,
+    variant: str = "smoothed",
+) -> dict[str, tuple[int, int]]:
+    """Detect centromere ranges in the combined coordinate system.
+
+    The non-combined cascade runs ``centromeres_run`` per contig; on the
+    combine path we detect against the combined-chromosome BEDs instead,
+    so the ranges are keyed by ``<chrom>_<hap>`` and expressed in
+    combined coordinates -- exactly what the centromere-mode renderer
+    needs to join against the combined binned BED.
+
+    Reuses :func:`find_centromere_ranges` and the combined binnings
+    (coarse 1 Mb + fine 100 kb) that :func:`_ensure_binned_scaffolded`
+    produces and caches. Writes the result to a
+    ``centromeres.combined_chromosomes.bed`` for parity with the
+    per-contig output, then returns it in memory.
+    """
+    coarse_path = _ensure_binned_scaffolded(
+        out_dir=out_dir,
+        stem=stem,
+        db_id=db_id,
+        fs=centromere_fs,
+        bin_size=DEFAULT_COARSE_BIN_SIZE,
+        leaf_set=centromere_leaves,
+        auto=auto,
+        input_name=input_name,
+        threads=threads,
+        map_rows=map_rows,
+        variant=variant,
+        combined=True,
+    )
+    coarse_bins = _load_binned_bed(coarse_path)
+    fine_bins: OrderedDict[str, list[Interval]] | None = None
+    if DEFAULT_FINE_BIN_SIZE:
+        fine_path = _ensure_binned_scaffolded(
+            out_dir=out_dir,
+            stem=stem,
+            db_id=db_id,
+            fs=centromere_fs,
+            bin_size=DEFAULT_FINE_BIN_SIZE,
+            leaf_set=centromere_leaves,
+            auto=auto,
+            input_name=input_name,
+            threads=threads,
+            map_rows=map_rows,
+            variant=variant,
+            combined=True,
+        )
+        fine_bins = _load_binned_bed(fine_path)
+    ranges = find_centromere_ranges(coarse_bins, fine_bins)
+
+    plain = out_dir / f"{stem}.{db_id}.centromeres.{_COMBINED_TAG}.bed"
+    with plain.open("w") as h:
+        for contig, (cstart, cend) in ranges.items():
+            h.write(f"{contig}\t{cstart}\t{cend}\n")
+    if bgzip:
+        _bgzip_file(plain, threads=threads)
+    return dict(ranges)
+
+
 #: Output formats supported by :func:`karyotype_run`. SVG is the
 #: native drawsvg output; PDF and PNG are produced by converting the
 #: SVG via :mod:`cairosvg`.
@@ -361,6 +520,9 @@ def karyotype_run(
     subtelomere_boundary: int = 250_000,
     min_scaffold_length: int = DEFAULT_MIN_SCAFFOLD_LENGTH,
     acrocentrics: set[str] | None = None,
+    combine_chromosomes: bool = False,
+    scaffold_gap_size: int = DEFAULT_SCAFFOLD_GAP_SIZE,
+    combine_acrocentrics: bool = False,
     split_haps_regex: str | None = None,
     threads: int = 0,
     auto: bool = True,
@@ -452,41 +614,89 @@ def karyotype_run(
             "full list of issues):\n  - " + "\n  - ".join(color_issues)
         )
 
+    if combine_chromosomes and scaffold_gap_size < 0:
+        raise KaryotypeError(f"scaffold_gap_size must be >= 0, got {scaffold_gap_size}")
+
+    # The acrocentric set drives which (chromosome, hap) groups get
+    # combined. Resolve it the same way scaffold does so the synthetic
+    # combined map rows agree with the combined BED's object names.
+    acros_set = acrocentrics if acrocentrics is not None else set(DEFAULT_HUMAN_ACROCENTRICS)
+
+    # Centromere detection feature set (combine path only -- the
+    # non-combine path lets centromeres_run resolve it internally).
+    want_centromere = "centromere" in requested_modes
+    centromere_fs: str | None = None
+    centromere_leaves: set[str] = set()
+    if combine_chromosomes and want_centromere:
+        centromere_fs = _resolve_centromere_role(manifest.roles, available)
+        centromere_leaves = leaves_for(hierarchy, centromere_fs)
+
     logger.info(
         "rendering karyotype(s): %d input(s), modes=%s, feature_sets=%s "
-        "(= %d SVG(s) x %d format(s))",
+        "(= %d SVG(s) x %d format(s))%s",
         len(inputs),
         requested_modes,
         requested,
         len(requested_modes) * len(requested),
         len(requested_formats),
+        " [combine-chromosomes]" if combine_chromosomes else "",
     )
 
     # Make sure scaffolded BEDs exist for every input + requested
     # feature set. scaffold_run short-circuits on existing files.
-    scaffold_run(
-        inputs,
-        db_root=db_root,
-        db_id=db_id_resolved,
-        feature_sets=requested,
-        mode="bed",
-        min_scaffold_length=min_scaffold_length,
-        acrocentrics=acrocentrics,
-        split_haps_regex=split_haps_regex,
-        threads=threads,
-        bgzip=bgzip,
-        auto=auto,
-        output_dir=output_dir,
-        write_scaffolded_beds=scaffolding,
-        annotation_variant=annotation_variant,
-    )
+    if combine_chromosomes:
+        # Combine path: cascade scaffold in 'both' mode so it writes the
+        # combined-chromosome BEDs (and the combined FASTA + AGP). The
+        # centromere-detection feature set is added to the set when
+        # centromere mode is requested so its combined BED exists for
+        # in-coordinate centromere detection below.
+        scaffold_feature_sets = list(requested)
+        if centromere_fs is not None and centromere_fs not in scaffold_feature_sets:
+            scaffold_feature_sets.append(centromere_fs)
+        scaffold_run(
+            inputs,
+            db_root=db_root,
+            db_id=db_id_resolved,
+            feature_sets=scaffold_feature_sets,
+            mode="both",
+            min_scaffold_length=min_scaffold_length,
+            acrocentrics=acros_set,
+            combine_chromosomes=True,
+            scaffold_gap_size=scaffold_gap_size,
+            combine_acrocentrics=combine_acrocentrics,
+            split_haps_regex=split_haps_regex,
+            threads=threads,
+            bgzip=bgzip,
+            auto=auto,
+            output_dir=output_dir,
+            annotation_variant=annotation_variant,
+        )
+    else:
+        scaffold_run(
+            inputs,
+            db_root=db_root,
+            db_id=db_id_resolved,
+            feature_sets=requested,
+            mode="bed",
+            min_scaffold_length=min_scaffold_length,
+            acrocentrics=acrocentrics,
+            split_haps_regex=split_haps_regex,
+            threads=threads,
+            bgzip=bgzip,
+            auto=auto,
+            output_dir=output_dir,
+            write_scaffolded_beds=scaffolding,
+            annotation_variant=annotation_variant,
+        )
 
     # For centromere mode, also ensure the centromere coordinates file
     # exists per input. centromeres_run cascades through scaffold and
     # bin internally. Only call when centromere mode is actually
     # requested -- it's expensive (an extra bin pass) and unnecessary
-    # for genome / subtelomere outputs.
-    if "centromere" in requested_modes:
+    # for genome / subtelomere outputs. On the combine path the
+    # per-input combined centromere ranges are detected lazily in the
+    # render loop instead (keyed by <chrom>_<hap>, in combined coords).
+    if want_centromere and not combine_chromosomes:
         centromeres_run(
             inputs,
             db_root=db_root,
@@ -532,6 +742,37 @@ def karyotype_run(
         stems = [stem for _, _, stem in per_input_state]
         sample_label = " + ".join(stems) if stems else None
 
+    # Combine path: precompute the per-input combined map rows (one
+    # synthetic <chrom>_<hap> row per combined object) and, when
+    # centromere mode is requested, the combined centromere ranges.
+    # Both are reused across every (mode, feature_set) render for that
+    # input. Keyed by the input FASTA path.
+    combined_rows_by_input: dict[Path, list[MapRow]] = {}
+    combined_cen_by_input: dict[Path, dict[str, tuple[int, int]]] = {}
+    if combine_chromosomes:
+        for spec, out_dir, stem in per_input_state:
+            per_contig_rows = read_map(out_dir / f"{stem}.{db_id_resolved}.scaffold_map.tsv")
+            crows = combined_map_rows(
+                per_contig_rows,
+                acrocentrics=acros_set,
+                combine_acrocentrics=combine_acrocentrics,
+            )
+            combined_rows_by_input[spec.path] = crows
+            if want_centromere and centromere_fs is not None:
+                combined_cen_by_input[spec.path] = _ensure_combined_centromeres(
+                    out_dir=out_dir,
+                    stem=stem,
+                    db_id=db_id_resolved,
+                    centromere_fs=centromere_fs,
+                    centromere_leaves=centromere_leaves,
+                    map_rows=crows,
+                    auto=auto,
+                    input_name=spec.path.name,
+                    threads=threads,
+                    bgzip=bgzip,
+                    variant=annotation_variant,
+                )
+
     results: list[KaryotypeResult] = []
     results_dir.mkdir(parents=True, exist_ok=True)
 
@@ -556,8 +797,13 @@ def karyotype_run(
             for spec, out_dir, stem in per_input_state:
                 # Read map first; the binner needs it on the
                 # ``--no-scaffolding`` path to apply rename + flip at
-                # bin time when no on-disk scaffolded BED exists.
-                map_rows = read_map(out_dir / f"{stem}.{db_id_resolved}.scaffold_map.tsv")
+                # bin time when no on-disk scaffolded BED exists. On the
+                # combine path the renderer instead consumes the
+                # synthetic combined map rows keyed by <chrom>_<hap>.
+                per_contig_rows = read_map(out_dir / f"{stem}.{db_id_resolved}.scaffold_map.tsv")
+                render_map_rows = (
+                    combined_rows_by_input[spec.path] if combine_chromosomes else per_contig_rows
+                )
                 binned_path = _ensure_binned_scaffolded(
                     out_dir=out_dir,
                     stem=stem,
@@ -568,31 +814,38 @@ def karyotype_run(
                     auto=auto,
                     input_name=spec.path.name,
                     threads=threads,
-                    map_rows=map_rows,
+                    map_rows=render_map_rows,
                     variant=annotation_variant,
+                    combined=combine_chromosomes,
                 )
                 binned_bed = _load_binned_bed(binned_path)
 
                 centromere_ranges: dict[str, tuple[int, int]] | None = None
                 if current_mode == "centromere":
-                    cpath = _centromeres_bed_path(out_dir, stem, db_id_resolved)
-                    if not cpath.is_file():
-                        raise KaryotypeError(
-                            f"missing centromeres BED for {spec.path.name} (expected at {cpath})"
-                        )
-                    centromere_ranges = _load_centromeres_bed(cpath)
+                    if combine_chromosomes:
+                        centromere_ranges = combined_cen_by_input[spec.path]
+                    else:
+                        cpath = _centromeres_bed_path(out_dir, stem, db_id_resolved)
+                        if not cpath.is_file():
+                            raise KaryotypeError(
+                                f"missing centromeres BED for {spec.path.name} "
+                                f"(expected at {cpath})"
+                            )
+                        centromere_ranges = _load_centromeres_bed(cpath)
 
                 render_inputs.append(
                     RenderInput(
-                        map_rows=map_rows,
+                        map_rows=render_map_rows,
                         binned_bed=binned_bed,
                         centromere_ranges=centromere_ranges,
                     )
                 )
 
             flat_colors = colors_for_set(colors, fs)
+            combined_tag = f".{_COMBINED_TAG}" if combine_chromosomes else ""
             stem_for_paths = (
-                f"{base_name}.{db_id_resolved}.{current_mode}.{fs}.{annotation_variant}.karyotype"
+                f"{base_name}.{db_id_resolved}.{current_mode}.{fs}."
+                f"{annotation_variant}{combined_tag}.karyotype"
             )
             svg_path = results_dir / f"{stem_for_paths}.svg"
             logger.info(

--- a/src/karyoscope/core/scaffold.py
+++ b/src/karyoscope/core/scaffold.py
@@ -891,6 +891,64 @@ def plan_combined_layout(
     return objects
 
 
+def combined_map_rows(
+    map_rows: list[MapRow],
+    *,
+    acrocentrics: set[str] = DEFAULT_HUMAN_ACROCENTRICS,
+    combine_acrocentrics: bool = False,
+) -> list[MapRow]:
+    """Synthetic map rows describing the combined-chromosome objects.
+
+    Mirrors the object naming and the ``(chromosome, hap)`` grouping of
+    :func:`plan_combined_layout`, but needs no FASTA: it produces one
+    :class:`MapRow` per output object so the karyotype renderer can join
+    the combined binned BED (keyed by object name) to chromosome / hap /
+    telomere metadata.
+
+    A combined object gets a synthetic ``new_name`` of ``<chrom>_<hap>``
+    (matching the combined BED's sequence name) and a ``stats`` proxy
+    carrying only the end-telomere flags the renderer reads: a leading
+    ``T`` iff the first component starts with a telomere, a trailing
+    ``T`` iff the last component ends with one. Acrocentric groups left
+    uncombined pass their per-contig rows through unchanged, so their
+    encoded ``new_name`` still matches the singleton object the layout
+    emits for them.
+
+    The ``length`` field is the sum of component ``bed_extent`` values
+    (informational only -- the renderer derives sequence lengths from the
+    binned BED, not from this field). ``flipped`` is always ``False`` on
+    a combined object: orientation was already baked into the component
+    coordinates when the combined BED was written.
+    """
+    groups: dict[tuple[str, str], list[MapRow]] = {}
+    for row in map_rows:
+        groups.setdefault((row.chromosome, row.hap), []).append(row)
+
+    out: list[MapRow] = []
+    for (chrom, hap), rows in groups.items():
+        is_acro = chrom in acrocentrics
+        combine = not (is_acro and not combine_acrocentrics)
+        if not combine:
+            out.extend(rows)
+            continue
+        start_t = rows[0].stats.startswith("T")
+        stop_t = rows[-1].stats.endswith("T")
+        stats = ("T" if start_t else "x") + ("T" if stop_t else "x")
+        out.append(
+            MapRow(
+                new_name=f"{chrom}_{hap}",
+                original_name=f"{chrom}_{hap}",
+                input_file=rows[0].input_file,
+                hap=hap,
+                chromosome=chrom,
+                flipped=False,
+                length=sum(r.length for r in rows),
+                stats=stats,
+            )
+        )
+    return out
+
+
 def _to_agp_objects(
     objects: list[ScaffoldObject],
     leftovers: list[tuple[str, int]],

--- a/tests/test_karyotype.py
+++ b/tests/test_karyotype.py
@@ -807,6 +807,25 @@ class TestCliSurface:
         assert result.exit_code != 0
         assert "--outdir and --output" in result.output
 
+    def test_help_lists_combine_chromosomes(self, cli_runner: CliRunner) -> None:
+        result = cli_runner.invoke(main, ["karyotype", "--help"])
+        assert result.exit_code == 0
+        assert "--combine-chromosomes" in result.output
+
+    def test_negative_scaffold_gap_size_rejected(
+        self,
+        cli_runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        fa = tmp_path / "x.fa"
+        fa.write_text(">a\nACGT\n")
+        result = cli_runner.invoke(
+            main,
+            ["karyotype", "-i", str(fa), "--combine-chromosomes", "--scaffold-gap-size", "-1"],
+        )
+        assert result.exit_code != 0
+        assert "scaffold-gap-size" in result.output
+
 
 # --- integration tests against the dummy DB ------------------------
 
@@ -866,6 +885,92 @@ def test_karyotype_genome_mode_against_dummy_db(
     assert "</svg>" in text
     # Colour from the dummy db's region set.
     assert "#2ca02c" in text or "#d62728" in text or "#9467bd" in text
+
+
+@_required
+@pytest.mark.integration
+def test_karyotype_combine_chromosomes_against_dummy_db(
+    cli_runner: CliRunner,
+    populated_db_root: Path,
+    dummy_assembly_fasta: Path,
+    tmp_path: Path,
+) -> None:
+    """--combine-chromosomes cascades scaffold's combine path and renders
+    from the combined-chromosome BEDs.
+
+    Verifies the karyotype outputs carry the ``combined_chromosomes`` tag
+    and that the combined scaffolded FASTA + AGP side artifacts are
+    produced.
+    """
+    out_dir = tmp_path / "out"
+    result = cli_runner.invoke(
+        main,
+        [
+            "karyotype",
+            "-i",
+            f"hap1={dummy_assembly_fasta}",
+            "--outdir",
+            str(out_dir),
+            "--mode",
+            "genome",
+            "--bin-size",
+            "10",
+            "--min-scaffold-length",
+            "1",
+            "--feature-set",
+            "region",
+            "--no-human-chroms",
+            "--combine-chromosomes",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    tagged_svgs = list(out_dir.glob("*.combined_chromosomes.karyotype.svg"))
+    assert tagged_svgs, f"no combined SVGs; got: {list(out_dir.iterdir())}"
+    text = tagged_svgs[0].read_text()
+    assert "<svg" in text and "</svg>" in text
+
+    # The combine cascade leaves the combined FASTA + AGP as side artifacts.
+    assert list(out_dir.glob("*.scaffolded.combined_chromosomes.fa*"))
+    assert list(out_dir.glob("*.scaffolded.combined_chromosomes.agp"))
+    # The combined binned BED (keyed by <chrom>_<hap>) was materialised.
+    assert list(out_dir.glob("*.scaffolded.combined_chromosomes.binned*.bed.gz"))
+
+
+@_required
+@pytest.mark.integration
+def test_karyotype_combine_centromere_mode_against_dummy_db(
+    cli_runner: CliRunner,
+    populated_db_root: Path,
+    dummy_assembly_fasta: Path,
+    tmp_path: Path,
+) -> None:
+    """Combine + centromere mode detects centromeres in combined coords
+    and writes a combined-tagged centromeres BED."""
+    out_dir = tmp_path / "out"
+    result = cli_runner.invoke(
+        main,
+        [
+            "karyotype",
+            "-i",
+            f"hap1={dummy_assembly_fasta}",
+            "--outdir",
+            str(out_dir),
+            "--mode",
+            "centromere",
+            "--bin-size",
+            "10",
+            "--min-scaffold-length",
+            "1",
+            "--feature-set",
+            "region",
+            "--no-human-chroms",
+            "--combine-chromosomes",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert list(out_dir.glob("*.centromere.region.smoothed.combined_chromosomes.karyotype.svg"))
+    assert list(out_dir.glob("*.centromeres.combined_chromosomes.bed*"))
 
 
 @_required

--- a/tests/test_karyotype_run.py
+++ b/tests/test_karyotype_run.py
@@ -12,7 +12,10 @@ from pathlib import Path
 from karyoscope.core.io.scaffold_map import MapRow, map_signature
 from karyoscope.core.karyotype_run import (
     _binned_bed_is_current,
+    _binned_combined_scaffolded_bed_path,
     _binned_mapsig_path,
+    _combined_centromeres_bed_path,
+    _combined_scaffolded_bed_path,
     _write_binned_mapsig,
 )
 
@@ -86,3 +89,29 @@ def test_sidecar_contents_match_signature(tmp_path: Path) -> None:
     rows = [_row("chr1_hap1_a", hap="hap1")]
     _write_binned_mapsig(binned, rows)
     assert _binned_mapsig_path(binned).read_text().strip() == map_signature(rows)
+
+
+# --- combine-chromosome path naming ---------------------------------
+
+
+def test_combined_scaffolded_bed_path_defaults_to_gz(tmp_path: Path) -> None:
+    p = _combined_scaffolded_bed_path(tmp_path, "samp", "DB", "region")
+    assert p.name == "samp.DB.region.smoothed.scaffolded.combined_chromosomes.bed.gz"
+
+
+def test_combined_scaffolded_bed_path_prefers_existing_plain(tmp_path: Path) -> None:
+    plain = tmp_path / "samp.DB.region.smoothed.scaffolded.combined_chromosomes.bed"
+    plain.write_text("")
+    assert _combined_scaffolded_bed_path(tmp_path, "samp", "DB", "region") == plain
+
+
+def test_binned_combined_scaffolded_bed_path(tmp_path: Path) -> None:
+    p = _binned_combined_scaffolded_bed_path(tmp_path, "samp", "DB", "region", 1_000_000)
+    assert p.name == (
+        "samp.DB.region.smoothed.scaffolded.combined_chromosomes.binned1000000.bed.gz"
+    )
+
+
+def test_combined_centromeres_bed_path(tmp_path: Path) -> None:
+    p = _combined_centromeres_bed_path(tmp_path, "samp", "DB")
+    assert p.name == "samp.DB.centromeres.combined_chromosomes.bed.gz"

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -17,6 +17,7 @@ from karyoscope.core.scaffold import (
     category_index,
     chromosome_sort_key,
     classify_and_orient,
+    combined_map_rows,
     find_largest_contiguous_region,
     flip_bins,
     get_simple_region,
@@ -640,6 +641,76 @@ class TestPlanCombinedLayout:
         objs = plan_combined_layout(rows, {"A": 10}, gap_size=5, acrocentrics=set())
         assert len(objs) == 1
         assert [c.row.original_name for c in objs[0].components] == ["A"]
+
+
+class TestCombinedMapRows:
+    """Synthetic map rows for the karyotype combine path.
+
+    Object naming must match :func:`plan_combined_layout` so the
+    renderer can join the combined binned BED (keyed by object name) to
+    these rows.
+    """
+
+    @staticmethod
+    def _mr(new_name: str, chrom: str, hap: str, stats: str) -> MapRow:
+        return MapRow(new_name, new_name, "in.fa", hap, chrom, False, 100, stats)
+
+    def test_group_collapses_to_one_row_named_chrom_hap(self) -> None:
+        rows = [
+            self._mr("chr1_hap1_A", "chr1", "hap1", "TPCQ"),
+            self._mr("chr1_hap1_B", "chr1", "hap1", "CQT"),
+        ]
+        out = combined_map_rows(rows, acrocentrics=set())
+        assert len(out) == 1
+        assert out[0].new_name == "chr1_hap1"
+        assert out[0].chromosome == "chr1"
+        assert out[0].hap == "hap1"
+        assert out[0].length == 200
+
+    def test_telomere_flags_taken_from_ends(self) -> None:
+        # First component starts with telomere, last ends with one.
+        rows = [
+            self._mr("chr1_hap1_A", "chr1", "hap1", "TPCQ"),
+            self._mr("chr1_hap1_B", "chr1", "hap1", "CQT"),
+        ]
+        stats = combined_map_rows(rows, acrocentrics=set())[0].stats
+        assert stats.startswith("T")
+        assert stats.endswith("T")
+
+    def test_no_telomere_when_ends_lack_it(self) -> None:
+        rows = [
+            self._mr("chr2_hap1_A", "chr2", "hap1", "PCQ"),
+            self._mr("chr2_hap1_B", "chr2", "hap1", "CQP"),
+        ]
+        stats = combined_map_rows(rows, acrocentrics=set())[0].stats
+        assert not stats.startswith("T")
+        assert not stats.endswith("T")
+
+    def test_haps_stay_separate(self) -> None:
+        rows = [
+            self._mr("chr1_hap1_A", "chr1", "hap1", "TPCQT"),
+            self._mr("chr1_hap2_B", "chr1", "hap2", "TPCQT"),
+        ]
+        out = combined_map_rows(rows, acrocentrics=set())
+        assert sorted(r.new_name for r in out) == ["chr1_hap1", "chr1_hap2"]
+
+    def test_acrocentric_rows_pass_through_uncombined(self) -> None:
+        rows = [
+            self._mr("chr13_hap1_A", "chr13", "hap1", "TPCQ"),
+            self._mr("chr13_hap1_B", "chr13", "hap1", "CQT"),
+        ]
+        out = combined_map_rows(rows, acrocentrics={"chr13"}, combine_acrocentrics=False)
+        # Encoded per-contig names preserved (match the singleton objects
+        # plan_combined_layout emits for an uncombined acrocentric group).
+        assert [r.new_name for r in out] == ["chr13_hap1_A", "chr13_hap1_B"]
+
+    def test_acrocentric_combined_when_forced(self) -> None:
+        rows = [
+            self._mr("chr13_hap1_A", "chr13", "hap1", "TPCQ"),
+            self._mr("chr13_hap1_B", "chr13", "hap1", "CQT"),
+        ]
+        out = combined_map_rows(rows, acrocentrics={"chr13"}, combine_acrocentrics=True)
+        assert [r.new_name for r in out] == ["chr13_hap1"]
 
 
 # --- combined FASTA -------------------------------------------------


### PR DESCRIPTION
Adds --combine-chromosomes to `karyoscope karyotype` (plus --scaffold-gap-size and --combine-acrocentrics, mirroring the scaffold flags). When set, karyotype cascades scaffold in --mode both with --combine-chromosomes so the combined_chromosomes BEDs (and the combined FASTA + AGP side artifacts) are created, then lays out the figure from those combined BEDs: each \<chrom\>_\<hap\> becomes one ideogram cell instead of one cell per contig.

The renderer is unchanged. karyotype bins the combined BEDs (keyed \<chrom\>_\<hap\>) and joins them to synthetic combined map rows produced by scaffold.combined_map_rows(), which mirrors plan_combined_layout's grouping and object naming (no FASTA needed) and carries end-telomere flags taken from the first and last component.

All three modes work: genome / subtelomere consume the combined binned BEDs directly; centromere detects centromere ranges in the combined coordinate system and writes centromeres.combined_chromosomes.bed. Combined centromere detection is done inline in karyotype_run so the scaffold combine cascade (a full-FASTA read) runs once per invocation rather than twice.

Output SVG/PDF/PNG filenames carry the combined_chromosomes tag so combined and per-contig figures coexist in one directory.

Tests: combined_map_rows unit tests, combine-path naming helpers, CLI surface (flag listed, negative gap rejected), and two integration tests against the dummy DB (genome + centromere combine, asserting the tagged SVGs and the combined FASTA/AGP/BED artifacts).