### PR TITLE
fix(karyotype): name multi-input output by common stem prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``date-released`` fields).
 
 ### Fixed
+- The default karyotype output filename for multi-input runs (no `--output`) is
+  no longer named after only the first input. It now collapses the input stems to
+  their common prefix (`GM04890.haplotype1` + `GM04890.haplotype2` -> `GM04890`),
+  so a both-haplotype plot is no longer misleadingly named `...haplotype1...`. The
+  title band already showed both stems; the filename now agrees. Single-input runs
+  are unchanged, and runs whose stems share no separator-delimited prefix fall
+  back to the first stem. (Also corrected the stale module docstring, which claimed
+  the default base was the literal `"karyotype"`.)
 - Genome-karyotype haplotype columns are now assigned and ordered by the *true*
   haplotype encoded in each contig's name (`infer_hap_from_contig`) rather than
   the file-level `hap` label recorded during scaffolding. Combined-FASTA

--- a/docs/commands/karyotype.md
+++ b/docs/commands/karyotype.md
@@ -64,7 +64,7 @@ karyoscope karyotype -i asm.fa --mode genome --feature-set chromosome \
 
 ## Output
 
-One image is written per (mode, feature_set) combination, named `<base>.<dbid>.<mode>.<feature_set>.smoothed.karyotype.svg`, where `<base>` is `karyotype` by default or the basename of `--output PATH` when given. Passing `--format pdf` / `--format png` (repeatable) additionally produces those formats by converting the SVG via cairosvg (which needs libcairo at runtime). Using `--presmoothed` renders from raw annotations, and the filename then reflects that variant. The cascade also writes the intermediate scaffolded / binned / centromere BEDs unless suppressed.
+One image is written per (mode, feature_set) combination, named `<base>.<dbid>.<mode>.<feature_set>.smoothed.karyotype.svg`. `<base>` is the basename of `--output PATH` when given; otherwise it is derived from the input stems — a single input's stem, or for multi-input runs the longest common prefix of the stems (e.g. `GM04890.haplotype1` + `GM04890.haplotype2` → `GM04890`), falling back to the first stem when the stems share no separator-delimited prefix. Passing `--format pdf` / `--format png` (repeatable) additionally produces those formats by converting the SVG via cairosvg (which needs libcairo at runtime). Using `--presmoothed` renders from raw annotations, and the filename then reflects that variant. The cascade also writes the intermediate scaffolded / binned / centromere BEDs unless suppressed.
 
 ## See also
 

--- a/src/karyoscope/core/karyotype_run.py
+++ b/src/karyoscope/core/karyotype_run.py
@@ -18,9 +18,12 @@ the pipeline. Auto-derives missing prerequisites the same way
 Output paths follow the convention
 ``<base>.<dbid>.<mode>.<feature_set>.karyotype.svg`` per feature set.
 ``<base>`` is either an explicit ``--output PATH`` (then we use the
-basename without ``.svg``) or, when no explicit path is given,
-the literal string ``"karyotype"`` so the filename is sample-agnostic
-(the sample is implied by ``<dbid>`` and the ``--outdir``).
+basename without ``.svg``) or, when no explicit path is given, a
+sample-identifying base derived from the input stems: the single
+input's stem, or for multi-input runs the longest common prefix of the
+input stems (e.g. ``GM04890.haplotype1`` + ``GM04890.haplotype2`` ->
+``GM04890``), falling back to the first stem when the stems share no
+separator-delimited prefix. See :func:`_common_base`.
 """
 
 from __future__ import annotations
@@ -101,6 +104,51 @@ def _input_stem(path: Path) -> str:
         if lower.endswith(ext):
             return name[: -len(ext)]
     return path.stem
+
+
+#: Separator characters used to find a token boundary in input stems.
+_STEM_SEPARATORS = "._-"
+
+
+def _common_base(stems: list[str]) -> str:
+    """The filename base shared by one or more input stems.
+
+    For a single input this is just its stem. For multi-input runs --
+    e.g. separate ``hap1``/``hap2`` FASTAs -- the output filename should
+    name the *sample*, not just the first input, so it isn't misleading
+    (a both-hap plot named ``...haplotype1...``). We take the
+    character-wise longest common prefix of the stems, trim it back to
+    the last separator (so a partially-shared trailing token like
+    ``haplotype`` is dropped rather than left dangling), and strip
+    trailing separators::
+
+        ["GM04890.haplotype1", "GM04890.haplotype2"]  -> "GM04890"
+        ["BJ.hap1", "BJ.hap2"]                         -> "BJ"
+        ["HG002.maternal", "HG002.paternal"]           -> "HG002"
+
+    Falls back to the first stem when the stems are identical or share
+    no separator-delimited prefix (so the result is never empty).
+    """
+    if not stems:
+        return ""
+    first = stems[0]
+    if len(stems) == 1 or all(s == first for s in stems):
+        return first
+
+    lcp_len = len(first)
+    for s in stems[1:]:
+        limit = min(lcp_len, len(s))
+        i = 0
+        while i < limit and first[i] == s[i]:
+            i += 1
+        lcp_len = i
+    lcp = first[:lcp_len]
+
+    cut = max((lcp.rfind(c) for c in _STEM_SEPARATORS), default=-1)
+    if cut == -1:
+        return first  # no shared separator-delimited prefix
+    base = lcp[:cut].rstrip(_STEM_SEPARATORS)
+    return base or first
 
 
 def _scaffolded_bed_path(
@@ -837,11 +885,14 @@ def karyotype_run(
             base_name = base_name[:-4]
         results_dir = output_path.parent
     else:
-        # Default to the first input's stem so the on-disk filename
+        # Default the on-disk filename to a sample-identifying base so it
         # tells the user at a glance which sample produced the SVGs.
-        # Multi-input runs (e.g. separate hap1/hap2 FASTAs) get the
-        # first input's stem; pass --output to override.
-        base_name = per_input_state[0][2]
+        # Multi-input runs (e.g. separate hap1/hap2 FASTAs) collapse to
+        # the common prefix of the input stems (GM04890.haplotype1 +
+        # GM04890.haplotype2 -> GM04890), matching what the title band
+        # already shows and avoiding a misleading "...haplotype1..." name
+        # for a both-hap plot. Pass --output to override.
+        base_name = _common_base([stem for _, _, stem in per_input_state])
         results_dir = output_dir if output_dir is not None else per_input_state[0][1]
 
     # Sample label for the SVG title band. Defaults to the first

--- a/tests/test_karyotype_run.py
+++ b/tests/test_karyotype_run.py
@@ -16,8 +16,46 @@ from karyoscope.core.karyotype_run import (
     _binned_mapsig_path,
     _combined_centromeres_bed_path,
     _combined_scaffolded_bed_path,
+    _common_base,
     _write_binned_mapsig,
 )
+
+
+class TestCommonBase:
+    def test_single_input_returns_its_stem(self) -> None:
+        assert _common_base(["GM00392.assembly"]) == "GM00392.assembly"
+
+    def test_haplotype_pair_collapses_to_sample(self) -> None:
+        assert _common_base(["GM04890.haplotype1", "GM04890.haplotype2"]) == "GM04890"
+
+    def test_hap_pair_collapses_to_sample(self) -> None:
+        assert _common_base(["BJ.hap1", "BJ.hap2"]) == "BJ"
+
+    def test_maternal_paternal_collapses_to_sample(self) -> None:
+        assert _common_base(["HG002.maternal", "HG002.paternal"]) == "HG002"
+
+    def test_three_inputs_with_unassigned(self) -> None:
+        assert _common_base(["S.hap1", "S.hap2", "S.unassigned"]) == "S"
+
+    def test_deeper_shared_prefix_kept(self) -> None:
+        assert _common_base(["HG002.hifiasm.hap1", "HG002.hifiasm.hap2"]) == "HG002.hifiasm"
+
+    def test_underscore_separator(self) -> None:
+        assert _common_base(["GM04890_hap1", "GM04890_hap2"]) == "GM04890"
+
+    def test_no_common_separator_prefix_falls_back_to_first(self) -> None:
+        # Shared chars but no separator boundary -> don't emit a partial
+        # token; fall back to the first stem.
+        assert _common_base(["abc1", "abc2"]) == "abc1"
+
+    def test_no_overlap_falls_back_to_first(self) -> None:
+        assert _common_base(["alpha", "beta"]) == "alpha"
+
+    def test_identical_stems_kept_whole(self) -> None:
+        assert _common_base(["sampleX", "sampleX"]) == "sampleX"
+
+    def test_empty_returns_empty(self) -> None:
+        assert _common_base([]) == ""
 
 
 def _row(new_name: str, *, hap: str, flipped: bool = False) -> MapRow:


### PR DESCRIPTION
When no --output is given, the default karyotype filename base was the first input's stem, so a diploid render from separate hap FASTAs (-i GM04890.haplotype1.fa -i GM04890.haplotype2.fa) was named `GM04890.haplotype1.<dbid>...karyotype.svg` even though it contains both haplotypes -- misleading, and inconsistent with the title band, which already joins all input stems.

Collapse the input stems to their common prefix instead (new `_common_base` helper): char-wise longest common prefix trimmed back to the last separator and stripped of trailing separators, so GM04890.haplotype1 + GM04890.haplotype2 -> GM04890 and BJ.hap1 + BJ.hap2 -> BJ. Single-input runs are unchanged; runs whose stems share no separator-delimited prefix fall back to the first stem (result is never empty).

Also correct the stale default-base description in the module docstring and docs/commands/karyotype.md, which both claimed the default base was the literal "karyotype" -- the code has used the first input's stem.