### PR TITLE
register command + canonical --db-root flag on info/download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (unsmoothed) annotation BEDs instead of the hierarchy-smoothed
   ones, so users can visually compare the effect of smoothing. Both
   variants are produced by ``karyoscope annotate``.
+- ``karyoscope register`` registers a database that is already present
+  under the database root (built locally or copied from another machine)
+  by writing its ``installed.json`` entry, so the data commands can use
+  it without going through ``download``. It validates the layout, derives
+  the id and version from ``manifest.yaml``, records ``source: local``,
+  and refuses to clobber an existing entry without ``--force``.
 
 ### Fixed
 - Haplotype inference now recognises contig names of the form
@@ -129,6 +135,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   BED filenames (scaffolded, binned-scaffolded) also include the
   variant. This is a naming change from v1.0.0; existing scripts
   that glob for ``*.karyotype.svg`` will still match.
+
+### Deprecated
+- The database-root override on ``karyoscope info`` and ``karyoscope
+  download`` is now spelled ``--db-root``, matching the data commands
+  (``annotate``, ``bin``, ``scaffold``, ``centromeres``, ``karyotype``),
+  where ``--db`` selects a database *id*. ``--db`` remains a hidden,
+  working alias on ``info``/``download`` for one release and prints a
+  deprecation warning; it will be removed in a future version. Switch to
+  ``--db-root``.
 
 ## [1.0.0] - 2026-05-21
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Pass `--format pdf` or `--format png` (repeatable) to additionally produce those
 | Command | Purpose |
 |---|---|
 | [`karyoscope download`](docs/commands/download.md) | Acquire pre-built databases |
+| [`karyoscope register`](docs/commands/register.md) | Register a locally-placed database so commands can use it |
 | [`karyoscope annotate`](docs/commands/annotate.md) | Annotate sequences with *k*-mer features |
 | [`karyoscope scaffold`](docs/commands/scaffold.md) | Order, orient, and rename assembly contigs |
 | [`karyoscope bin`](docs/commands/bin.md) | Aggregate base-pair annotations into larger bins |

--- a/src/karyoscope/cli.py
+++ b/src/karyoscope/cli.py
@@ -39,6 +39,7 @@ from karyoscope.commands import (
     download,
     info,
     karyotype,
+    register,
     scaffold,
     version,
 )
@@ -127,6 +128,7 @@ def main(verbose: int, quiet: bool) -> None:
 
 # Register subcommands. The order here determines the order in `--help`.
 main.add_command(download.cmd, name="download")
+main.add_command(register.cmd, name="register")
 main.add_command(annotate.cmd, name="annotate")
 main.add_command(scaffold.cmd, name="scaffold")
 main.add_command(bin_cmd.cmd, name="bin")

--- a/src/karyoscope/commands/_options.py
+++ b/src/karyoscope/commands/_options.py
@@ -1,0 +1,44 @@
+"""Shared helpers for KaryoScope CLI option handling."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import click
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_db_root_flag(
+    db_root: Path | None,
+    legacy_db: Path | None,
+    *,
+    command: str,
+) -> Path | None:
+    """Reconcile the canonical ``--db-root`` flag with the deprecated ``--db`` alias.
+
+    ``info`` and ``download`` historically spelled the database-root override
+    ``--db``. That collides with the data commands (``annotate``, ``bin``,
+    ``scaffold``, ``centromeres``, ``karyotype``), where ``--db`` selects a
+    database *id* and ``--db-root`` is the root directory. The root override is
+    now ``--db-root`` on every command; ``--db`` remains a hidden, deprecated
+    alias on ``info``/``download`` for one release.
+
+    Returns the effective root override (``None`` if neither flag was given).
+    Raises :class:`click.UsageError` if both flags are supplied, and emits a
+    deprecation warning when the legacy ``--db`` flag is used.
+    """
+    if legacy_db is None:
+        return db_root
+    if db_root is not None:
+        raise click.UsageError(
+            f"`{command}`: pass --db-root, not both --db-root and --db "
+            "(--db is a deprecated alias for --db-root)."
+        )
+    logger.warning(
+        "`--db` is deprecated for `%s` and will be removed in a future release; "
+        "use `--db-root` instead.",
+        command,
+    )
+    return legacy_db

--- a/src/karyoscope/commands/download.py
+++ b/src/karyoscope/commands/download.py
@@ -23,6 +23,7 @@ from karyoscope import download as _download
 from karyoscope import installed as _installed
 from karyoscope import paths
 from karyoscope import registry as _registry
+from karyoscope.commands._options import resolve_db_root_flag
 from karyoscope.exceptions import (
     ChecksumError,
     DatabaseLayoutError,
@@ -280,10 +281,17 @@ def _action_install(
     help="Include community-contributed databases in listings.",
 )
 @click.option(
-    "--db",
+    "--db-root",
     "db_root_arg",
     type=click.Path(file_okay=False, path_type=Path),
     help="Override the database root directory (default: $KARYOSCOPE_DB or ~/.karyoscope/db/).",
+)
+@click.option(
+    "--db",
+    "db_alias",
+    type=click.Path(file_okay=False, path_type=Path),
+    hidden=True,
+    help="Deprecated alias for --db-root.",
 )
 @click.option(
     "--registry-url",
@@ -328,6 +336,7 @@ def cmd(
     tag: str | None,
     community: bool,
     db_root_arg: Path | None,
+    db_alias: Path | None,
     registry_url: str | None,
     refresh_registry: bool,
     force: bool,
@@ -355,7 +364,7 @@ def cmd(
         # Remove an installed database
         karyoscope download --remove KS_mouse_v1
     """
-    db_root = paths.ensure_db_root(db_root_arg)
+    db_root = paths.ensure_db_root(resolve_db_root_flag(db_root_arg, db_alias, command="download"))
     effective_registry_url = registry_url or _registry.DEFAULT_REGISTRY_URL
 
     # The action flags are mutually exclusive at the conceptual level.

--- a/src/karyoscope/commands/info.py
+++ b/src/karyoscope/commands/info.py
@@ -26,6 +26,7 @@ import click
 
 from karyoscope import installed as _installed
 from karyoscope import paths
+from karyoscope.commands._options import resolve_db_root_flag
 from karyoscope.core.io.hierarchy import (
     HierarchyError,
     parse_hierarchy,
@@ -272,12 +273,19 @@ def _show_path(path: Path) -> None:
 )
 @click.argument("target", required=False)
 @click.option(
-    "--db",
+    "--db-root",
     "db_root_arg",
     type=click.Path(file_okay=False, path_type=Path),
     help="Override the database root directory (default: $KARYOSCOPE_DB or ~/.karyoscope/db/).",
 )
-def cmd(target: str | None, db_root_arg: Path | None) -> None:
+@click.option(
+    "--db",
+    "db_alias",
+    type=click.Path(file_okay=False, path_type=Path),
+    hidden=True,
+    help="Deprecated alias for --db-root.",
+)
+def cmd(target: str | None, db_root_arg: Path | None, db_alias: Path | None) -> None:
     """Show information about installed databases or a given path.
 
     \b
@@ -286,7 +294,7 @@ def cmd(target: str | None, db_root_arg: Path | None) -> None:
         karyoscope info KS_human_CHM13_v2   # details on one database
         karyoscope info ./some/path/        # probe a filesystem path
     """
-    db_root = paths.ensure_db_root(db_root_arg)
+    db_root = paths.ensure_db_root(resolve_db_root_flag(db_root_arg, db_alias, command="info"))
 
     try:
         if target is None:

--- a/src/karyoscope/commands/register.py
+++ b/src/karyoscope/commands/register.py
@@ -1,0 +1,146 @@
+"""``karyoscope register`` — register a manually-placed database.
+
+``karyoscope download`` is the normal way to install a database: it
+fetches a tarball, extracts it under the database root, validates it, and
+records it in ``installed.json`` so the data commands can find it. But
+databases are sometimes produced locally — built by hand or copied from
+another machine — and unpacked into the database root directly. Such a
+database is valid on disk yet invisible to ``annotate``, ``bin``,
+``scaffold``, ``centromeres``, and ``karyotype``, because those commands
+resolve databases through ``installed.json`` only (see
+:func:`karyoscope.core.annotate.resolve_database`).
+
+``register`` closes that gap: point it at an already-present database
+directory and it writes the ``installed.json`` entry, deriving everything
+it can from the manifest. The ``version`` and ``id`` come from
+``manifest.yaml``; ``installed_at`` is the time of registration (matching
+how ``download`` records it); ``source_url`` is recorded as ``local`` and
+there is no archive to checksum, so ``source_sha256`` is left empty.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import click
+
+from karyoscope import installed as _installed
+from karyoscope import paths
+from karyoscope.exceptions import (
+    DatabaseLayoutError,
+    KaryoscopeError,
+    ManifestError,
+)
+from karyoscope.installed import InstalledRecord, now_iso
+from karyoscope.manifest import validate_database_layout
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_target_dir(db_root: Path, target: str) -> Path:
+    """Resolve TARGET (a database id or a filesystem path) to a directory.
+
+    An existing path is used as-is; otherwise TARGET is treated as a
+    database id located directly under ``db_root``.
+    """
+    as_path = Path(target).expanduser()
+    if as_path.exists():
+        return as_path.resolve()
+    return (db_root / target).resolve()
+
+
+def _register(db_root: Path, target: str, *, force: bool) -> None:
+    db_root = db_root.resolve()
+    db_dir = _resolve_target_dir(db_root, target)
+
+    if not db_dir.is_dir():
+        raise DatabaseLayoutError(
+            f"no database directory found for {target!r} (looked at {db_dir}). "
+            f"Place the database under {db_root} first, or pass a path to it."
+        )
+
+    # installed.json stores the directory as a path relative to db_root, and
+    # the data commands resolve it as `db_root / directory`. So the database
+    # must live inside the root.
+    try:
+        rel = db_dir.relative_to(db_root)
+    except ValueError as e:
+        raise DatabaseLayoutError(
+            f"database directory {db_dir} is not inside the database root {db_root}. "
+            "Move it under the root (or pass --db-root pointing at its parent) and retry."
+        ) from e
+
+    # Validates the manifest and that the referenced files exist; returns the
+    # parsed manifest. This is the same check `download` runs at install time.
+    manifest = validate_database_layout(db_dir)
+    db_id = manifest.id
+
+    if db_dir.name != db_id:
+        logger.warning(
+            "directory name %r does not match manifest id %r; the database "
+            "layout spec expects them to match. Recording under id %r.",
+            db_dir.name,
+            db_id,
+            db_id,
+        )
+
+    state = _installed.load(db_root)
+    already = db_id in state.databases
+    if already and not force:
+        existing = state.databases[db_id]
+        raise KaryoscopeError(
+            f"database {db_id!r} is already registered (directory "
+            f"{existing.directory!r}). Re-run with --force to overwrite the entry."
+        )
+
+    installed_at = now_iso()
+    _installed.record_install(
+        db_root,
+        db_id,
+        InstalledRecord(
+            version=manifest.version,
+            installed_at=installed_at,
+            source_url="local",
+            source_sha256="",
+            directory=str(rel),
+            registry_doi=None,
+        ),
+    )
+
+    click.echo(f"{'Re-registered' if already else 'Registered'} {db_id} v{manifest.version}")
+    click.echo(f"  Directory:    {db_dir}")
+    click.echo(f"  Installed at: {installed_at}")
+    click.echo("  Source:       local")
+    click.echo(f"Run `karyoscope info {db_id}` to inspect it.")
+
+
+@click.command(
+    help="Register a database already present under the database root so the "
+    "data commands can use it.",
+)
+@click.argument("target", metavar="DATABASE_ID_OR_PATH")
+@click.option(
+    "--db-root",
+    "db_root_arg",
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Override the database root directory (default: $KARYOSCOPE_DB or ~/.karyoscope/db/).",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Overwrite an existing installed.json entry for this database.",
+)
+def cmd(target: str, db_root_arg: Path | None, force: bool) -> None:
+    """Record an on-disk database in installed.json so commands can use it.
+
+    \b
+    Examples:
+        karyoscope register KS_human_CHM13_cytoband
+        karyoscope register ./KS_human_CHM13_cytoband --db-root /data/ksdb
+    """
+    db_root = paths.default_db_root(db_root_arg)
+    try:
+        _register(db_root, target, force=force)
+    except (DatabaseLayoutError, ManifestError, KaryoscopeError) as e:
+        raise click.ClickException(str(e)) from e

--- a/src/karyoscope/paths.py
+++ b/src/karyoscope/paths.py
@@ -2,7 +2,7 @@
 
 The default location for installed databases follows this precedence:
 
-1. An explicit path passed by the caller (typically via a `--db` CLI flag).
+1. An explicit path passed by the caller (typically via a `--db-root` CLI flag).
 2. The `KARYOSCOPE_DB` environment variable.
 3. `~/.karyoscope/db/` (created lazily on first use).
 
@@ -29,7 +29,7 @@ def default_db_root(explicit: Path | str | None = None) -> Path:
 
     Precedence:
 
-    1. ``explicit`` if provided (usually from a ``--db`` CLI flag).
+    1. ``explicit`` if provided (usually from a ``--db-root`` CLI flag).
     2. The ``KARYOSCOPE_DB`` environment variable.
     3. ``~/.karyoscope/db/`` as a last resort.
 

--- a/tests/test_command_download.py
+++ b/tests/test_command_download.py
@@ -26,7 +26,7 @@ def test_list_shows_dummy_db(
         "--list",
         "--registry-url",
         dummy_registry_url,
-        "--db",
+        "--db-root",
         str(isolated_db_root),
     )
     assert result.exit_code == 0, result.output
@@ -46,7 +46,7 @@ def test_list_organism_filter(
         "Synthetic",
         "--registry-url",
         dummy_registry_url,
-        "--db",
+        "--db-root",
         str(isolated_db_root),
     )
     assert matching.exit_code == 0
@@ -60,7 +60,7 @@ def test_list_organism_filter(
         "platypus",
         "--registry-url",
         dummy_registry_url,
-        "--db",
+        "--db-root",
         str(isolated_db_root),
     )
     assert not_matching.exit_code == 0
@@ -79,7 +79,7 @@ def test_list_tag_filter(
         "test",
         "--registry-url",
         dummy_registry_url,
-        "--db",
+        "--db-root",
         str(isolated_db_root),
     )
     assert result.exit_code == 0
@@ -93,7 +93,7 @@ def test_list_tag_filter(
         "definitely_not_a_tag",
         "--registry-url",
         dummy_registry_url,
-        "--db",
+        "--db-root",
         str(isolated_db_root),
     )
     assert result2.exit_code == 0
@@ -113,7 +113,7 @@ def test_info_displays_details(
         "KS_dummy_test_v1",
         "--registry-url",
         dummy_registry_url,
-        "--db",
+        "--db-root",
         str(isolated_db_root),
     )
     assert result.exit_code == 0, result.output
@@ -133,7 +133,7 @@ def test_info_unknown_id_fails_cleanly(
         "does_not_exist",
         "--registry-url",
         dummy_registry_url,
-        "--db",
+        "--db-root",
         str(isolated_db_root),
     )
     assert result.exit_code != 0
@@ -148,7 +148,7 @@ def test_status_empty(cli_runner: CliRunner, isolated_db_root: Path) -> None:
         cli_runner,
         "download",
         "--status",
-        "--db",
+        "--db-root",
         str(isolated_db_root),
     )
     assert result.exit_code == 0
@@ -160,7 +160,7 @@ def test_status_after_install(cli_runner: CliRunner, populated_db_root: Path) ->
         cli_runner,
         "download",
         "--status",
-        "--db",
+        "--db-root",
         str(populated_db_root),
     )
     assert result.exit_code == 0
@@ -179,7 +179,7 @@ def test_install_default_database(
         "download",
         "--registry-url",
         dummy_registry_url,
-        "--db",
+        "--db-root",
         str(isolated_db_root),
         "--quiet",
     )
@@ -197,7 +197,7 @@ def test_install_by_id(
         "KS_dummy_test_v1",
         "--registry-url",
         dummy_registry_url,
-        "--db",
+        "--db-root",
         str(isolated_db_root),
         "--quiet",
     )
@@ -214,7 +214,7 @@ def test_install_unknown_id_fails(
         "ghost_db",
         "--registry-url",
         dummy_registry_url,
-        "--db",
+        "--db-root",
         str(isolated_db_root),
         "--quiet",
     )
@@ -232,7 +232,7 @@ def test_install_skips_if_already_present(
         "KS_dummy_test_v1",
         "--registry-url",
         dummy_registry_url,
-        "--db",
+        "--db-root",
         str(isolated_db_root),
         "--quiet",
     )
@@ -243,7 +243,7 @@ def test_install_skips_if_already_present(
         "KS_dummy_test_v1",
         "--registry-url",
         dummy_registry_url,
-        "--db",
+        "--db-root",
         str(isolated_db_root),
         "--quiet",
     )
@@ -261,7 +261,7 @@ def test_remove_with_yes_flag(cli_runner: CliRunner, populated_db_root: Path) ->
         "--remove",
         "KS_dummy_test_v1",
         "-y",
-        "--db",
+        "--db-root",
         str(populated_db_root),
     )
     assert result.exit_code == 0, result.output
@@ -276,7 +276,7 @@ def test_remove_unknown_id(cli_runner: CliRunner, isolated_db_root: Path) -> Non
         "--remove",
         "ghost",
         "-y",
-        "--db",
+        "--db-root",
         str(isolated_db_root),
     )
     assert result.exit_code != 0
@@ -297,9 +297,32 @@ def test_action_flags_are_mutually_exclusive(
             "--status",
             "--registry-url",
             dummy_registry_url,
-            "--db",
+            "--db-root",
             str(isolated_db_root),
         ],
     )
     assert result.exit_code != 0
     assert "Only one of" in result.output
+
+
+# --- --db / --db-root flag handling -----------------------------------
+
+
+def test_db_is_deprecated_alias_for_db_root(cli_runner: CliRunner, isolated_db_root: Path) -> None:
+    """The legacy --db flag still resolves the database root (here via --status)."""
+    result = _invoke(cli_runner, "download", "--status", "--db", str(isolated_db_root))
+    assert result.exit_code == 0, result.output
+
+
+def test_db_and_db_root_conflict(cli_runner: CliRunner, isolated_db_root: Path) -> None:
+    result = _invoke(
+        cli_runner,
+        "download",
+        "--status",
+        "--db",
+        str(isolated_db_root),
+        "--db-root",
+        str(isolated_db_root),
+    )
+    assert result.exit_code != 0
+    assert "not both" in result.output

--- a/tests/test_command_info.py
+++ b/tests/test_command_info.py
@@ -18,7 +18,7 @@ def _invoke(runner: CliRunner, *args: str) -> object:
 
 def test_info_empty_db_root(cli_runner: CliRunner, isolated_db_root: Path) -> None:
     """With nothing installed, `info` should report cleanly."""
-    result = _invoke(cli_runner, "info", "--db", str(isolated_db_root))
+    result = _invoke(cli_runner, "info", "--db-root", str(isolated_db_root))
     assert result.exit_code == 0, result.output
     assert str(isolated_db_root) in result.output
     # Either "No installed databases" or the "root does not exist yet" message.
@@ -26,7 +26,7 @@ def test_info_empty_db_root(cli_runner: CliRunner, isolated_db_root: Path) -> No
 
 
 def test_info_lists_installed_databases(cli_runner: CliRunner, populated_db_root: Path) -> None:
-    result = _invoke(cli_runner, "info", "--db", str(populated_db_root))
+    result = _invoke(cli_runner, "info", "--db-root", str(populated_db_root))
     assert result.exit_code == 0, result.output
     assert "KS_dummy_test_v1" in result.output
     assert "Version:" in result.output
@@ -39,7 +39,7 @@ def test_info_lists_installed_databases(cli_runner: CliRunner, populated_db_root
 def test_info_detailed_view_of_installed_database(
     cli_runner: CliRunner, populated_db_root: Path
 ) -> None:
-    result = _invoke(cli_runner, "info", "KS_dummy_test_v1", "--db", str(populated_db_root))
+    result = _invoke(cli_runner, "info", "KS_dummy_test_v1", "--db-root", str(populated_db_root))
     assert result.exit_code == 0, result.output
     assert "KS_dummy_test_v1" in result.output
     assert "k-mer:" in result.output
@@ -50,7 +50,7 @@ def test_info_detailed_view_of_installed_database(
 
 
 def test_info_unknown_database_id(cli_runner: CliRunner, isolated_db_root: Path) -> None:
-    result = _invoke(cli_runner, "info", "not_a_real_database", "--db", str(isolated_db_root))
+    result = _invoke(cli_runner, "info", "not_a_real_database", "--db-root", str(isolated_db_root))
     assert result.exit_code != 0
     assert "not installed" in result.output
 
@@ -64,7 +64,7 @@ def test_info_existing_database_directory(
     isolated_db_root: Path,
 ) -> None:
     """Pointing at a database directory on disk works even if not installed."""
-    result = _invoke(cli_runner, "info", str(unpacked_dummy_db), "--db", str(isolated_db_root))
+    result = _invoke(cli_runner, "info", str(unpacked_dummy_db), "--db-root", str(isolated_db_root))
     assert result.exit_code == 0, result.output
     assert "KaryoScope database directory" in result.output
     assert "KS_dummy_test_v1" in result.output
@@ -77,7 +77,7 @@ def test_info_existing_regular_file(
 ) -> None:
     a_file = tmp_path / "something.bed"
     a_file.write_text("chrom\tstart\tend\tname\n")
-    result = _invoke(cli_runner, "info", str(a_file), "--db", str(isolated_db_root))
+    result = _invoke(cli_runner, "info", str(a_file), "--db-root", str(isolated_db_root))
     assert result.exit_code == 0, result.output
     assert "Type: file" in result.output
 
@@ -88,6 +88,26 @@ def test_info_missing_path(
     isolated_db_root: Path,
 ) -> None:
     nope = tmp_path / "does-not-exist"
-    result = _invoke(cli_runner, "info", str(nope), "--db", str(isolated_db_root))
+    result = _invoke(cli_runner, "info", str(nope), "--db-root", str(isolated_db_root))
     assert result.exit_code == 0
     assert "Does not exist" in result.output
+
+
+# --- --db / --db-root flag handling ---------------------------------
+
+
+def test_info_db_is_deprecated_alias_for_db_root(
+    cli_runner: CliRunner, isolated_db_root: Path
+) -> None:
+    """The legacy --db flag still resolves the database root."""
+    result = _invoke(cli_runner, "info", "--db", str(isolated_db_root))
+    assert result.exit_code == 0, result.output
+    assert str(isolated_db_root) in result.output
+
+
+def test_info_db_and_db_root_conflict(cli_runner: CliRunner, isolated_db_root: Path) -> None:
+    result = _invoke(
+        cli_runner, "info", "--db", str(isolated_db_root), "--db-root", str(isolated_db_root)
+    )
+    assert result.exit_code != 0
+    assert "not both" in result.output

--- a/tests/test_command_register.py
+++ b/tests/test_command_register.py
@@ -1,0 +1,123 @@
+"""Tests for the ``karyoscope register`` command."""
+
+from __future__ import annotations
+
+import re
+import tarfile
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from karyoscope import installed as _installed
+from karyoscope.cli import main
+from karyoscope.core.annotate import resolve_database
+from karyoscope.exceptions import DatabaseNotFoundError
+
+from .conftest import DUMMY_DB_ID, _extractall_compat
+
+
+def _invoke(runner: CliRunner, *args: str) -> object:
+    return runner.invoke(main, list(args), catch_exceptions=False)
+
+
+@pytest.fixture
+def unregistered_db_root(tmp_path: Path, dummy_db_tarball: Path) -> Path:
+    """A database root with the dummy db extracted but NOT recorded in installed.json."""
+    db_root = tmp_path / "karyoscope_db"
+    db_root.mkdir()
+    with tarfile.open(dummy_db_tarball, "r:gz") as tar:
+        _extractall_compat(tar, db_root)
+    assert (db_root / DUMMY_DB_ID).is_dir()
+    # Sanity: nothing recorded yet.
+    assert not _installed.load(db_root).databases
+    return db_root
+
+
+def test_register_by_id(cli_runner: CliRunner, unregistered_db_root: Path) -> None:
+    result = _invoke(cli_runner, "register", DUMMY_DB_ID, "--db-root", str(unregistered_db_root))
+    assert result.exit_code == 0, result.output
+    assert f"Registered {DUMMY_DB_ID}" in result.output
+
+    state = _installed.load(unregistered_db_root)
+    assert DUMMY_DB_ID in state.databases
+    rec = state.databases[DUMMY_DB_ID]
+    assert rec.version == "1.0.0"  # from the dummy manifest
+    assert rec.directory == DUMMY_DB_ID
+    assert rec.source_url == "local"
+    assert rec.source_sha256 == ""
+
+
+def test_register_by_path(cli_runner: CliRunner, unregistered_db_root: Path) -> None:
+    db_dir = unregistered_db_root / DUMMY_DB_ID
+    result = _invoke(cli_runner, "register", str(db_dir), "--db-root", str(unregistered_db_root))
+    assert result.exit_code == 0, result.output
+    assert DUMMY_DB_ID in _installed.load(unregistered_db_root).databases
+
+
+def test_register_installed_at_is_registration_time(
+    cli_runner: CliRunner, unregistered_db_root: Path
+) -> None:
+    """installed_at records when register ran, in the same format as now_iso."""
+    result = _invoke(cli_runner, "register", DUMMY_DB_ID, "--db-root", str(unregistered_db_root))
+    assert result.exit_code == 0, result.output
+    installed_at = _installed.load(unregistered_db_root).databases[DUMMY_DB_ID].installed_at
+    # Well-formed ISO-8601 UTC timestamp, and a real one (not epoch).
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", installed_at)
+    assert installed_at >= "2025-01-01T00:00:00Z"
+
+
+def test_register_makes_database_resolvable(
+    cli_runner: CliRunner, unregistered_db_root: Path
+) -> None:
+    """After registering, the data-command resolver must find the database."""
+    # Before: resolution fails because it isn't recorded.
+    with pytest.raises(DatabaseNotFoundError):
+        resolve_database(unregistered_db_root, DUMMY_DB_ID)
+
+    result = _invoke(cli_runner, "register", DUMMY_DB_ID, "--db-root", str(unregistered_db_root))
+    assert result.exit_code == 0, result.output
+
+    db_id, db_dir = resolve_database(unregistered_db_root, DUMMY_DB_ID)
+    assert db_id == DUMMY_DB_ID
+    assert db_dir == (unregistered_db_root / DUMMY_DB_ID).resolve()
+
+
+def test_register_already_registered_errors_without_force(
+    cli_runner: CliRunner, unregistered_db_root: Path
+) -> None:
+    first = _invoke(cli_runner, "register", DUMMY_DB_ID, "--db-root", str(unregistered_db_root))
+    assert first.exit_code == 0, first.output
+
+    second = _invoke(cli_runner, "register", DUMMY_DB_ID, "--db-root", str(unregistered_db_root))
+    assert second.exit_code != 0
+    assert "already registered" in second.output
+    assert "--force" in second.output
+
+
+def test_register_force_overwrites(cli_runner: CliRunner, unregistered_db_root: Path) -> None:
+    _invoke(cli_runner, "register", DUMMY_DB_ID, "--db-root", str(unregistered_db_root))
+    result = _invoke(
+        cli_runner, "register", DUMMY_DB_ID, "--db-root", str(unregistered_db_root), "--force"
+    )
+    assert result.exit_code == 0, result.output
+    assert "Re-registered" in result.output
+
+
+def test_register_unknown_id_errors(cli_runner: CliRunner, isolated_db_root: Path) -> None:
+    isolated_db_root.mkdir(parents=True, exist_ok=True)
+    result = _invoke(cli_runner, "register", "not_a_real_db", "--db-root", str(isolated_db_root))
+    assert result.exit_code != 0
+    assert "no database directory found" in result.output
+
+
+def test_register_directory_outside_db_root_errors(
+    cli_runner: CliRunner, unpacked_dummy_db: Path, isolated_db_root: Path
+) -> None:
+    """A database directory outside the db root cannot be registered."""
+    isolated_db_root.mkdir(parents=True, exist_ok=True)
+    result = _invoke(
+        cli_runner, "register", str(unpacked_dummy_db), "--db-root", str(isolated_db_root)
+    )
+    assert result.exit_code != 0
+    assert "not inside the database root" in result.output


### PR DESCRIPTION
Add `karyoscope register`, which records an already-present database (built locally or copied in) into installed.json so the data commands can resolve it without going through `download`. It validates the layout via validate_database_layout, derives id/version from manifest.yaml, records `source: local` with no checksum, takes --db-root for the root, and refuses to overwrite an existing entry without --force.

Make --db-root the canonical database-root flag on `info` and `download`, matching the data commands (annotate/bin/scaffold/centromeres/karyotype), where --db selects a database *id*. --db stays as a hidden, deprecated alias on info/download for one release: it still works but prints a deprecation warning, and combining it with --db-root errors. The reconciliation lives in commands/_options.resolve_db_root_flag so both commands share one implementation.

Docs: add register to the README command table, add CHANGELOG entries (Added: register; Deprecated: --db alias), and fix now-stale --db references in paths.py docstrings and a register error message.
