### PR TITLE
info: note when a database declares no manifest roles

### DIFF
--- a/src/karyoscope/commands/info.py
+++ b/src/karyoscope/commands/info.py
@@ -120,6 +120,14 @@ def _print_manifest_summary(manifest: Manifest, db_dir: Path) -> None:
     if manifest.roles:
         roles = ", ".join(f"{k}={v}" for k, v in sorted(manifest.roles.items()))
         click.echo(f"  Roles:                  {roles}")
+    else:
+        # Roles are optional: only scaffold/centromeres/karyotype consult them.
+        # A database without roles (e.g. a cytoband database) is still valid for
+        # annotate/bin, so we note the absence rather than treating it as an error.
+        click.echo(
+            "  Roles:                  (none declared — fine for annotate/bin; "
+            "scaffold/centromeres/karyotype fall back to default feature-set names)"
+        )
     if manifest.smoothing:
         for k, v in sorted(manifest.smoothing.items()):
             click.echo(f"  Smoothing ({k}): {v}")


### PR DESCRIPTION
`roles` in manifest.yaml is optional and only consumed by scaffold/centromeres/karyotype. Databases meant only for annotate/bin (e.g. a cytoband database) omit it. `karyoscope info` previously dropped the Roles line entirely in that case; now it prints an explanatory note so the absence is clearly intentional rather than appearing to be missing metadata.