### PR TITLE
Expose legend_sort_key as public API

### DIFF
--- a/src/karyoscope/core/karyotype.py
+++ b/src/karyoscope/core/karyotype.py
@@ -308,6 +308,11 @@ def _legend_sort_key(
     return (0, 0, 0, name)
 
 
+#: Public alias: the legend sort key is reused by downstream tools (e.g. KaryoScope-analysis,
+#: which sorts its overlay legends featureset-first, then by this within-featureset key).
+legend_sort_key = _legend_sort_key
+
+
 def _haps_natural_sort_key(hap: str) -> tuple[int, int, str]:
     """Order haplotypes naturally.
 


### PR DESCRIPTION
Add a public alias for _legend_sort_key so downstream tools (KaryoScope-analysis) can reuse the canonical legend ordering (chromosomes natural-sorted, categorized pinned, hierarchy order, novel last) instead of duplicating it.