### PR TITLE
Karyotype colors option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   section, and ``CITATION.cff`` (top-level ``doi`` / ``version`` /
   ``date-released`` fields).
 
+### Fixed
+- Acrocentric short-arm contigs (chr13/14/15/21/22 p-arms: satellite, stalk,
+  rDNA, plus the p-ter telomere) are now consistently oriented telomere-first
+  (p-ter at the top) during scaffolding. Previously the flip decision for these
+  fragments was gated on the p-ter telomere being *continuous* with the
+  chromosome-assignment region block; satellite/novel gaps routinely break that
+  continuity, so otherwise-identical short arms were oriented inconsistently
+  (some ``CT``, some ``TC``). The acrocentric short-arm rule now keys off the raw
+  telomere flags instead, flipping a single-telomere non-q-arm fragment so its
+  telomere sits at the top regardless of continuity. Full-chromosome and q-arm
+  body contigs (with both telomeres or a q-ter telomere) are unaffected.
+  Surfaced by ISCN validation on GM03417.
+
 ### Changed
 - With ``--combine-chromosomes`` but not ``--combine-acrocentrics``, the
   acrocentric contigs that stay as separate records are now renamed in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``date-released`` fields).
 
 ### Fixed
+- Genome-karyotype haplotype columns are now assigned and ordered by the *true*
+  haplotype encoded in each contig's name (`infer_hap_from_contig`) rather than
+  the file-level `hap` label recorded during scaffolding. Combined-FASTA
+  assemblies (one file, hap-tagged contig names such as `haplotype1-*` /
+  `haplotype2-*`) are labelled with a single file-level hap by `scaffold`, which
+  previously collapsed every contig into one column drawn by contig size -- so a
+  larger hap2 contig could read as hap1. The renderer now derives the column
+  from the contig name, keeping `hap1` left of `hap2` regardless of size, and
+  labels each column (`h1` / `h2`). Surfaced by ISCN validation on GM00392
+  chr16.
+- Unassigned contigs (`*_unassigned-*` fragments in combined-FASTA assemblies)
+  are now segregated into their own labelled (`u`) column at the right of each
+  chromosome, instead of being silently mixed into a haplotype column. Makes a
+  small unassigned fragment (e.g. GM00392 `chr2_*_unassigned-*`, a 1-bin piece)
+  visually distinguishable from a real haplotype sequence.
 - Acrocentric short-arm contigs (chr13/14/15/21/22 p-arms: satellite, stalk,
   rDNA, plus the p-ter telomere) are now consistently oriented telomere-first
   (p-ter at the top) during scaffolding. Previously the flip decision for these

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `karyotype --colors PATH`: render with a custom colour file (same
+  `feature_set`/`feature`/`color` format as a database `colors.tsv`) instead of
+  the database default — e.g. the cytoband database's `colors_chromosome.tsv` to
+  colour bands by chromosome. The colour file's stem is appended to the output
+  filename (`...smoothed.<colors-stem>.karyotype.svg`) so a custom-colour render
+  never clobbers the default-colour one in the same directory.
 - `remap-bed` command: apply an existing `scaffold_map.tsv` to a BED that was
   annotated separately -- possibly against a *different* database than the one
   used to derive the map -- rewriting it into the scaffolded coordinate system.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ dependencies = [
 dev = [
   "pytest>=8.0",
   "pytest-cov>=4.1",
+  # Keep in sync with the rev pinned in .pre-commit-config.yaml.
+  "ruff==0.15.13",
 ]
 docs = [
   "mkdocs>=1.5",

--- a/src/karyoscope/commands/karyotype.py
+++ b/src/karyoscope/commands/karyotype.py
@@ -304,6 +304,17 @@ logger = logging.getLogger(__name__)
     "with --output foo.svg you get foo.<dbid>.<mode>.<fs>.karyotype.svg. "
     "Conflicts with --outdir when both are set.",
 )
+@click.option(
+    "--colors",
+    "colors_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Custom colour file (same format as a database colors.tsv: "
+    "feature_set / feature / color columns) to use instead of the database's "
+    "default colours. The colour-file stem is appended to the output filename "
+    "so it doesn't clash with the default-colour render. Default: the database's "
+    "colors.tsv.",
+)
 def cmd(
     inputs_raw: tuple[str, ...],
     telo_raw: tuple[str, ...],
@@ -336,6 +347,7 @@ def cmd(
     use_smoothed: bool,
     output_dir: Path | None,
     output_path: Path | None,
+    colors_path: Path | None,
 ) -> None:
     """Render karyotype SVGs.
 
@@ -457,6 +469,7 @@ def cmd(
             annotation_variant="smoothed" if use_smoothed else "presmoothed",
             output_dir=output_dir,
             output_path=output_path,
+            colors_path=colors_path,
             seed_human_chromosomes=not no_human_chroms,
         )
     except (

--- a/src/karyoscope/core/karyotype.py
+++ b/src/karyoscope/core/karyotype.py
@@ -34,6 +34,7 @@ laid out side by side.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from math import floor
 from pathlib import Path
@@ -41,6 +42,7 @@ from typing import Literal
 
 import drawsvg as draw
 
+from karyoscope.core.hap_inference import infer_hap_from_contig
 from karyoscope.core.io.features import NOVEL_NAME
 from karyoscope.core.io.scaffold_map import MapRow
 from karyoscope.core.scaffold import Interval, chromosome_sort_key
@@ -343,6 +345,41 @@ def _haps_natural_sort_key(hap: str) -> tuple[int, int, str]:
     return (2, 0, hap)
 
 
+#: Matches an ``unassigned`` token in a contig name (combined-FASTA
+#: assemblies name their non-haplotype fragments ``unassigned-0000409``
+#: and the like). ``infer_hap_from_contig`` deliberately never returns
+#: ``"unassigned"`` (that label is reserved for an explicit
+#: ``-i unassigned=PATH`` in the scaffolder), so the renderer detects it
+#: here to give those fragments their own segregated, labelled column.
+_UNASSIGNED_RE = re.compile(r"(?:^|[._\-/])unassigned(?:[._\-/]|$)", re.IGNORECASE)
+
+
+def _effective_hap(row: MapRow) -> str:
+    """The haplotype column a contig belongs to.
+
+    Derived from the *true* haplotype encoded in the contig's original
+    name rather than the file-level label in ``row.hap``. Combined-FASTA
+    assemblies carry hap-tagged contig names (``haplotype1-*`` /
+    ``haplotype2-*`` / ``unassigned-*``) while the scaffold step may have
+    labelled every contig with a single file-level hap (the sample stem,
+    or an explicit ``-i NAME=``). Ordering the karyotype's haplotype
+    columns by that file-level label collapses the true haplotypes into
+    one column drawn by contig size; deriving the hap from the contig
+    name keeps hap1 / hap2 / unassigned in their own, correctly-ordered
+    columns.
+
+    Falls back to ``row.hap`` when the contig name carries no haplotype
+    marker (e.g. the genuine one-file-per-haplotype convention, where
+    ``row.hap`` is already authoritative).
+    """
+    inferred = infer_hap_from_contig(row.original_name)
+    if inferred is not None:
+        return inferred
+    if _UNASSIGNED_RE.search(row.original_name):
+        return "unassigned"
+    return row.hap
+
+
 # --- main renderer -------------------------------------------------------
 
 
@@ -467,7 +504,7 @@ def render_karyotype(
     haps_seen: set[str] = set()
     for row in map_by_name.values():
         chroms_seen.add(row.chromosome)
-        haps_seen.add(row.hap)
+        haps_seen.add(_effective_hap(row))
 
     CHROMOSOMES: list[str] = []
     if seed_human_chromosomes:
@@ -621,7 +658,7 @@ def render_karyotype(
     intra_hap_indices: dict[str, int] = {}
     for seq in sequences_to_plot:
         row = map_by_name[seq]
-        chrom, hap = row.chromosome, row.hap
+        chrom, hap = row.chromosome, _effective_hap(row)
         sequences_per_chrom_hap.setdefault(chrom, {}).setdefault(hap, []).append(seq)
         intra_hap_indices[seq] = len(sequences_per_chrom_hap[chrom][hap]) - 1
 
@@ -771,7 +808,13 @@ def render_karyotype(
             for hap in layout.drawable_haps_per_chrom.get(chromosome, []):
                 hap_start = layout.hap_start_x[chromosome][hap]
                 hap_width = layout.hap_block_widths[chromosome][hap]
-                hap_text = f"h{hap[3:]}" if hap.startswith("hap") else hap[:1]
+                # Compact column designator so the narrow columns stay
+                # legible without widening the layout: "h1"/"h2" for
+                # haplotypes, a single-letter tag otherwise ("u" for
+                # unassigned, "m"/"p" for maternal/paternal).
+                hap_text = (
+                    f"h{hap[3:]}" if (hap.startswith("hap") and hap[3:].isdigit()) else hap[:1]
+                )
                 d.append(draw.Rectangle(hap_start, hap_line_y, hap_width, 1, fill=text_color))
                 d.append(
                     draw.Text(

--- a/src/karyoscope/core/karyotype_run.py
+++ b/src/karyoscope/core/karyotype_run.py
@@ -151,6 +151,16 @@ def _binned_scaffolded_bed_path(
 _COMBINED_TAG = "combined_chromosomes"
 
 
+def _colors_filename_tag(colors_path: Path | None) -> str:
+    """Output-filename tag for a custom ``--colors`` file (empty for default colours).
+
+    Appending the colour file's stem (e.g. ``.colors_chromosome``) keeps a
+    custom-colour render from overwriting the default-colour one in the same
+    directory.
+    """
+    return f".{colors_path.stem}" if colors_path is not None else ""
+
+
 def _combined_scaffolded_bed_path(
     out_dir: Path, stem: str, db_id: str, fs: str, variant: str = "smoothed"
 ) -> Path:
@@ -538,6 +548,7 @@ def karyotype_run(
     sample_label: str | None = None,
     show_title: bool = True,
     show_legend: bool = True,
+    colors_path: Path | None = None,
 ) -> list[KaryotypeResult]:
     """Render one SVG per (mode, feature_set) combination.
 
@@ -632,7 +643,12 @@ def karyotype_run(
         if bin_size < 1:
             raise KaryotypeError(f"--bin-size must be a positive integer, got {bin_size}")
 
-    colors = parse_colors(db_dir / manifest.colors)
+    # Colours: a user-supplied --colors file overrides the database default.
+    # Its stem tags the output filename so a custom-colour render never clobbers
+    # the default-colour one (e.g. '...smoothed.colors_chromosome.karyotype.svg').
+    colors_source = colors_path if colors_path is not None else db_dir / manifest.colors
+    colors = parse_colors(colors_source)
+    colors_tag = _colors_filename_tag(colors_path)
     hierarchy = parse_hierarchy(db_dir / manifest.hierarchy)
 
     # Hard check that every hierarchy node has a colour. ``download``
@@ -940,7 +956,7 @@ def karyotype_run(
             combined_tag = f".{_COMBINED_TAG}" if combine_chromosomes else ""
             stem_for_paths = (
                 f"{base_name}.{db_id_resolved}.{current_mode}.{fs}."
-                f"{annotation_variant}{combined_tag}.karyotype"
+                f"{annotation_variant}{combined_tag}{colors_tag}.karyotype"
             )
             svg_path = results_dir / f"{stem_for_paths}.svg"
             logger.info(

--- a/src/karyoscope/core/scaffold.py
+++ b/src/karyoscope/core/scaffold.py
@@ -301,11 +301,14 @@ def need_to_flip(
 ) -> bool:
     """Decide whether the contig is reversed (q-then-p) and should be flipped.
 
-    Direct port of the archive's ``calculate_need_to_flip`` (the newer
+    Ported from the archive's ``calculate_need_to_flip`` (the newer
     version with the centroid-based both-tel rule for chrY-like
-    cases). The body is a boolean ladder over arm/centromere
-    composition and telomere placement; see the inline comments for
-    the intuition behind each branch.
+    cases), with one addition: acrocentric short-arm fragments are
+    forced telomere-first (p-ter at the top) off the raw telomere
+    flags, since their satellite/novel content breaks the region-block
+    continuity the other branches rely on. The body is a boolean
+    ladder over arm/centromere composition and telomere placement; see
+    the inline comments for the intuition behind each branch.
     """
     simple_region = scaffold_region_majority(region_bins, region_start, region_end)
 
@@ -329,7 +332,21 @@ def need_to_flip(
     is_q_not_c_not_p_like = is_q_like and (not is_c_like) and (not is_p_like)
     is_q_and_c_not_p_like = is_q_like and is_c_like and (not is_p_like)
     is_p_and_q_like = is_p_like and is_q_like
-    is_pure_telomere = (not is_p_like) and (not is_q_like) and (not is_c_like)
+
+    # Acrocentric short arms (chr13/14/15/21/22 p-arms: satellite, stalk,
+    # rDNA, plus the p-ter telomere) must be drawn telomere-first, i.e.
+    # with p-ter at the top. These short-arm fragments are not q-arm
+    # bodies (``not is_q_like``); their satellite/novel content routinely
+    # breaks region-block continuity, so -- unlike the branches below --
+    # we key off the raw telomere flags rather than the ``continuous_*``
+    # variants (gating on continuity is exactly what left these contigs
+    # inconsistently oriented). We only force the single-telomere case:
+    # the lone telomere is the p-ter and belongs at the top. Contigs with
+    # telomeres on both ends fall through to the centroid logic so a
+    # genuinely reversed full chromosome is still detected, and q-arm
+    # bodies keep their q-ter telomere at the bottom via the ladder below.
+    if is_acrocentric and (not is_q_like) and (has_start_tel != has_stop_tel):
+        return has_stop_tel
 
     if continuous_start_tel and continuous_stop_tel:
         # Both ends telomere-capped: pick the orientation that puts
@@ -359,8 +376,6 @@ def need_to_flip(
         return first_half_q > second_half_q
 
     if continuous_start_tel or continuous_stop_tel:
-        if is_pure_telomere and is_acrocentric and continuous_stop_tel:
-            return True
         if is_p_or_c_not_q_like and continuous_stop_tel:
             return True
         if is_q_not_c_not_p_like and continuous_start_tel:

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -208,3 +208,35 @@ class TestValidateColors:
         assert len(issues) == 1
         assert "'chromosome'" in issues[0]
         assert "'shared'" in issues[0]
+
+
+class TestCustomColorsFile:
+    """A user-supplied ``karyotype --colors`` file is parsed + validated exactly
+    like a database ``colors.tsv``, so it fails *gracefully* (a clean
+    ``ColorsError`` / ``KaryotypeError``, caught by the CLI) rather than crashing
+    mid-render when it is malformed or missing features."""
+
+    def test_malformed_custom_file_raises_colorserror(self, tmp_path: Path) -> None:
+        p = tmp_path / "custom.tsv"
+        # Missing the colour column -> rejected before any rendering.
+        p.write_text("feature_set\tfeature\tcolor\ncytoband\t14q12\n")
+        with pytest.raises(ColorsError):
+            parse_colors(p)
+
+    def test_custom_file_missing_features_is_flagged(self, tmp_path: Path) -> None:
+        # A custom palette that omits some hierarchy nodes is caught by
+        # validate_colors (which karyotype_run turns into a KaryotypeError).
+        h = Hierarchy(
+            rows=[
+                HierarchyRow("cytoband", "14q12", "categorized"),
+                HierarchyRow("cytoband", "21q21.1", "categorized"),
+            ]
+        )
+        p = tmp_path / "custom.tsv"
+        p.write_text(
+            "feature_set\tfeature\tcolor\n"
+            "cytoband\tcategorized\t#FFFFFF\n"
+            "cytoband\t14q12\t#a67c5b\n"  # 21q21.1 deliberately omitted
+        )
+        issues = validate_colors(h, parse_colors(p))
+        assert any("21q21.1" in issue for issue in issues)

--- a/tests/test_karyotype.py
+++ b/tests/test_karyotype.py
@@ -1073,3 +1073,21 @@ def test_karyotype_no_scaffolding_path_renders(
     # rename + flip).
     maps = list(out_dir.glob("*.scaffold_map.tsv"))
     assert maps, "scaffold_map.tsv should still be written when --no-scaffolding"
+
+
+class TestColorsFilenameTag:
+    """The --colors output tag keeps custom-colour renders from clobbering defaults."""
+
+    def test_default_colors_no_tag(self) -> None:
+        from karyoscope.core.karyotype_run import _colors_filename_tag
+
+        assert _colors_filename_tag(None) == ""
+
+    def test_custom_colors_tagged_by_stem(self) -> None:
+        from pathlib import Path
+
+        from karyoscope.core.karyotype_run import _colors_filename_tag
+
+        assert _colors_filename_tag(Path("/x/colors_chromosome.tsv")) == ".colors_chromosome"
+        # A custom file and the default produce different tags -> different filenames.
+        assert _colors_filename_tag(Path("/x/my_palette.tsv")) != _colors_filename_tag(None)

--- a/tests/test_karyotype.py
+++ b/tests/test_karyotype.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 from pathlib import Path
 from typing import ClassVar
@@ -14,6 +15,7 @@ from karyoscope.core.io.scaffold_map import MapRow
 from karyoscope.core.karyotype import (
     PREDEFINED_SEX_SYSTEMS,
     RenderInput,
+    _effective_hap,
     _haps_natural_sort_key,
     _legend_sort_key,
     convert_svg,
@@ -377,6 +379,113 @@ def _row(
 
 def _read_svg_text(p: Path) -> str:
     return p.read_text()
+
+
+def _label_x(svg: str, label: str) -> float:
+    """Return the x of the first ``<text ...>label</text>`` column header."""
+    m = re.search(rf"<text\b([^>]*)>{re.escape(label)}</text>", svg)
+    assert m is not None, f"column label {label!r} not found in SVG"
+    xm = re.search(r'x="([-\d.]+)"', m.group(1))
+    assert xm is not None, f"no x on label {label!r}"
+    return float(xm.group(1))
+
+
+class TestEffectiveHap:
+    def test_infers_hap_from_contig_name_over_file_label(self) -> None:
+        # Combined-FASTA case: scaffold labelled every contig with the
+        # sample stem, but the contig name carries the true haplotype.
+        row = _row(
+            "chr16_GM00392_haplotype2-0000061",
+            chrom="chr16",
+            hap="GM00392",
+        )
+        assert _effective_hap(row) == "hap2"
+
+    def test_detects_unassigned_from_contig_name(self) -> None:
+        row = _row("chr2_GM00392_unassigned-0000409", chrom="chr2", hap="GM00392")
+        assert _effective_hap(row) == "unassigned"
+
+    def test_falls_back_to_file_label_when_no_marker(self) -> None:
+        # One-file-per-haplotype convention: contig name has no marker, so
+        # the file-level hap label remains authoritative.
+        row = _row("chr1_hap1_ptg000001l", chrom="chr1", hap="hap1")
+        assert _effective_hap(row) == "hap1"
+
+
+class TestHaplotypeColumns:
+    def test_columns_ordered_by_true_hap_not_size(self, tmp_path: Path) -> None:
+        # GM00392 chr16: the dup is on hap2 (full chr16, large) while hap1
+        # holds only 16p-ter (small). Both contigs carry the file-level
+        # label "GM00392"; ordering by that label (then size) would draw
+        # the large hap2 contig first/left. Deriving the hap from the
+        # contig name must put hap1 left of hap2 regardless of size.
+        ri = RenderInput(
+            map_rows=[
+                _row(
+                    "chr16_GM00392_haplotype2-0000061",
+                    chrom="chr16",
+                    hap="GM00392",
+                    stats="TPCQT",
+                    length=174_000_000,
+                ),
+                _row(
+                    "chr16_GM00392_haplotype1-0000013",
+                    chrom="chr16",
+                    hap="GM00392",
+                    stats="TP",
+                    length=15_000_000,
+                ),
+            ],
+            binned_bed={
+                "chr16_GM00392_haplotype2-0000061": [(0, 500, "rA"), (500, 1000, "rB")],
+                "chr16_GM00392_haplotype1-0000013": [(0, 500, "rA")],
+            },
+        )
+        out = tmp_path / "chr16.svg"
+        render_karyotype(
+            [ri],
+            colors={"rA": "#2ca02c", "rB": "#d62728"},
+            mode="genome",
+            seed_human_chromosomes=False,
+            output_path=out,
+        )
+        text = _read_svg_text(out)
+        # Both haplotype columns are labelled ("h1"/"h2")...
+        assert "<text" in text and ">h1</text>" in text and ">h2</text>" in text
+        # ...and hap1 is drawn to the left of hap2 (true-haplotype order,
+        # not size order).
+        assert _label_x(text, "h1") < _label_x(text, "h2")
+
+    def test_unassigned_segregated_and_labelled(self, tmp_path: Path) -> None:
+        # GM00392 chr2: both haplotypes fully assembled plus a tiny
+        # unassigned fragment. The unassigned contig must land in its own
+        # labelled column, to the right of the real haplotypes.
+        ri = RenderInput(
+            map_rows=[
+                _row("chr2_GM00392_haplotype1-0000012", chrom="chr2", hap="GM00392", length=243),
+                _row("chr2_GM00392_haplotype2-0000056", chrom="chr2", hap="GM00392", length=242),
+                _row("chr2_GM00392_unassigned-0000409", chrom="chr2", hap="GM00392", length=59),
+            ],
+            binned_bed={
+                "chr2_GM00392_haplotype1-0000012": [(0, 500, "rA")],
+                "chr2_GM00392_haplotype2-0000056": [(0, 500, "rA")],
+                "chr2_GM00392_unassigned-0000409": [(0, 500, "rA")],
+            },
+        )
+        out = tmp_path / "chr2.svg"
+        render_karyotype(
+            [ri],
+            colors={"rA": "#2ca02c"},
+            mode="genome",
+            seed_human_chromosomes=False,
+            output_path=out,
+        )
+        text = _read_svg_text(out)
+        # Unassigned column is flagged with a compact "u" tag...
+        assert ">u</text>" in text
+        # ...and sits to the right of both real haplotypes.
+        assert _label_x(text, "u") > _label_x(text, "h2")
+        assert _label_x(text, "h2") > _label_x(text, "h1")
 
 
 class TestRenderKaryotypeUnit:

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -227,6 +227,103 @@ class TestNeedToFlip:
             is_acrocentric=True,
         )
 
+    def test_acrocentric_short_arm_stop_tel_flips_without_continuity(self) -> None:
+        # GM03417-style acrocentric short-arm fragment: satellite / stalk
+        # content (ct/HSat/bSat all collapse to "centromere"), no q-arm,
+        # with the p-ter telomere at the stop end. The telomere is NOT
+        # continuous with the region block (region_end < scaffold_length,
+        # as satellite/novel gaps cause), so the old continuity-gated
+        # branch left it un-flipped. The short-arm rule must flip it so
+        # p-ter ends up at the top regardless of continuity.
+        bins = [
+            (0, 1_000_000, "ct"),
+            (1_000_000, 3_000_000, "HSat1A"),
+            (3_000_000, 5_000_000, "bSat"),
+            (5_000_000, 5_351_257, "ct"),
+        ]
+        assert need_to_flip(
+            bins,
+            self._halfs(bins, 5_351_257),
+            region_start=0,
+            region_end=4_000_000,
+            scaffold_length=5_351_257,
+            telo=TeloFlags(False, True),
+            is_acrocentric=True,
+        )
+
+    def test_acrocentric_short_arm_start_tel_does_not_flip(self) -> None:
+        # Same short-arm fragment but the p-ter telomere is already at the
+        # start (top): must not flip.
+        bins = [
+            (0, 351_257, "ct"),
+            (351_257, 2_351_257, "bSat"),
+            (2_351_257, 5_351_257, "rDNA"),
+        ]
+        assert not need_to_flip(
+            bins,
+            self._halfs(bins, 5_351_257),
+            region_start=1_000_000,
+            region_end=5_351_257,
+            scaffold_length=5_351_257,
+            telo=TeloFlags(True, False),
+            is_acrocentric=True,
+        )
+
+    def test_acrocentric_q_arm_body_keeps_qter_tel_at_bottom(self) -> None:
+        # The acrocentric main body (centromere + q-arm + q-ter telomere)
+        # is q-like, so the short-arm rule must NOT fire: the q-ter
+        # telomere stays at the bottom (no flip).
+        bins = [
+            (0, 2_000_000, "centromere1"),
+            (2_000_000, 95_000_000, "q_arm_long"),
+        ]
+        assert not need_to_flip(
+            bins,
+            self._halfs(bins, 95_000_000),
+            region_start=0,
+            region_end=95_000_000,
+            scaffold_length=95_000_000,
+            telo=TeloFlags(False, True),
+            is_acrocentric=True,
+        )
+
+    def test_nonacrocentric_short_arm_unaffected_by_rule(self) -> None:
+        # A non-acrocentric centromere-dominant fragment with a
+        # non-continuous stop telomere must NOT be force-flipped by the
+        # acrocentric short-arm rule (control for blast radius).
+        bins = [
+            (0, 1_000_000, "ct"),
+            (1_000_000, 3_000_000, "centromere1"),
+            (3_000_000, 5_351_257, "ct"),
+        ]
+        assert not need_to_flip(
+            bins,
+            self._halfs(bins, 5_351_257),
+            region_start=0,
+            region_end=4_000_000,
+            scaffold_length=5_351_257,
+            telo=TeloFlags(False, True),
+            is_acrocentric=False,
+        )
+
+    def test_acrocentric_both_tels_fall_through_to_centroid(self) -> None:
+        # An acrocentric contig with telomeres on BOTH ends is not a
+        # single-telomere short arm, so the rule defers to the centroid
+        # logic: q-arm centroid before p-arm centroid here → flip.
+        bins = [
+            (0, 2_000_000, "q_arm"),
+            (8_000_000, 10_000_000, "p_arm"),
+        ]
+        assert need_to_flip(
+            bins,
+            self._halfs(bins, 10_000_000),
+            region_start=0,
+            region_end=10_000_000,
+            scaffold_length=10_000_000,
+            telo=TeloFlags(True, True),
+            is_acrocentric=True,
+        )
+
 
 class TestFlipBins:
     def test_mirror_and_reverse(self) -> None:


### PR DESCRIPTION
## Summary                                                                                             
                                                                                                         
  Bundles the pending `karyotype --colors` feature with three scaffolding/plotting                       
  fixes surfaced while validating KaryoScope-ISCN against the genome-karyotype SVGs.
  All changes are additive or fix-only; default behavior for existing users is unchanged
  except where a plot was previously misleading.                                                                                 
                                                                                                         
  ## What's included                                                                                     
                                                                                                         
  ### `karyotype --colors PATH` (custom colour file)                                                     
  Render with a custom colour file (same `feature_set`/`feature`/`color` format as a                     
  database `colors.tsv`) instead of the database default — e.g. the cytoband                             
  database's `colors_chromosome.tsv` to colour bands by chromosome. The colour                           
  file's stem is appended to the output filename                                                         
  (`...smoothed.<colors-stem>.karyotype.svg`) so a custom-colour render never                            
  clobbers the default-colour one in the same directory.                                                 
                                                                                                         
  ### Fix: acrocentric short arms oriented telomere-first (p-ter up)                                     
  Acrocentric p-arms (chr13/14/15/21/22: satellite / stalk / rDNA + the p-ter                            
  telomere) were oriented inconsistently because the flip decision gated the                             
  telomere-up rule on the p-ter telomere being *continuous* with the                                     
  chromosome-assignment region block. Satellite/novel gaps routinely break that                          
  continuity, so otherwise-identical short arms came out some `CT`, some `TC`.                           
                                                                                                         
  The acrocentric short-arm rule now keys off the raw telomere flags: a                                  
  p-ter telomere sits at the top, regardless of continuity. Full chromosomes (both                       
  telomeres) defer to the existing centroid logic and q-arm bodies keep their q-ter                      
  telomere at the bottom, so only the short-arm fragments change.                                        
                                                                                                         
  **Validated on GM03417:** all four mis-oriented short-arm fragments                                    
  (chr13/15/21/22) now read telomere-first; q-arm bodies unchanged.

### Fix: genome-karyotype haplotype columns by true haplotype                                          
  Haplotype columns were assigned from the file-level `hap` recorded by `scaffold`.                      
  For combined-FASTA assemblies (one file, hap-tagged contig names like                                  
  `haplotype1-*` / `haplotype2-*`), `scaffold` labels every contig with a single                         
  file-level hap, so the renderer collapsed both haplotypes into one column drawn by                     
  contig size — a larger hap2 contig could read as hap1 (GM00392 chr16).                                 
                                                                                                         
  The renderer now derives the column from the true haplotype encoded in the contig
  name (`infer_hap_from_contig`, via a new `_effective_hap` helper), falling back to
  `row.hap` when the name carries no marker (the one-file-per-haplotype convention,
  where the file label is authoritative). Columns order `hap1` left of `hap2`
  regardless of size and are labelled `h1`/`h2`. **Within-column stacking order
  is unchanged** (canonical category × descending-length × name).
                                                     
  ### Fix: segregate/label unassigned contigs
  `*_unassigned-*` fragments in combined-FASTA assemblies were silently mixed into a
  haplotype column. They now segregate into their own labelled (`u`) column at the 
  right of each chromosome, making a small unassigned fragment (e.g. GM00392
  `chr2_*_unassigned-*`, a 1-bin piece) visually distinguishable from a real
  haplotype sequence.                                
                                                     
  **Validated on the real GM00392 scaffold map** (all 48 contigs file-labelled
  `GM00392`): columns now derive `hap1`/`hap2`/`unassigned` from the contig names;
  chr16 dup correctly on hap2 (not size-swapped).       
                           
  ## Testing
  - Full suite green: **584 passed, 1 skipped**, ruff clean.
  - New unit tests for the acrocentric rule (incl. the non-continuous-telomere case
    that broke the old logic), `_effective_hap`, and hap-column ordering / unassigned
    segregation.                                     
  - Real-data validation against the GM03417 and GM00392 ISCN repro samples.
  - `ruff` added to the dev extras (pinned `==0.15.13` to match `.pre-commit-config.yaml`).
