### PR TITLE
docs: add Zenodo archive DOI (concept 10.5281/zenodo.20657816)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Zenodo archive DOI for the software (concept DOI
+  ``10.5281/zenodo.20657816``) added to the README badge, the citation
+  section, and ``CITATION.cff`` (top-level ``doi`` / ``version`` /
+  ``date-released`` fields).
+
 ## [1.1.0] - 2026-06-11
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,6 +14,9 @@ authors:
 repository-code: "https://github.com/barthel-lab/KaryoScope"
 url: "https://github.com/barthel-lab/KaryoScope"
 license: "GPL-3.0-or-later"
+version: "1.1.0"
+date-released: "2026-06-11"
+doi: "10.5281/zenodo.20657816"
 keywords:
   - bioinformatics
   - genomics

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![bioRxiv](https://img.shields.io/badge/bioRxiv-2026.05.15.725544-red)](https://doi.org/10.64898/2026.05.15.725544)
 [![CI](https://github.com/barthel-lab/KaryoScope/actions/workflows/ci.yml/badge.svg)](https://github.com/barthel-lab/KaryoScope/actions/workflows/ci.yml)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20657816.svg)](https://doi.org/10.5281/zenodo.20657816)
 <!-- Add after publication:
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.PLACEHOLDER.svg)](https://doi.org/10.5281/zenodo.PLACEHOLDER)
 [![Bioconda](https://img.shields.io/conda/dn/bioconda/karyoscope?label=bioconda)](https://bioconda.github.io/recipes/karyoscope/README.html)
 -->
 
@@ -250,6 +250,8 @@ Per sample, the bucket contains:
 If you use KaryoScope in your work, please cite our preprint:
 
 > Ranallo-Benavidez TR, Chen YA, Potapova T, Alanko J, Loucks H, Lucas J, Human Pangenome Reference Consortium, Guarracino A, Puglisi SJ, Marchet C, Miga K, Gerton JL, Barthel FP. *KaryoScope: rapid, alignment-free sequence annotation for the pangenome era.* bioRxiv (2026). doi: [10.64898/2026.05.15.725544](https://doi.org/10.64898/2026.05.15.725544)
+
+To cite the software itself — for example, to record the exact version you ran — use its Zenodo archive. The concept DOI [10.5281/zenodo.20657816](https://doi.org/10.5281/zenodo.20657816) always resolves to the latest release, and each release also receives its own version-specific DOI on the same record.
 
 A `CITATION.cff` file in this repository provides machine-readable citation metadata.
 


### PR DESCRIPTION
The v1.1.0 GitHub release was archived on Zenodo. Wire the concept DOI (always resolves to the latest version) into the project metadata:

- README: enable the Zenodo DOI badge and add a software-citation note to the Citation section, distinct from the bioRxiv preprint DOI.
- CITATION.cff: add top-level doi, version, and date-released for the software entity (preferred-citation still points at the preprint).
- CHANGELOG: note the DOI under [Unreleased].
