### PR TITLE
feat(preflight): check free disk space and dependencies before doing work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-07-27
+
 ### Added
 - **Free-space preflight.** `download` and `annotate` now verify the target
   filesystem can hold what they are about to write, and fail immediately with
@@ -1378,7 +1380,8 @@ For releases, copy the [Unreleased] section to a new heading like:
 ## [1.1.0] - YYYY-MM-DD
 -->
 
-[Unreleased]: https://github.com/barthel-lab/KaryoScope/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/barthel-lab/KaryoScope/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/barthel-lab/KaryoScope/releases/tag/v2.1.0
 [2.0.0]: https://github.com/barthel-lab/KaryoScope/releases/tag/v2.0.0
 [1.1.0]: https://github.com/barthel-lab/KaryoScope/releases/tag/v1.1.0
 [1.0.0]: https://github.com/barthel-lab/KaryoScope/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   set(s)`) because it smooths every set in a single streaming pass. `karyotype`
   reports per `mode/feature_set` render and indents the cascade's nested
   `annotate` one level, so its headline reads as a step of the run rather than
-  a separate command. Detailed per-step timings stay at INFO, so `-v` is
+  a separate command. It also names any feature set the cascade pulls in
+  beyond `--feature-set` — scaffolding needs the chromosome- and
+  region-assignment sets to place and orient contigs regardless of what is
+  being plotted, so asking for two sets and watching `annotate` report three
+  was otherwise baffling. Detailed per-step timings stay at INFO, so `-v` is
   unchanged and nothing is printed twice.
 - `-q/--quiet` now suppresses this narration as well as logging. It previously
   only lowered the log level, which would have left no way to silence a run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `HKS_human_CHM13_v2`. Entries without `download_size_gb` fall back to
   `size_gb` for both and are labelled as estimates.
 
+### Fixed
+- `download` no longer discards a completed archive when the install fails.
+  The archive was unlinked in a `finally`, so a run that finished a 25-minute
+  transfer and then hit ENOSPC during extraction left nothing behind and the
+  retry re-downloaded everything. It is now kept (its SHA-256 proves the bytes
+  are identical to a fresh fetch), re-verified on the next run, and extracted
+  directly — a failed install costs one extraction, not a second transfer.
+  Conversely, a partially-extracted database directory is now *removed* on
+  failure: it is unusable, is deleted at the start of the next attempt anyway,
+  and when the failure was ENOSPC it occupies exactly the space the retry
+  needs. Both outcomes are reported at WARNING so they are visible by default.
+  A staged archive whose checksum doesn't match is discarded and re-fetched.
+
 ### Changed
 - `download --list` and `--info` report the download size and the on-disk size
   separately, and `--info` also reports the free space needed to install. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Free-space preflight.** `download` and `annotate` now verify the target
+  filesystem can hold what they are about to write, and fail immediately with
+  the required / available / shortfall figures instead of dying on
+  `OSError: [Errno 28]` after the work is done. Previously a user with 12 GB
+  free could spend 25 minutes downloading `HKS_human_CHM13_v2` before extraction
+  ran out of room, and a six-feature-set `annotate` of a diploid assembly could
+  fill a disk 20 minutes in. Both checks are overridable with `--no-space-check`.
+  A new `karyoscope.diskspace` module also translates any `ENOSPC` that escapes
+  mid-run — from any command — into a message naming the filesystem that filled
+  up, rather than a traceback.
+- **Dependency preflight.** Commands now resolve the external tools they will
+  need before starting, and report *every* missing one at once with an install
+  hint, instead of failing at the point of use. `annotate` checks its k-mer
+  backend binary (plus `samtools` for BAM input and `bgzip` unless `--no-bgzip`);
+  `karyotype` additionally checks `cairosvg` when `--format pdf/png` is requested
+  and `seqtk` when telomere detection will be auto-run — both of which used to
+  surface only after the entire cascade had already run. Resolution goes through
+  each backend's own lookup order, so `$KARYOSCOPE_HKS`,
+  `$KARYOSCOPE_GET_FEATUREIDS`, and the source-tree `get_featureIDs` of an
+  editable install are all honoured.
+- Registry entries may declare `download_size_gb` (the `.tar.gz`) alongside
+  `size_gb`, which is now defined as the size of the *extracted* database.
+  Installing needs the sum of the two, since the archive is not deleted until
+  extraction succeeds — ~34 GB for `KS_human_CHM13_v2` and ~36 GB for
+  `HKS_human_CHM13_v2`. Entries without `download_size_gb` fall back to
+  `size_gb` for both and are labelled as estimates.
+
+### Changed
+- `download --list` and `--info` report the download size and the on-disk size
+  separately, and `--info` also reports the free space needed to install. The
+  single unlabelled size they used to print was the archive size for
+  `HKS_human_CHM13_v2` and the extracted size for `KS_human_CHM13_v2`, so it
+  understated the requirement by ~9 GB for the former.
+- `karyoscope version` reports `get_featureIDs` (previously omitted entirely)
+  and resolves it and `hks` the same way the commands do, so an editable install
+  or an environment override is no longer reported as "not found on PATH".
+
+### Documentation
+- README and the `download` / `annotate` command pages gained Disk space
+  sections covering archive vs extracted database size, the peak during install,
+  and annotation output footprint (~0.8 GB per feature set per Gbp of input).
+  Documents that `--bgzip` shrinks the result but not the peak, because
+  compression runs only after every BED has been written.
+
 ## [2.0.0] - 2026-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.1.0] - 2026-07-27
 
 ### Added
+- **Progress output for the long-running commands.** `download` and `build`
+  already announced themselves and their results, but `annotate` (7-22 min)
+  and `karyotype` (tens of minutes) printed nothing at all until their closing
+  `Wrote:` block — so the two slowest commands were the two silent ones, and a
+  user could not tell a working run from a hung one. Both now print an opening
+  summary and a milestone line as each unit of work completes:
+
+  ```
+  Annotating hg002v1.1.fasta.gz against HKS_human_CHM13_v2
+    6 feature set(s), 16 thread(s), ~34 GB estimated output
+    [1/6] chromosome    4m05s
+    ...
+    bgzip (12 file(s))  1m31s
+  Wrote:
+    ...
+  ```
+
+  The shape follows what each backend actually knows: HKS reports per feature
+  set, while KMC reports named phases (`k-mer query`, `smoothing 6 feature
+  set(s)`) because it smooths every set in a single streaming pass. `karyotype`
+  reports per `mode/feature_set` render and indents the cascade's nested
+  `annotate` one level, so its headline reads as a step of the run rather than
+  a separate command. Detailed per-step timings stay at INFO, so `-v` is
+  unchanged and nothing is printed twice.
+- `-q/--quiet` now suppresses this narration as well as logging. It previously
+  only lowered the log level, which would have left no way to silence a run.
+  The `Wrote:` block still prints — it is the command's result, not narration.
 - **Free-space preflight.** `download` and `annotate` now verify the target
   filesystem can hold what they are about to write, and fail immediately with
   the required / available / shortfall figures instead of dying on

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,8 +14,11 @@ authors:
 repository-code: "https://github.com/barthel-lab/KaryoScope"
 url: "https://github.com/barthel-lab/KaryoScope"
 license: "GPL-3.0-or-later"
-version: "2.0.0"
-date-released: "2026-07-23"
+version: "2.1.0"
+date-released: "2026-07-27"
+# Concept DOI (conceptrecid 20657816): always resolves to the latest
+# version, so it stays fixed across releases. Zenodo mints a separate
+# version DOI per GitHub release automatically.
 doi: "10.5281/zenodo.20657816"
 keywords:
   - bioinformatics

--- a/README.md
+++ b/README.md
@@ -73,8 +73,30 @@ A pre-built database for the human genome is distributed alongside the tool, der
 **Hardware.** No non-standard hardware is required — KaryoScope runs on a standard CPU and has no GPU dependency. Resource needs scale with the input:
 
 - **Demo and small inputs:** run on any laptop in seconds (see [Demo](#demo)).
-- **Human whole-genome inputs (KMC backend):** the pre-built human database is ~17 GB on disk, and loading its KMC index during `annotate` needs roughly 30 GB of RAM (we measured ~30–35 GB peak at 16 threads). We recommend ≥ 50 GB RAM and ≥ 16 CPU cores for human-scale runs. A single human haplotype's six-feature-set run takes ~17–22 minutes at 16 threads.
-- **Human whole-genome inputs (HKS backend):** the HKS database is ~24 GB on disk (~13 GB compressed). `annotate` holds the index (~10 GB, fixed) plus per-query buffering that grows with how much sequence one lookup processes at once, so the memory you should request depends on the input shape. A **single haplotype** peaks at **~10 GB** (request ≥ 16 GB) and finishes in **~7–9 minutes** at 16 threads. A **combined diploid assembly** — both haplotypes in one file, e.g. HG002 v1.1 — peaks at **~17 GB** (request ≥ 24 GB); annotating each haplotype separately keeps the peak at ~10 GB. Measured at 16 threads on T2T-CHM13v2.0, HG008N, HG008T, and HG002 v1.1.
+- **Human whole-genome inputs (KMC backend):** loading the KMC index during `annotate` needs roughly 30 GB of RAM (we measured ~30–35 GB peak at 16 threads). We recommend ≥ 50 GB RAM and ≥ 16 CPU cores for human-scale runs. A single human haplotype's six-feature-set run takes ~17–22 minutes at 16 threads. See [Disk space](#disk-space) for storage.
+- **Human whole-genome inputs (HKS backend):** `annotate` holds the index (~10 GB, fixed) plus per-query buffering that grows with how much sequence one lookup processes at once, so the memory you should request depends on the input shape. A **single haplotype** peaks at **~10 GB** (request ≥ 16 GB) and finishes in **~7–9 minutes** at 16 threads. A **combined diploid assembly** — both haplotypes in one file, e.g. HG002 v1.1 — peaks at **~17 GB** (request ≥ 24 GB); annotating each haplotype separately keeps the peak at ~10 GB. Measured at 16 threads on T2T-CHM13v2.0, HG008N, HG008T, and HG002 v1.1.
+
+### Disk space
+
+Databases are large, and the archive is **not** deleted until extraction finishes — so installing needs room for the download *and* the extracted database at the same time. That peak, not the download size, is the number to check against `df -h`:
+
+| Database | Backend | Download (`.tar.gz`) | On disk after install | **Free space to install** |
+|---|---|---|---|---|
+| `KS_human_CHM13_v2` (default) | KMC | 16.3 GB | 17.2 GB | **~34 GB** |
+| `HKS_human_CHM13_v2` | HKS | 13.3 GB | 22.7 GB | **~36 GB** |
+
+The HKS archive compresses far better than the KMC one, so its download is the *smaller* of the two while its installed footprint is the larger. Once the install completes the archive is removed and only the "on disk" column remains occupied.
+
+`karyoscope download` checks free space before it starts transferring anything and refuses with the shortfall spelled out rather than failing after a 25-minute download. `karyoscope download --info <ID>` prints all three figures for any database. Sizes here are decimal GB (10⁹ bytes); `df -h` reports binary GiB, so 36 GB shows there as 34 GiB.
+
+**Annotation output** is also substantial, and `--bgzip` does not reduce the peak — every BED is written in full before the compression pass runs. Budget roughly **0.8 GB per feature set per Gbp of input**, plus one intermediate:
+
+| Input | Feature sets | Output BEDs (uncompressed) | Peak including intermediate |
+|---|---|---|---|
+| Single human haplotype (~3.1 Gbp) | 6 | ~15 GB | ~18 GB |
+| Diploid assembly, e.g. HG002 v1.1 (~6.0 Gbp) | 6 | ~29 GB | ~34 GB |
+
+Measured on HG002 v1.1 against `HKS_human_CHM13_v2`. Restricting `--feature-set`, or dropping one output variant with `--no-keep-presmoothed` / `--no-smooth`, scales this down proportionally. `annotate` estimates the footprint from the input size and checks `--outdir` before starting; pass `--no-space-check` to override the estimate.
 
 ## Installation
 
@@ -203,7 +225,10 @@ This walkthrough uses the [HG002 v1.1 T2T diploid assembly](https://s3-us-west-2
      to the HKS figures (~16-24 GB). Keep it on KMC until then. -->
 
 ```bash
-# 1. Download the recommended human reference database (~17 GB, one-time)
+# 1. Download the recommended human reference database (one-time).
+#    16.3 GB download, 17.2 GB on disk once installed -- but you need
+#    ~34 GB free to install, because the archive isn't deleted until
+#    extraction finishes. See "Disk space" above.
 karyoscope download
 
 # 2. Download the HG002 v1.1 diploid assembly (~3 GB, one-time)
@@ -215,8 +240,11 @@ curl -O https://s3-us-west-2.amazonaws.com/human-pangenomics/T2T/HG002/assemblie
 #    assembly and its annotate peaks at ~17 GB (a single haplotype peaks
 #    at ~10 GB and fits 16 GB). The KMC backend needs ≥ 50 GB. HG002 runs
 #    in ~20-30 min at -t 16.
-#    --no-bgzip keeps the per-feature-set BEDs as plain text for easy
-#    inspection; drop it to get the default bgzipped outputs.
+#    Needs ~34 GB free in results/ -- six feature sets over a 6 Gbp
+#    diploid assembly. --no-bgzip keeps the per-feature-set BEDs as plain
+#    text for easy inspection; drop it to get the default bgzipped
+#    outputs (which shrink the result but not the peak, since compression
+#    runs after every BED has been written).
 #    Accepts FASTA, FASTQ (plain or .gz), and BAM. For BAM, samtools
 #    must be on PATH (it's invoked as `samtools fasta` to stream into
 #    get_featureIDs). For read-level inputs also pass --no-preserve-order
@@ -269,12 +297,13 @@ Per-command reference pages live under [`docs/commands/`](docs/commands/) — on
 
 ## Databases
 
-KaryoScope works with pre-built databases distributed via the [KaryoScope registry](https://github.com/barthel-lab/KaryoScope-registry). The current default is `KS_human_CHM13_v2` (~17 GB), built from the T2T-CHM13v2.0 reference.
+KaryoScope works with pre-built databases distributed via the [KaryoScope registry](https://github.com/barthel-lab/KaryoScope-registry). The current default is `KS_human_CHM13_v2` (17.2 GB installed; see [Disk space](#disk-space) for the free space needed to install it), built from the T2T-CHM13v2.0 reference.
 
 Browse and download available databases:
 
 ```bash
-karyoscope download --list
+karyoscope download --list           # download and on-disk size for each
+karyoscope download --info <ID>      # ...plus the free space needed to install
 ```
 
 You can also build your own database from a genome and per-feature-set BED annotations with [`karyoscope build`](docs/commands/build.md). `build` starts from a final labelled BED; producing that BED from raw annotation sources (GFF3/GTF, RepeatMasker/EDTA, satellite catalogs) is currently a manual, source-specific step, and a dedicated `karyoscope prep-bed` helper to automate it is [planned](docs/commands/build.md#preparing-a-feature-set-bed).

--- a/docs/commands/annotate.md
+++ b/docs/commands/annotate.md
@@ -58,6 +58,25 @@ Smoothing promotes short noisy intervals (especially short `novel` runs flanked 
 
 For human-scale inputs, use at least 16 threads. Memory to request depends on the backend and input shape. With the **HKS backend**, a single haplotype peaks at ~10 GB (request ≥ 16 GB) and a combined diploid assembly such as HG002 v1.1 peaks at ~17 GB (request ≥ 24 GB); annotating each haplotype separately keeps the peak at ~10 GB. The **KMC backend** peaks at ~30–35 GB (request ≥ 50 GB). HG002 runs in ~20–30 min at `-t 16`.
 
+## Progress output
+
+`annotate` reports what it is doing as it goes, so a long run is distinguishable from a hung one:
+
+```
+Annotating hg002v1.1.fasta.gz against HKS_human_CHM13_v2
+  6 feature set(s), 16 thread(s), ~34 GB estimated output
+  [1/6] chromosome    4m05s
+  [2/6] region        3m45s
+  ...
+  bgzip (12 file(s))  1m31s
+Wrote:
+  ...
+```
+
+The milestone shape follows the backend. HKS queries each feature set in sequence, so it reports `[i/N]` per set. KMC runs one combined query and then smooths every set in a single streaming pass, so it reports named phases instead (`k-mer query`, `smoothing 6 feature set(s)`).
+
+Pass `-q` (before the subcommand: `karyoscope -q annotate ...`) to suppress the narration; the closing `Wrote:` block still prints, since that is the command's result. Detailed per-step timings remain on the logging channel — `karyoscope -v annotate ...` for those.
+
 ## Disk space
 
 Output is large. Budget roughly **0.8 GB per feature set per Gbp of input**, plus one intermediate the size of the largest single feature set's presmoothed BED:

--- a/docs/commands/annotate.md
+++ b/docs/commands/annotate.md
@@ -27,7 +27,8 @@ karyoscope annotate -i INPUT [OPTIONS]
 | `--keep-presmoothed` / `--no-keep-presmoothed` | Keep the presmoothed BED. Pass `--no-keep-presmoothed` to write only the smoothed output. [default: `keep-presmoothed`] |
 | `--keep-intermediates` | Keep the combined `.featureIDs.bed` from the C++ step (useful for debugging). |
 | `--force` | Regenerate the combined intermediate even if a complete one already exists. By default a rerun reuses a verified combined BED left by a previous (e.g. OOM-killed) run and skips the `get_featureIDs` step, resuming straight into smoothing. A partial file from a killed run is never reused regardless of this flag. |
-| `--bgzip` / `--no-bgzip` | bgzip the per-feature-set output BEDs. Pass `--no-bgzip` to write plain `.bed` files. [default: `bgzip`] |
+| `--bgzip` / `--no-bgzip` | bgzip the per-feature-set output BEDs. Pass `--no-bgzip` to write plain `.bed` files. Note this shrinks the final output but not peak disk usage: compression runs after every BED has been written in full. [default: `bgzip`] |
+| `--no-space-check` | Skip the up-front free-space check on `--outdir`. See [Disk space](#disk-space). |
 | `--preserve-order` / `--no-preserve-order` | Write output BEDs with sequences in the same order as the input. Pass `--no-preserve-order` for the fastest path when order doesn't matter downstream (typically read data). [default: `preserve-order`] |
 | `-h`, `--help` | Show this message and exit. |
 
@@ -56,6 +57,25 @@ Each BED's 4th column is the human-readable feature name. k-mers absent from the
 Smoothing promotes short noisy intervals (especially short `novel` runs flanked by specific features) to the lowest common ancestor of their flankers in the feature set's hierarchy.
 
 For human-scale inputs, use at least 16 threads. Memory to request depends on the backend and input shape. With the **HKS backend**, a single haplotype peaks at ~10 GB (request ≥ 16 GB) and a combined diploid assembly such as HG002 v1.1 peaks at ~17 GB (request ≥ 24 GB); annotating each haplotype separately keeps the peak at ~10 GB. The **KMC backend** peaks at ~30–35 GB (request ≥ 50 GB). HG002 runs in ~20–30 min at `-t 16`.
+
+## Disk space
+
+Output is large. Budget roughly **0.8 GB per feature set per Gbp of input**, plus one intermediate the size of the largest single feature set's presmoothed BED:
+
+| Input | Feature sets | Output BEDs (uncompressed) | Peak including intermediate |
+|---|---|---|---|
+| Single human haplotype (~3.1 Gbp) | 6 | ~15 GB | ~18 GB |
+| Diploid assembly, e.g. HG002 v1.1 (~6.0 Gbp) | 6 | ~29 GB | ~34 GB |
+
+Measured on HG002 v1.1 against `HKS_human_CHM13_v2`: 21.7 GB of presmoothed BED, 7.3 GB of smoothed BED, and a 5.4 GB lookup TSV live at the peak. The BED content is the same for either backend, so the figures hold for both.
+
+`--bgzip` (the default) does **not** lower the peak — every BED is written in full before the compression pass starts. What does lower it:
+
+- `--feature-set` to annotate a subset at a time
+- `--no-keep-presmoothed` (drops the larger of the two variants, ~0.6 of the 0.8 GB) or `--no-smooth`
+- splitting a diploid assembly into per-haplotype runs
+
+`annotate` estimates this footprint before starting and refuses if `--outdir` can't hold it, so a full disk is caught in a second rather than after the k-mer query. The estimate uses an exact base count from a sibling `.fai` when one exists, and otherwise scales the input file size. Pass `--no-space-check` if the estimate is wrong for your input.
 
 ## See also
 

--- a/docs/commands/download.md
+++ b/docs/commands/download.md
@@ -12,7 +12,7 @@ karyoscope download [OPTIONS] [DATABASE_ID ...]
 
 Databases are resolved through an `installed.json` file kept under the database root, and running `karyoscope download` is the normal way to install a pre-built database. Several "action" flags (`--list`, `--info`, `--status`, `--remove`) also make this command the entry point for discovering and managing databases. The default database root is `$KARYOSCOPE_DB` or `~/.karyoscope/db/`.
 
-Downloads are SHA-256 verified; HTTP downloads stage to a `.part` file and resume via HTTP Range requests if interrupted. The registry is cached for 24 hours at `<db_root>/registry_cache.yaml`, and a stale cache is used on transient network failure. The current default database is `KS_human_CHM13_v2` (17.2 GB installed).
+Downloads are SHA-256 verified; HTTP downloads stage to a `.part` file and resume via HTTP Range requests if interrupted. If the download completes but the *install* then fails — extraction runs out of space, the run is interrupted — the verified archive is kept at `<db_root>/.<DATABASE_ID>.tar.gz` and any partially-extracted directory is removed. Re-running `karyoscope download <ID>` re-verifies that archive and extracts it directly, so a failed install costs one extraction rather than a second full transfer. Delete the staged file to reclaim its space instead. The registry is cached for 24 hours at `<db_root>/registry_cache.yaml`, and a stale cache is used on transient network failure. The current default database is `KS_human_CHM13_v2` (17.2 GB installed).
 
 ### Disk space
 
@@ -23,7 +23,7 @@ A database has two sizes, and for the HKS databases they differ substantially:
 | `KS_human_CHM13_v2` (default) | 16.3 GB | 17.2 GB | **~34 GB** |
 | `HKS_human_CHM13_v2` | 13.3 GB | 22.7 GB | **~36 GB** |
 
-Installing needs the sum of the two columns, because the archive is only deleted once extraction succeeds. `download` verifies that up front and refuses with the exact shortfall rather than filling the disk part-way through extraction; `--no-space-check` overrides it. Reinstalling over an existing copy credits the space that copy will free, and an interrupted download's `.part` file is credited too, so resuming doesn't require room for the archive twice.
+Installing needs the sum of the two columns, because the archive is only deleted once extraction succeeds. `download` verifies that up front and refuses with the exact shortfall rather than filling the disk part-way through extraction; `--no-space-check` overrides it. Reinstalling over an existing copy credits the space that copy will free, and a staged or partially-downloaded archive is credited too, so a retry doesn't require room for the archive twice.
 
 Sizes come from the registry's `size_gb` (extracted) and `download_size_gb` (archive) fields, in decimal GB. `df -h` reports binary GiB, so 36 GB appears there as 34 GiB. An entry that predates `download_size_gb` falls back to `size_gb` for both, and the resulting figure is labelled as an estimate.
 

--- a/docs/commands/download.md
+++ b/docs/commands/download.md
@@ -12,7 +12,20 @@ karyoscope download [OPTIONS] [DATABASE_ID ...]
 
 Databases are resolved through an `installed.json` file kept under the database root, and running `karyoscope download` is the normal way to install a pre-built database. Several "action" flags (`--list`, `--info`, `--status`, `--remove`) also make this command the entry point for discovering and managing databases. The default database root is `$KARYOSCOPE_DB` or `~/.karyoscope/db/`.
 
-Downloads are SHA-256 verified; HTTP downloads stage to a `.part` file and resume via HTTP Range requests if interrupted. The registry is cached for 24 hours at `<db_root>/registry_cache.yaml`, and a stale cache is used on transient network failure. The current default database is `KS_human_CHM13_v2` (~17 GB).
+Downloads are SHA-256 verified; HTTP downloads stage to a `.part` file and resume via HTTP Range requests if interrupted. The registry is cached for 24 hours at `<db_root>/registry_cache.yaml`, and a stale cache is used on transient network failure. The current default database is `KS_human_CHM13_v2` (17.2 GB installed).
+
+### Disk space
+
+A database has two sizes, and for the HKS databases they differ substantially:
+
+| Database | Download (`.tar.gz`) | On disk after install | **Free space to install** |
+|---|---|---|---|
+| `KS_human_CHM13_v2` (default) | 16.3 GB | 17.2 GB | **~34 GB** |
+| `HKS_human_CHM13_v2` | 13.3 GB | 22.7 GB | **~36 GB** |
+
+Installing needs the sum of the two columns, because the archive is only deleted once extraction succeeds. `download` verifies that up front and refuses with the exact shortfall rather than filling the disk part-way through extraction; `--no-space-check` overrides it. Reinstalling over an existing copy credits the space that copy will free, and an interrupted download's `.part` file is credited too, so resuming doesn't require room for the archive twice.
+
+Sizes come from the registry's `size_gb` (extracted) and `download_size_gb` (archive) fields, in decimal GB. `df -h` reports binary GiB, so 36 GB appears there as 34 GiB. An entry that predates `download_size_gb` falls back to `size_gb` for both, and the resulting figure is labelled as an estimate.
 
 ## Options
 
@@ -30,6 +43,7 @@ Downloads are SHA-256 verified; HTTP downloads stage to a `.part` file and resum
 | `--refresh-registry` | Force a fresh fetch of the registry, ignoring any cached copy. |
 | `--force` | Re-download and re-install even if the database is already present. |
 | `--no-checksum` | Skip SHA-256 verification (not recommended; useful for debugging). |
+| `--no-space-check` | Install even if the database root looks too small to hold the archive and its extracted contents. Only useful when the registry's declared sizes are wrong for your copy of the database. |
 | `-y, --yes` | Assume 'yes' to interactive prompts (e.g. `--remove`). |
 | `-q, --quiet` | Suppress progress bars. |
 | `-h, --help` | Show this message and exit. |

--- a/docs/commands/karyotype.md
+++ b/docs/commands/karyotype.md
@@ -95,6 +95,19 @@ Wrote:
   ...
 ```
 
+When you restrict `--feature-set` to sets that don't cover the layout roles, an extra line names what the cascade pulls in — so a request for two feature sets that makes `annotate` report three is self-explanatory:
+
+```
+Rendering karyotypes for hg002v1.1.fasta.gz against HKS_human_CHM13_v2
+  1 mode(s) x 2 feature set(s) = 2 render(s)
+  scaffolding also needs region (annotated if missing; not rendered)
+  Annotating hg002v1.1.fasta.gz against HKS_human_CHM13_v2
+    3 feature set(s), 16 thread(s), ~17 GB estimated output
+    ...
+```
+
+That line appears when the cascade requires a feature set you didn't ask to render. Laying out a karyotype needs the chromosome-assignment set (which chromosome each contig belongs to) and the region-assignment set (which way round it goes, and where the centromere is) whatever is being plotted, so `annotate` may report more feature sets than `--feature-set` requested. The line is omitted when your `--feature-set` choices already cover those roles.
+
 Each render's time is measured from the top of its loop, so the first view of a mode carries its binning pass (and any cascade work its feature set needed) rather than reporting a misleadingly fast render.
 
 Pass `-q` (before the subcommand: `karyoscope -q karyotype ...`) to suppress the narration; the closing `Wrote:` block still prints. Use `-v` for the full per-step logging on stderr.

--- a/docs/commands/karyotype.md
+++ b/docs/commands/karyotype.md
@@ -77,6 +77,28 @@ karyoscope karyotype -i asm.fa --mode genome --feature-set chromosome \
 
 One image is written per (mode, feature_set) combination, named `<base>.<dbid>.<mode>.<feature_set>.smoothed.karyotype.svg`. `<base>` is the basename of `--output PATH` when given; otherwise it is derived from the input stems — a single input's stem, or for multi-input runs the longest common prefix of the stems (e.g. `GM04890.haplotype1` + `GM04890.haplotype2` → `GM04890`), falling back to the first stem when the stems share no separator-delimited prefix. Passing `--format pdf` / `--format png` (repeatable) additionally produces those formats by converting the SVG via cairosvg (which needs libcairo at runtime). Using `--presmoothed` renders from raw annotations, and the filename then reflects that variant. The cascade also writes the intermediate scaffolded / binned / centromere BEDs unless suppressed.
 
+## Progress output
+
+The cascade reports as it goes, so a run that takes tens of minutes is distinguishable from a hung one. Nested steps — the `annotate` the cascade runs to derive missing annotations, which is usually the bulk of the wall time — are indented one level, so their headline reads as part of this run rather than a separate command:
+
+```
+Rendering karyotypes for hg002v1.1.fasta.gz against HKS_human_CHM13_v2
+  3 mode(s) x 6 feature set(s) = 18 render(s)
+  Annotating hg002v1.1.fasta.gz against HKS_human_CHM13_v2
+    6 feature set(s), 16 thread(s), ~34 GB estimated output
+    [1/6] chromosome    4m05s
+    ...
+  [1/18] genome/chromosome      52.1s
+  [2/18] genome/region          48.7s
+  ...
+Wrote:
+  ...
+```
+
+Each render's time is measured from the top of its loop, so the first view of a mode carries its binning pass (and any cascade work its feature set needed) rather than reporting a misleadingly fast render.
+
+Pass `-q` (before the subcommand: `karyoscope -q karyotype ...`) to suppress the narration; the closing `Wrote:` block still prints. Use `-v` for the full per-step logging on stderr.
+
 ## See also
 
 - [`karyoscope annotate`](annotate.md), [`karyoscope scaffold`](scaffold.md), [`karyoscope centromeres`](centromeres.md) — the cascade stages karyotype drives

--- a/src/karyoscope/_fetch.py
+++ b/src/karyoscope/_fetch.py
@@ -27,7 +27,7 @@ from karyoscope.exceptions import ChecksumError, FetchError, UnsupportedSchemeEr
 _CHUNK_SIZE = 1024 * 1024
 
 
-def _sha256_file(path: Path) -> str:
+def sha256_file(path: Path) -> str:
     """Return the hex SHA-256 digest of a file's contents."""
     h = hashlib.sha256()
     with path.open("rb") as f:
@@ -175,7 +175,7 @@ def fetch(
         raise UnsupportedSchemeError(f"unsupported URL scheme {scheme!r}; expected http(s) or file")
 
     if expected_sha256 is not None:
-        actual = _sha256_file(dest)
+        actual = sha256_file(dest)
         if actual.lower() != expected_sha256.lower():
             raise ChecksumError(
                 f"SHA-256 mismatch for {dest.name}: "

--- a/src/karyoscope/_version.py
+++ b/src/karyoscope/_version.py
@@ -1,4 +1,4 @@
 # Single source of truth for the KaryoScope version.
 # This file is read by hatchling at build time (see pyproject.toml).
 # It is also imported by `karyoscope.__init__` to expose `__version__`.
-__version__ = "2.0.0"
+__version__ = "2.1.0"

--- a/src/karyoscope/cli.py
+++ b/src/karyoscope/cli.py
@@ -141,7 +141,8 @@ def _configure_logging(verbosity: int) -> None:
     is_flag=True,
     help="Decrease logging verbosity to errors only. Conflicts with -v.",
 )
-def main(verbose: int, quiet: bool) -> None:
+@click.pass_context
+def main(ctx: click.Context, verbose: int, quiet: bool) -> None:
     """KaryoScope: rapid, alignment-free sequence annotation for the pangenome era.
 
     Run a subcommand with ``--help`` to see its options, e.g.:
@@ -155,6 +156,12 @@ def main(verbose: int, quiet: bool) -> None:
         raise click.UsageError("--quiet and --verbose cannot be combined.")
     verbosity = -1 if quiet else verbose
     _configure_logging(verbosity)
+    # --quiet has to reach the *program output* channel too, not just
+    # logging: the milestone lines the long-running commands print (see
+    # karyoscope.progress) go to stdout, so lowering the log level alone
+    # would leave no way to get a silent run. Stashed on the context
+    # rather than threaded through every command signature.
+    ctx.ensure_object(dict)["quiet"] = quiet
 
 
 # Register subcommands. The order here determines the order in `--help`.

--- a/src/karyoscope/cli.py
+++ b/src/karyoscope/cli.py
@@ -31,6 +31,7 @@ import sys
 
 import click
 
+from karyoscope import diskspace
 from karyoscope._version import __version__
 from karyoscope.commands import (
     annotate,
@@ -50,6 +51,34 @@ CONTEXT_SETTINGS = {
     "help_option_names": ["-h", "--help"],
     "max_content_width": 100,
 }
+
+
+class _KaryoscopeGroup(click.Group):
+    """Command group that turns a full disk into a message, not a traceback.
+
+    Commands check free space before they start, but an estimate can be
+    beaten: a shared filesystem fills up underneath a long run, a quota
+    lands mid-write, or a database's registry entry understates its size.
+    When that happens the failure is a bare ``OSError: [Errno 28]`` from
+    whichever write happened to be unlucky — a stack trace through
+    ``tarfile`` or a BED writer that tells the user nothing about their
+    actual problem.
+
+    Catching it here covers every subcommand, including ones that don't
+    (yet) run their own space check.
+    """
+
+    def invoke(self, ctx: click.Context) -> object:
+        try:
+            return super().invoke(ctx)
+        except OSError as exc:
+            if not diskspace.is_enospc(exc):
+                raise
+            command = ctx.invoked_subcommand or "karyoscope"
+            raise click.ClickException(
+                str(diskspace.enospc_error(exc, what=f"running `karyoscope {command}`"))
+            ) from exc
+
 
 #: Maps a verbosity integer (negative for quiet, 0 default, positive for verbose)
 #: to a stdlib logging level. Anything beyond ``2`` is clamped to DEBUG.
@@ -93,7 +122,7 @@ def _configure_logging(verbosity: int) -> None:
     root.setLevel(level)
 
 
-@click.group(context_settings=CONTEXT_SETTINGS)
+@click.group(cls=_KaryoscopeGroup, context_settings=CONTEXT_SETTINGS)
 @click.version_option(
     __version__,
     "-V",

--- a/src/karyoscope/commands/annotate.py
+++ b/src/karyoscope/commands/annotate.py
@@ -41,8 +41,10 @@ from karyoscope.core.external import ExternalToolError, ToolNotFoundError
 from karyoscope.exceptions import (
     DatabaseLayoutError,
     DatabaseNotFoundError,
+    InsufficientDiskSpaceError,
     KaryoscopeError,
     ManifestError,
+    MissingDependencyError,
 )
 
 logger = logging.getLogger(__name__)
@@ -144,7 +146,18 @@ logger = logging.getLogger(__name__)
     "--bgzip/--no-bgzip",
     default=True,
     show_default=True,
-    help="bgzip the per-feature-set output BEDs. Pass --no-bgzip to write plain .bed files.",
+    help="bgzip the per-feature-set output BEDs. Pass --no-bgzip to write plain .bed files. "
+    "Note this shrinks the final output but not the peak disk usage: compression runs "
+    "after every BED has been written in full.",
+)
+@click.option(
+    "--no-space-check",
+    is_flag=True,
+    default=False,
+    help="Skip the up-front free-space check on --outdir. The check estimates the "
+    "output footprint from the input size (roughly 0.8 GB per feature set per Gbp "
+    "of input, plus one intermediate); pass this if that estimate is wrong for "
+    "your input.",
 )
 @click.option(
     "--preserve-order/--no-preserve-order",
@@ -173,6 +186,7 @@ def cmd(
     keep_presmoothed: bool,
     keep_intermediates: bool,
     bgzip: bool,
+    no_space_check: bool,
     preserve_input_order: bool,
     force: bool,
 ) -> None:
@@ -213,6 +227,7 @@ def cmd(
             bgzip=bgzip,
             preserve_input_order=preserve_input_order,
             force=force,
+            check_space=not no_space_check,
         )
     except (
         DatabaseNotFoundError,
@@ -220,6 +235,8 @@ def cmd(
         ManifestError,
         ToolNotFoundError,
         ExternalToolError,
+        InsufficientDiskSpaceError,
+        MissingDependencyError,
         KaryoscopeError,
     ) as e:
         raise click.ClickException(str(e)) from e

--- a/src/karyoscope/commands/annotate.py
+++ b/src/karyoscope/commands/annotate.py
@@ -36,6 +36,7 @@ from pathlib import Path
 import click
 
 from karyoscope import paths
+from karyoscope import progress as _progress
 from karyoscope.core.annotate import annotate
 from karyoscope.core.external import ExternalToolError, ToolNotFoundError
 from karyoscope.exceptions import (
@@ -228,6 +229,7 @@ def cmd(
             preserve_input_order=preserve_input_order,
             force=force,
             check_space=not no_space_check,
+            progress=_progress.from_context(),
         )
     except (
         DatabaseNotFoundError,

--- a/src/karyoscope/commands/download.py
+++ b/src/karyoscope/commands/download.py
@@ -264,6 +264,18 @@ def _action_install(
             f"{diskspace.format_bytes(diskspace.free_bytes(db_root))} available "
             f"on {db_root}"
         )
+        # An archive left by a failed run is reused if it verifies. Say so
+        # here rather than only in the log: without it, the pause while we
+        # hash 13 GB looks like a hang, and the absence of a progress bar
+        # looks like nothing is happening. The verdict itself is logged by
+        # install_database, which is where the hashing happens.
+        staged = _download.staged_archive_path(db_root, entry.id)
+        if staged.is_file():
+            click.echo(
+                f"  Found an archive from an earlier run "
+                f"({diskspace.format_bytes(staged.stat().st_size)}); "
+                "verifying it — if it matches, the download is skipped."
+            )
         target = _download.install_database(
             entry,
             db_root,

--- a/src/karyoscope/commands/download.py
+++ b/src/karyoscope/commands/download.py
@@ -19,9 +19,9 @@ from pathlib import Path
 
 import click
 
+from karyoscope import diskspace, paths
 from karyoscope import download as _download
 from karyoscope import installed as _installed
-from karyoscope import paths
 from karyoscope import registry as _registry
 from karyoscope.commands._options import resolve_db_root_flag
 from karyoscope.exceptions import (
@@ -30,6 +30,7 @@ from karyoscope.exceptions import (
     DatabaseNotFoundError,
     FetchError,
     IncompatibleVersionError,
+    InsufficientDiskSpaceError,
     KaryoscopeError,
     ManifestError,
     RegistryError,
@@ -43,6 +44,27 @@ def _format_size_gb(gb: float) -> str:
     return f"{gb:.1f} GB"
 
 
+def _format_bytes_gb(n: float) -> str:
+    """Render a byte count in GB with one decimal."""
+    return _format_size_gb(n / diskspace.GB)
+
+
+def _format_sizes(entry: _registry.DatabaseEntry) -> str:
+    """Render an entry's download and on-disk sizes.
+
+    These differ enough to matter — the HKS human database is a 13 GB
+    download that unpacks to 23 GB — so both are shown rather than the one
+    unlabelled figure we used to print. Entries that predate
+    ``download_size_gb`` only have the on-disk number to show.
+    """
+    if not entry.download_size_is_declared:
+        return f"{_format_bytes_gb(entry.installed_size_bytes)} on disk"
+    return (
+        f"{_format_bytes_gb(entry.download_size_bytes)} download, "
+        f"{_format_bytes_gb(entry.installed_size_bytes)} on disk"
+    )
+
+
 def _format_db_short(entry: _registry.DatabaseEntry) -> str:
     """One-line summary used by ``--list``."""
     default_tag = " (default)" if entry.is_default else ""
@@ -51,7 +73,7 @@ def _format_db_short(entry: _registry.DatabaseEntry) -> str:
     return (
         f"{entry.id}{default_tag}{community_tag}  "
         f"v{entry.version}  "
-        f"{_format_size_gb(entry.size_gb)}  "
+        f"{_format_sizes(entry)}  "
         f"({taxa})"
     )
 
@@ -124,7 +146,16 @@ def _action_info(
     if entry.release_date:
         click.echo(f"  Release date: {entry.release_date}")
     click.echo(f"  KaryoScope min version: {entry.karyoscope_min_version}")
-    click.echo(f"  Size: {_format_size_gb(entry.size_gb)}")
+    click.echo(f"  Size on disk after install: {_format_bytes_gb(entry.installed_size_bytes)}")
+    if entry.download_size_is_declared:
+        click.echo(f"  Download size: {_format_bytes_gb(entry.download_size_bytes)} (.tar.gz)")
+        click.echo(
+            f"  Free space needed to install: "
+            f"{_format_bytes_gb(entry.peak_install_bytes)} "
+            "(archive and extracted database coexist until extraction finishes)"
+        )
+    else:
+        click.echo("  Download size: not declared in the registry")
     taxa_str = "; ".join(
         f"{t.genus} {t.species}" + (f" ({t.common_name})" if t.common_name else "")
         for t in entry.taxonomy
@@ -196,6 +227,7 @@ def _action_install(
     force: bool,
     verify_checksum: bool,
     show_progress: bool,
+    check_space: bool,
 ) -> None:
     registry = _registry.load_registry(db_root, registry_url, refresh=refresh)
 
@@ -223,13 +255,22 @@ def _action_install(
             click.echo(f"{entry.id}: already installed, skipping (use --force to reinstall)")
             continue
 
-        click.echo(f"Installing {entry.id} v{entry.version} ({_format_size_gb(entry.size_gb)})...")
+        click.echo(f"Installing {entry.id} v{entry.version} ({_format_sizes(entry)})...")
+        # Spelled out before the progress bar starts, because the peak is the
+        # number that matters and it is larger than either figure above: the
+        # archive is not deleted until extraction succeeds.
+        click.echo(
+            f"  Needs {_format_bytes_gb(entry.peak_install_bytes)} free during install; "
+            f"{diskspace.format_bytes(diskspace.free_bytes(db_root))} available "
+            f"on {db_root}"
+        )
         target = _download.install_database(
             entry,
             db_root,
             verify_checksum=verify_checksum,
             show_progress=show_progress,
             force=force,
+            check_space=check_space,
         )
         click.echo(f"  Installed to {target}")
 
@@ -315,6 +356,13 @@ def _action_install(
     help="Skip SHA-256 verification (not recommended; useful for debugging).",
 )
 @click.option(
+    "--no-space-check",
+    is_flag=True,
+    help="Install even if the database root looks too small to hold the archive "
+    "and its extracted contents. Only useful when the registry's declared "
+    "sizes are wrong for your copy of the database.",
+)
+@click.option(
     "-y",
     "--yes",
     is_flag=True,
@@ -341,6 +389,7 @@ def cmd(
     refresh_registry: bool,
     force: bool,
     no_checksum: bool,
+    no_space_check: bool,
     yes: bool,
     quiet: bool,
 ) -> None:
@@ -407,6 +456,7 @@ def cmd(
             force=force,
             verify_checksum=not no_checksum,
             show_progress=not quiet,
+            check_space=not no_space_check,
         )
     except (
         RegistryError,
@@ -416,6 +466,7 @@ def cmd(
         ChecksumError,
         FetchError,
         IncompatibleVersionError,
+        InsufficientDiskSpaceError,
         KaryoscopeError,
     ) as e:
         # Convert known KaryoScope errors to clean user-facing messages.

--- a/src/karyoscope/commands/karyotype.py
+++ b/src/karyoscope/commands/karyotype.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 import click
 
-from karyoscope import paths
+from karyoscope import paths, preflight
 from karyoscope.commands.scaffold import _parse_named_path, _split_comma
 from karyoscope.core.external import ExternalToolError, ToolNotFoundError
 from karyoscope.core.karyotype_run import karyotype_run
@@ -451,6 +451,25 @@ def cmd(
     modes = [m.lower() for m in modes_raw] if modes_raw else None
     formats = [f.lower() for f in formats_raw] if formats_raw else None
 
+    # The cascade is the longest-running command in the suite -- a whole-
+    # genome diploid render is tens of minutes of annotate, scaffold, and
+    # bin before the first pixel is drawn. Anything we can check now saves
+    # all of that. cairosvg in particular is only touched at the very last
+    # step, so a missing libcairo used to surface after the entire pipeline
+    # had already succeeded.
+    #
+    # The k-mer backend binary is deliberately not checked here: whether
+    # it's needed depends on which intermediates already exist, and
+    # `annotate` runs its own preflight the moment the cascade decides to
+    # invoke it.
+    needed: list[str] = []
+    if formats is not None and any(fmt in ("pdf", "png") for fmt in formats):
+        needed.append("cairosvg")
+    if bgzip:
+        needed.append("bgzip")
+    if auto and any(spec.telo_path is None for spec in inputs):
+        needed.append("seqtk")
+
     db_root = paths.ensure_db_root(db_root_arg)
     # --scaffold-db-root defaults to --db-root when unset (the layout DB
     # usually lives in the same registry). None here => karyotype_run
@@ -459,6 +478,7 @@ def cmd(
         paths.ensure_db_root(scaffold_db_root_arg) if scaffold_db_root_arg is not None else None
     )
     try:
+        preflight.require(needed, context="the karyotype cascade")
         results = karyotype_run(
             inputs,
             db_root=db_root,

--- a/src/karyoscope/commands/karyotype.py
+++ b/src/karyoscope/commands/karyotype.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import click
 
 from karyoscope import paths, preflight
+from karyoscope import progress as _progress
 from karyoscope.commands.scaffold import _parse_named_path, _split_comma
 from karyoscope.core.external import ExternalToolError, ToolNotFoundError
 from karyoscope.core.karyotype_run import karyotype_run
@@ -481,6 +482,7 @@ def cmd(
         preflight.require(needed, context="the karyotype cascade")
         results = karyotype_run(
             inputs,
+            progress=_progress.from_context(),
             db_root=db_root,
             db_id=db_id,
             scaffold_db_id=scaffold_db_id,

--- a/src/karyoscope/commands/scaffold.py
+++ b/src/karyoscope/commands/scaffold.py
@@ -33,6 +33,7 @@ from pathlib import Path
 import click
 
 from karyoscope import paths
+from karyoscope import progress as _progress
 from karyoscope.core.external import ExternalToolError, ToolNotFoundError
 from karyoscope.core.scaffold import DEFAULT_HUMAN_ACROCENTRICS
 from karyoscope.core.scaffold_run import InputSpec, scaffold_run
@@ -335,6 +336,7 @@ def cmd(
     try:
         results = scaffold_run(
             inputs,
+            progress=_progress.from_context(),
             db_root=db_root,
             db_id=db_id,
             feature_sets=feature_sets,

--- a/src/karyoscope/commands/version.py
+++ b/src/karyoscope/commands/version.py
@@ -10,20 +10,28 @@ pasting into bug reports.
 from __future__ import annotations
 
 import platform
-import shutil
 import subprocess
 import sys
 from importlib.metadata import PackageNotFoundError, version
 
 import click
 
+from karyoscope import preflight
 from karyoscope._version import __version__
 from karyoscope.paths import default_db_root, installed_databases
 
 #: External tools KaryoScope shells out to. Each entry is
 #: (display_name, executable_name, --version flag).
+#:
+#: ``hks`` and ``get_featureIDs`` are resolved through
+#: :mod:`karyoscope.preflight` rather than a bare ``which``, because both
+#: honour an environment override and ``get_featureIDs`` also resolves out
+#: of the source tree in an editable install. Reporting "not found" for a
+#: working install is worse than not reporting at all -- it sends people
+#: chasing a problem they don't have.
 _EXTERNAL_TOOLS: tuple[tuple[str, str, str], ...] = (
     ("KMC", "kmc", "--version"),
+    ("get_featureIDs", "get_featureIDs", ""),
     # hks 0.2.0 has no --version flag; run with no args and read the
     # "Running hks version X" banner it prints (like seqtk below).
     ("HKS", "hks", ""),
@@ -59,11 +67,11 @@ def _external_tool_version(executable: str, version_flag: str) -> tuple[str | No
     with no arguments (covers tools like seqtk that print usage with a version
     in their header).
     """
-    path = shutil.which(executable)
+    path = preflight.resolve_binary(executable)
     if path is None:
         return None, None
 
-    cmd = [executable, version_flag] if version_flag else [executable]
+    cmd = [path, version_flag] if version_flag else [path]
     try:
         proc = subprocess.run(
             cmd,

--- a/src/karyoscope/core/annotate.py
+++ b/src/karyoscope/core/annotate.py
@@ -73,6 +73,7 @@ from karyoscope.exceptions import (
     KaryoscopeError,
 )
 from karyoscope.manifest import validate_database_layout
+from karyoscope.progress import SILENT, Progress
 
 logger = logging.getLogger(__name__)
 
@@ -1015,6 +1016,7 @@ def _run_hks_backend(
     smoothed_paths: dict[str, Path],
     threads: int,
     k: int,
+    progress: Progress = SILENT,
 ) -> None:
     """Run the HKS lookup and optional smoothing for every requested feature set.
 
@@ -1040,7 +1042,9 @@ def _run_hks_backend(
     is_reads = _is_reads_input(input_path)
 
     t_hks_start = time.perf_counter()
+    tracker = progress.track(requested)
     for fs in requested:
+        t_fs = time.perf_counter()
         fs_file = db_dir / f"{manifest.index.basename}.{fs}.hksf"
         hierarchy_file = db_dir / f"{manifest.index.basename}.{fs}.hierarchy.txt"
         raw_tsv = output_dir / f"{prefix}.{fs}.lookup_raw.tmp.tsv"
@@ -1084,6 +1088,10 @@ def _run_hks_backend(
                 raw_tsv.unlink()
             except OSError as exc:
                 logger.warning("could not remove temp lookup TSV %s: %s", raw_tsv, exc)
+        # Reported here rather than per sub-step: one line per feature set
+        # is the granularity a user waiting on the run actually needs, and
+        # HKS processes them strictly in sequence so the counter is honest.
+        tracker.step(fs, time.perf_counter() - t_fs)
 
     logger.info(
         "hks backend complete in %.1fs (%d feature set(s))",
@@ -1111,6 +1119,7 @@ def annotate(
     force: bool = False,
     k: int | None = None,
     check_space: bool = True,
+    progress: Progress = SILENT,
 ) -> AnnotateResult:
     """Run the full annotate pipeline for one input FASTA.
 
@@ -1153,6 +1162,9 @@ def annotate(
         Estimate the output footprint and refuse to start if ``output_dir``
         can't hold it. Default: ``True``. The estimate is derived from the
         input size, so pass ``False`` if it misjudges an unusual input.
+    progress
+        Milestone reporter for stdout. Defaults to silence, so importing
+        KaryoScope as a library never prints; the CLI passes an enabled one.
 
     Raises
     ------
@@ -1244,6 +1256,16 @@ def annotate(
         skip=not check_space,
     )
 
+    # Announce the run before the first expensive step. Everything below
+    # this point can take twenty minutes, and until now the terminal stayed
+    # blank for all of it.
+    n_threads = threads if threads > 0 else (os.cpu_count() or 1)
+    progress.start(
+        f"Annotating {input_path.name} against {db_id_resolved}",
+        f"{len(requested)} feature set(s), {n_threads} thread(s), "
+        f"~{_human_bytes(needed_bytes)} estimated output",
+    )
+
     t_annotate_start = time.perf_counter()
 
     # Parse features.tsv up front so we fail fast if it's malformed. It maps
@@ -1327,6 +1349,7 @@ def annotate(
             smoothed_paths=smoothed_paths,
             threads=threads,
             k=query_k,
+            progress=progress,
         )
     else:  # "kmc" -- the only other supported type (guaranteed by parse_manifest)
         # Run the C++ helper -- unless a complete combined BED from a prior
@@ -1346,6 +1369,10 @@ def annotate(
                 "-- skipping get_featureIDs. Pass --force to regenerate.",
                 _human_bytes(combined_bed.stat().st_size),
                 combined_bed,
+            )
+            progress.note(
+                f"reusing the combined BED from a previous run "
+                f"({_human_bytes(combined_bed.stat().st_size)}); skipping the k-mer query"
             )
         else:
             logger.info(
@@ -1371,6 +1398,11 @@ def annotate(
                 time.perf_counter() - t_kmc_start,
                 _human_bytes(combined_bed.stat().st_size),
             )
+            # Named stages rather than [i/N]: the KMC backend runs one
+            # combined query and then one streaming smoothing pass over
+            # every feature set at once, so there is no per-feature-set
+            # completion moment to count.
+            progress.stage("k-mer query", time.perf_counter() - t_kmc_start)
         logger.debug("combined BED at %s", combined_bed)
 
         # Run the smoothing pass. One pool initialised with every
@@ -1411,12 +1443,20 @@ def annotate(
                     is_reads_input=is_reads,
                 )
             logger.info("smoothing pass complete in %.1fs", time.perf_counter() - t_smooth_start)
+            progress.stage(
+                f"smoothing {len(requested)} feature set(s)",
+                time.perf_counter() - t_smooth_start,
+            )
         else:
             # Only presmoothed output, no smoothing.
             logger.info("splitting combined BED into %d per-feature-set BED(s)", len(requested))
             t_split_start = time.perf_counter()
             _split_combined_bed(combined_bed, requested, features, presmoothed_paths)
             logger.info("split complete in %.1fs", time.perf_counter() - t_split_start)
+            progress.stage(
+                f"splitting into {len(requested)} feature set(s)",
+                time.perf_counter() - t_split_start,
+            )
 
         # Tidy up the combined intermediate unless asked to keep it. Remove
         # its completion marker alongside it so no dangling marker is left
@@ -1445,6 +1485,10 @@ def annotate(
             if fs in smoothed_paths:
                 smoothed_paths[fs] = _bgzip_file(smoothed_paths[fs], threads=threads)
         logger.info("bgzip pass complete in %.1fs", time.perf_counter() - t_bgzip_start)
+        # Worth its own line: compressing 12 BEDs of a human diploid run
+        # takes minutes, and it happens after the last feature-set line, so
+        # without this the run looks finished-but-hung right at the end.
+        progress.stage(f"bgzip ({n_to_bgzip} file(s))", time.perf_counter() - t_bgzip_start)
 
     n_outputs = len(presmoothed_paths) + len(smoothed_paths)
     logger.info(

--- a/src/karyoscope/core/annotate.py
+++ b/src/karyoscope/core/annotate.py
@@ -40,6 +40,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TextIO
 
+from karyoscope import diskspace, preflight
 from karyoscope import installed as _installed
 from karyoscope.core.external import require_tool, run_tool
 from karyoscope.core.io.features import Features, parse_features, render_feature
@@ -201,6 +202,146 @@ def _is_reads_input(input_path: Path) -> bool:
     """
     name_lower = input_path.name.lower()
     return any(name_lower.endswith(ext) for ext in _READS_INPUT_EXTENSIONS)
+
+
+# --- output-size estimation ------------------------------------------
+#
+# Annotate is the command most likely to fill a disk: a six-feature-set
+# run on a diploid human assembly writes ~29 GB of uncompressed BED, and
+# bgzip does not reduce the peak because it runs after every BED has been
+# written. The constants below let us say so before the run starts,
+# instead of after twenty minutes of work.
+#
+# Calibration (2026-07, HKS_human_CHM13_v2, HG002 v1.1, 6.00 Gbp diploid,
+# 6 feature sets, --no-bgzip):
+#
+#     presmoothed  21.70 GB  ->  0.603 bytes per base per feature set
+#     smoothed      7.26 GB  ->  0.202 bytes per base per feature set
+#
+# These describe BED content, so they hold for both backends — the
+# smoothed/presmoothed output of a KMC database is the same text as an
+# HKS one.
+
+#: Bytes of presmoothed BED per input base, per feature set.
+PRESMOOTHED_BYTES_PER_BASE = 0.60
+
+#: Bytes of smoothed BED per input base, per feature set.
+SMOOTHED_BYTES_PER_BASE = 0.20
+
+#: Transient intermediate allowance, as a multiple of one feature set's
+#: presmoothed estimate. Covers the HKS raw lookup TSV (one at a time,
+#: deleted after each set) and the KMC combined BED. Both are "one row per
+#: k-mer run" files dominated by the sequence name and coordinates that a
+#: presmoothed BED also carries, so one feature set's worth is the right
+#: scale; the 1.5 absorbs the spread between feature sets (the largest set
+#: measured 1.48x the six-set average).
+TRANSIENT_INTERMEDIATE_FACTOR = 1.5
+
+#: Uncompressed-to-compressed ratio assumed for a gzipped nucleotide
+#: FASTA/FASTQ when no ``.fai`` is available. Measured 3.45x on HG002 v1.1
+#: (1.77 GB gz -> 6.10 GB plain); rounded down so the estimate errs low
+#: rather than blocking runs that would have fit.
+GZIP_EXPANSION_FACTOR = 3.4
+
+#: Fraction of an uncompressed file's bytes that are sequence, by format.
+#: FASTA loses ~1.7% to headers and line breaks; FASTQ carries a quality
+#: string per base plus two header lines, so barely half its bytes are
+#: sequence. BAM stores bases 4-bit-packed alongside compressed qualities,
+#: which nets out near 1 base per byte of file.
+_SEQUENCE_FRACTION_FASTA = 0.98
+_SEQUENCE_FRACTION_FASTQ = 0.49
+_BASES_PER_BAM_BYTE = 1.0
+
+
+def _bases_from_fai(input_path: Path) -> int | None:
+    """Total sequence length from a samtools ``.fai`` index, if one exists.
+
+    Exact, and free — assemblies distributed as bgzipped FASTA usually
+    ship the index alongside. Returns None when there is no usable index,
+    leaving the caller to fall back on file-size heuristics.
+    """
+    fai = Path(str(input_path) + ".fai")
+    if not fai.is_file():
+        return None
+    total = 0
+    try:
+        with fai.open() as handle:
+            for line in handle:
+                fields = line.split("\t")
+                if len(fields) < 2:
+                    return None
+                total += int(fields[1])
+    except (OSError, ValueError) as exc:
+        logger.debug("could not read %s: %s", fai, exc)
+        return None
+    return total or None
+
+
+def estimate_input_bases(input_path: Path) -> int:
+    """Estimate the number of sequence bases in ``input_path``.
+
+    Prefers an exact count from a sibling ``.fai``; otherwise scales the
+    file size by the format's sequence fraction, expanding first if the
+    file is gzipped. The result feeds a disk-space estimate, so being
+    within a factor of ~1.2 is entirely adequate.
+    """
+    exact = _bases_from_fai(input_path)
+    if exact is not None:
+        logger.debug("input size from %s.fai: %d bases", input_path.name, exact)
+        return exact
+
+    try:
+        file_size = input_path.stat().st_size
+    except OSError:
+        return 0
+
+    name = input_path.name.lower()
+    if name.endswith(".bam"):
+        return int(file_size * _BASES_PER_BAM_BYTE)
+
+    uncompressed = file_size * GZIP_EXPANSION_FACTOR if name.endswith(".gz") else file_size
+    is_fastq = any(name.endswith(ext) for ext in (".fastq", ".fq", ".fastq.gz", ".fq.gz"))
+    fraction = _SEQUENCE_FRACTION_FASTQ if is_fastq else _SEQUENCE_FRACTION_FASTA
+    return int(uncompressed * fraction)
+
+
+def estimate_output_bytes(
+    *,
+    input_bases: int,
+    n_feature_sets: int,
+    keep_presmoothed: bool,
+    smooth: bool,
+) -> int:
+    """Estimate peak bytes written to the output directory by one annotate run.
+
+    "Peak", not "final": ``--bgzip`` compresses each BED only after all of
+    them have been written, so it shrinks the result but not the high-water
+    mark. ``--no-keep-presmoothed`` and ``--no-smooth`` do reduce it, and
+    are reflected here.
+    """
+    per_set = 0.0
+    if keep_presmoothed:
+        per_set += PRESMOOTHED_BYTES_PER_BASE
+    if smooth:
+        per_set += SMOOTHED_BYTES_PER_BASE
+    outputs = input_bases * per_set * n_feature_sets
+    transient = input_bases * PRESMOOTHED_BYTES_PER_BASE * TRANSIENT_INTERMEDIATE_FACTOR
+    return int(outputs + transient)
+
+
+def _annotate_dependencies(*, index_type: str, input_path: Path, bgzip: bool) -> list[str]:
+    """External tools this particular annotate run will need.
+
+    Resolved from the database's backend, the input format, and the output
+    flags rather than assumed, so a user is never told to install ``kmc``
+    for an HKS run or ``samtools`` for a FASTA one.
+    """
+    needed = ["hks"] if index_type == "hks" else ["get_featureIDs"]
+    if input_path.suffix.lower() == ".bam":
+        needed.append("samtools")
+    if bgzip:
+        needed.append("bgzip")
+    return needed
 
 
 def resolve_database(
@@ -969,6 +1110,7 @@ def annotate(
     preserve_input_order: bool = True,
     force: bool = False,
     k: int | None = None,
+    check_space: bool = True,
 ) -> AnnotateResult:
     """Run the full annotate pipeline for one input FASTA.
 
@@ -1007,9 +1149,18 @@ def annotate(
         BED is present and its ``.done`` completion marker matches its
         size/mtime; a partial file left by a killed run has no matching
         marker and is regenerated regardless of this flag.
+    check_space
+        Estimate the output footprint and refuse to start if ``output_dir``
+        can't hold it. Default: ``True``. The estimate is derived from the
+        input size, so pass ``False`` if it misjudges an unusual input.
 
     Raises
     ------
+    InsufficientDiskSpaceError
+        If ``check_space`` is True and ``output_dir`` looks too small, or if
+        the filesystem fills up during the run regardless.
+    MissingDependencyError
+        If an external tool this run needs isn't installed.
     KaryoscopeError
         If ``smooth=False`` and ``keep_presmoothed=False`` (no output
         would be produced), if the input file doesn't exist, if the
@@ -1054,6 +1205,45 @@ def annotate(
             )
         requested = list(feature_sets)
     logger.info("annotating %s against %s, sets=%s", input_path, db_id_resolved, requested)
+
+    # Preflight. Both checks are cheap and both catch failures that would
+    # otherwise land many minutes in, after the k-mer query has run: a
+    # missing bgzip only bites at the very last step, and a full disk only
+    # once gigabytes have been written.
+    preflight.require(
+        _annotate_dependencies(index_type=manifest.index.type, input_path=input_path, bgzip=bgzip),
+        context=f"annotate against {db_id_resolved}",
+    )
+    input_bases = estimate_input_bases(input_path)
+    needed_bytes = estimate_output_bytes(
+        input_bases=input_bases,
+        n_feature_sets=len(requested),
+        keep_presmoothed=keep_presmoothed,
+        smooth=smooth,
+    )
+    logger.info(
+        "estimated output footprint: %s for %d feature set(s) over ~%.2f Gbp of input",
+        _human_bytes(needed_bytes),
+        len(requested),
+        input_bases / 1e9,
+    )
+    diskspace.require_free_space(
+        output_dir,
+        needed_bytes,
+        what=f"annotating {input_path.name} ({len(requested)} feature set(s))",
+        estimated=True,
+        hint=(
+            "Note that --bgzip shrinks the final output but not the peak: every "
+            "BED is written in full before the compression pass starts.\n"
+            "Options:\n"
+            "  - write to a larger filesystem with --outdir\n"
+            "  - annotate fewer feature sets at a time with --feature-set\n"
+            "  - drop one of the two outputs with --no-keep-presmoothed or --no-smooth\n"
+            "  - pass --no-space-check if this estimate looks wrong for your input"
+        ),
+        skip=not check_space,
+    )
+
     t_annotate_start = time.perf_counter()
 
     # Parse features.tsv up front so we fail fast if it's malformed. It maps

--- a/src/karyoscope/core/karyotype_run.py
+++ b/src/karyoscope/core/karyotype_run.py
@@ -67,6 +67,7 @@ from karyoscope.core.scaffold import (
 from karyoscope.core.scaffold_run import InputSpec, _resolve_roles, scaffold_run
 from karyoscope.exceptions import KaryotypeError
 from karyoscope.manifest import validate_database_layout
+from karyoscope.progress import SILENT, Progress
 
 logger = logging.getLogger(__name__)
 
@@ -611,6 +612,7 @@ def karyotype_run(
     output_path: Path | None = None,
     seed_human_chromosomes: bool = True,
     formats: list[str] | None = None,
+    progress: Progress = SILENT,
     sample_label: str | None = None,
     show_title: bool = True,
     show_legend: bool = True,
@@ -709,6 +711,22 @@ def karyotype_run(
         if bin_size < 1:
             raise KaryotypeError(f"--bin-size must be a positive integer, got {bin_size}")
 
+    # Announce the run before the cascade starts. Everything from here --
+    # annotate, scaffold, bin, render -- can take tens of minutes, and the
+    # nested annotate reports through this same reporter, so the user sees
+    # the expensive middle of the pipeline rather than a blank terminal.
+    sample_names = ", ".join(spec.path.name for spec in inputs)
+    progress.start(
+        f"Rendering karyotypes for {sample_names} against {db_id_resolved}",
+        f"{len(requested_modes)} mode(s) x {len(requested)} feature set(s) "
+        f"= {len(requested_modes) * len(requested)} render(s)",
+    )
+    tracker = progress.track([f"{mode}/{fs}" for mode in requested_modes for fs in requested])
+    # The cascade's own reporters nest one level in, so their headlines read
+    # as steps of this run rather than as separate commands that started on
+    # their own.
+    cascade_progress = progress.child()
+
     # Colours: a user-supplied --colors file overrides the database default.
     # Its stem tags the output filename so a custom-colour render never clobbers
     # the default-colour one (e.g. '...smoothed.colors_chromosome.karyotype.svg').
@@ -777,6 +795,7 @@ def karyotype_run(
             scaffold_feature_sets.append(centromere_fs)
         scaffold_run(
             inputs,
+            progress=cascade_progress,
             db_root=db_root,
             db_id=db_id_resolved,
             feature_sets=scaffold_feature_sets,
@@ -807,6 +826,7 @@ def karyotype_run(
         # scaffolded BEDs are produced.
         scaffold_run(
             inputs,
+            progress=cascade_progress,
             db_root=scaffold_db_root_eff,
             db_id=scaffold_db_id_resolved,
             feature_sets=[],
@@ -854,10 +874,12 @@ def karyotype_run(
                 threads=threads,
                 smooth=(annotation_variant == "smoothed"),
                 bgzip=bgzip,
+                progress=cascade_progress,
             )
     else:
         scaffold_run(
             inputs,
+            progress=cascade_progress,
             db_root=db_root,
             db_id=db_id_resolved,
             feature_sets=requested,
@@ -984,6 +1006,7 @@ def karyotype_run(
         )
 
         for fs in requested:
+            t_view = time.perf_counter()
             leaves = leaves_for(hierarchy, fs)
             # Legend sort: hand the renderer the list of child names
             # in hierarchy.tsv file order. Internal nodes appear first
@@ -1102,6 +1125,11 @@ def karyotype_run(
                     output_paths=output_paths,
                 )
             )
+            # Timed from the top of the inner loop, so the first view of a
+            # mode carries its bin pass (and, on a cold run, the cascade
+            # work its feature set needed) rather than reporting a
+            # misleadingly fast render.
+            tracker.step(f"{current_mode}/{fs}", time.perf_counter() - t_view)
 
     logger.info(
         "karyotype complete in %.1fs (%d render(s) -> %d file(s))",

--- a/src/karyoscope/core/karyotype_run.py
+++ b/src/karyoscope/core/karyotype_run.py
@@ -91,6 +91,51 @@ _GENOME_TARGET_BIN_COUNT = 250
 _MIN_AUTO_BIN_SIZE = 10_000
 
 
+def _scaffolding_prereq_note(
+    *,
+    requested: list[str],
+    scaffold_manifest_roles: dict[str, str],
+    scaffold_available: list[str],
+    centromere_fs: str | None,
+    scaffold_db_id: str | None,
+) -> str:
+    """Explain feature sets the cascade needs but the user didn't ask to plot.
+
+    Laying out a karyotype needs more than the sets being drawn: the
+    chromosome-assignment set says which chromosome each contig belongs to,
+    and the region-assignment set orients it (and, in centromere mode,
+    locates the centromere). :func:`scaffold_run` therefore appends those
+    role sets to whatever ``--feature-set`` asked for.
+
+    Without this note the progress output is quietly baffling — asking for
+    two feature sets and watching ``annotate`` report three, with no hint
+    which extra one appeared or why. Returns ``""`` when the requested sets
+    already cover the roles, so the common case stays uncluttered.
+
+    Deliberately phrased as a requirement rather than an action: the BEDs
+    may already exist from an earlier run, in which case the cascade
+    short-circuits and nothing is annotated at all.
+    """
+    try:
+        chromosome_fs, region_fs = _resolve_roles(scaffold_manifest_roles, scaffold_available)
+    except Exception:
+        # Role resolution failing is reported properly by the cascade; a
+        # missing progress line is not worth turning into an error here.
+        return ""
+
+    already = set(requested)
+    extras: list[str] = []
+    for fs in (chromosome_fs, region_fs, centromere_fs):
+        if fs is not None and fs not in already and fs not in extras:
+            extras.append(fs)
+    if not extras:
+        return ""
+
+    names = ", ".join(extras)
+    source = f" from {scaffold_db_id}" if scaffold_db_id else ""
+    return f"scaffolding also needs {names}{source} (annotated if missing; not rendered)"
+
+
 def _auto_bin_size(mode: str, max_seq_len: int) -> int:
     """Genome-view bin size scaled to the longest sequence; fixed otherwise."""
     if mode != "genome" or max_seq_len <= 0:
@@ -711,22 +756,6 @@ def karyotype_run(
         if bin_size < 1:
             raise KaryotypeError(f"--bin-size must be a positive integer, got {bin_size}")
 
-    # Announce the run before the cascade starts. Everything from here --
-    # annotate, scaffold, bin, render -- can take tens of minutes, and the
-    # nested annotate reports through this same reporter, so the user sees
-    # the expensive middle of the pipeline rather than a blank terminal.
-    sample_names = ", ".join(spec.path.name for spec in inputs)
-    progress.start(
-        f"Rendering karyotypes for {sample_names} against {db_id_resolved}",
-        f"{len(requested_modes)} mode(s) x {len(requested)} feature set(s) "
-        f"= {len(requested_modes) * len(requested)} render(s)",
-    )
-    tracker = progress.track([f"{mode}/{fs}" for mode in requested_modes for fs in requested])
-    # The cascade's own reporters nest one level in, so their headlines read
-    # as steps of this run rather than as separate commands that started on
-    # their own.
-    cascade_progress = progress.child()
-
     # Colours: a user-supplied --colors file overrides the database default.
     # Its stem tags the output filename so a custom-colour render never clobbers
     # the default-colour one (e.g. '...smoothed.colors_chromosome.karyotype.svg').
@@ -770,6 +799,35 @@ def karyotype_run(
     if combine_chromosomes and want_centromere:
         centromere_fs = _resolve_centromere_role(manifest.roles, available)
         centromere_leaves = leaves_for(hierarchy, centromere_fs)
+
+    # Announce the run before the cascade starts. Everything from here --
+    # annotate, scaffold, bin, render -- can take tens of minutes, and the
+    # nested annotate reports through a child of this reporter, so the user
+    # sees the expensive middle of the pipeline rather than a blank terminal.
+    #
+    # Placed after role resolution rather than at the top of the function so
+    # the announcement can name the feature sets the cascade will pull in
+    # beyond the ones being rendered. Nothing above this point is expensive
+    # (manifest, hierarchy, and colour validation), so nothing is hidden by
+    # announcing here.
+    sample_names = ", ".join(spec.path.name for spec in inputs)
+    progress.start(
+        f"Rendering karyotypes for {sample_names} against {db_id_resolved}",
+        f"{len(requested_modes)} mode(s) x {len(requested)} feature set(s) "
+        f"= {len(requested_modes) * len(requested)} render(s)",
+        _scaffolding_prereq_note(
+            requested=requested,
+            scaffold_manifest_roles=scaffold_manifest.roles,
+            scaffold_available=scaffold_available,
+            centromere_fs=centromere_fs,
+            scaffold_db_id=scaffold_db_id_resolved if use_scaffold_db else None,
+        ),
+    )
+    tracker = progress.track([f"{mode}/{fs}" for mode in requested_modes for fs in requested])
+    # The cascade's own reporters nest one level in, so their headlines read
+    # as steps of this run rather than as separate commands that started on
+    # their own.
+    cascade_progress = progress.child()
 
     logger.info(
         "rendering karyotype(s): %d input(s), modes=%s, feature_sets=%s "

--- a/src/karyoscope/core/scaffold_run.py
+++ b/src/karyoscope/core/scaffold_run.py
@@ -71,6 +71,7 @@ from karyoscope.core.scaffold import (
 )
 from karyoscope.exceptions import ScaffoldError
 from karyoscope.manifest import validate_database_layout
+from karyoscope.progress import SILENT, Progress
 
 logger = logging.getLogger(__name__)
 
@@ -246,6 +247,7 @@ def _ensure_annotated(
     threads: int,
     auto: bool,
     bgzip: bool,
+    progress: Progress = SILENT,
 ) -> None:
     """Run annotate if any required smoothed BED is missing.
 
@@ -287,6 +289,10 @@ def _ensure_annotated(
         keep_presmoothed=True,
         keep_intermediates=False,
         bgzip=bgzip,
+        # The cascade's annotate step is the bulk of a karyotype run's
+        # wall time, so it narrates through the parent's reporter rather
+        # than going silent just because it was invoked indirectly.
+        progress=progress,
     )
 
 
@@ -492,6 +498,7 @@ def scaffold_run(
     output_dir: Path | None = None,
     write_scaffolded_beds: bool = True,
     annotation_variant: str = "smoothed",
+    progress: Progress = SILENT,
 ) -> dict[str, ScaffoldResult]:
     """Run the full ``karyoscope scaffold`` pipeline.
 
@@ -638,6 +645,7 @@ def scaffold_run(
             threads=threads,
             auto=auto,
             bgzip=bgzip,
+            progress=progress,
         )
         _ensure_telo(r, auto=auto, telo_motif=telo_motif)
         _ensure_binned(

--- a/src/karyoscope/diskspace.py
+++ b/src/karyoscope/diskspace.py
@@ -1,0 +1,229 @@
+"""Free-disk-space accounting for commands that write large artifacts.
+
+KaryoScope routinely writes tens of gigabytes: installing the human
+database costs ~36 GB at peak (a ~13 GB archive plus its ~23 GB extracted
+form, both on disk at once), and a six-feature-set ``annotate`` of a
+diploid human assembly writes ~29 GB of BED. When the filesystem fills up
+mid-run the failure surfaces as a bare ``OSError: [Errno 28] No space left
+on device`` from deep inside a write loop — after the user has already
+spent 25 minutes downloading, or 20 minutes annotating.
+
+This module provides the two halves of a better story:
+
+* :func:`require_free_space` — an up-front check. Called before the
+  expensive step, it fails immediately with the numbers the user needs
+  (required, available, shortfall, which filesystem).
+* :func:`enospc_error` / :func:`reframe_enospc` — after-the-fact
+  translation. Any ``ENOSPC`` that still escapes gets re-raised as an
+  :class:`~karyoscope.exceptions.InsufficientDiskSpaceError` naming the
+  filesystem that filled up, instead of a traceback.
+
+Units
+=====
+
+Sizes are reported in decimal GB (10^9 bytes), matching the registry's
+``size_gb`` fields and the numbers Zenodo shows. Note this differs from
+``df -h`` on macOS/Linux, which reports binary GiB (2^30 bytes) — 36 GB is
+34 GiB. Messages say "GB" and the discrepancy is under 8%, which is well
+inside the margin these estimates carry anyway.
+"""
+
+from __future__ import annotations
+
+import errno
+import logging
+import os
+import shutil
+from pathlib import Path
+
+from karyoscope.exceptions import InsufficientDiskSpaceError
+
+logger = logging.getLogger(__name__)
+
+#: Extra headroom added to every requirement, as a fraction. Filesystems
+#: behave badly when driven to exactly zero free bytes, sizes in the
+#: registry are rounded, and the OS needs room for its own metadata.
+DEFAULT_MARGIN = 0.05
+
+#: Bytes per decimal GB. Everything user-facing is expressed in these.
+GB = 1_000_000_000
+
+
+def format_bytes(n: float) -> str:
+    """Render a byte count as a human-readable decimal-unit string."""
+    n = float(n)
+    for unit, scale in (("TB", GB * 1000), ("GB", GB), ("MB", 1_000_000), ("kB", 1000)):
+        if abs(n) >= scale:
+            return f"{n / scale:.1f} {unit}"
+    return f"{int(n)} B"
+
+
+def _nearest_existing(path: Path) -> Path:
+    """Walk up from ``path`` until we reach a directory that exists.
+
+    ``shutil.disk_usage`` needs an existing path, but callers routinely ask
+    about an output directory that hasn't been created yet. Its parent lives
+    on the same filesystem in every case that matters here.
+    """
+    p = path.resolve() if path.is_absolute() else (Path.cwd() / path).resolve()
+    while not p.exists():
+        parent = p.parent
+        if parent == p:  # reached the root without finding anything
+            return Path(p.anchor or ".")
+        p = parent
+    return p
+
+
+def free_bytes(path: Path) -> int:
+    """Return the free bytes on the filesystem holding ``path``.
+
+    ``path`` need not exist yet; the nearest existing ancestor is used.
+    Returns ``0`` if the filesystem cannot be queried at all (which makes
+    callers fail loudly rather than silently skipping the check).
+    """
+    target = _nearest_existing(path)
+    try:
+        return shutil.disk_usage(target).free
+    except OSError as exc:  # pragma: no cover — platform-specific
+        logger.debug("could not stat filesystem for %s: %s", target, exc)
+        return 0
+
+
+def directory_size(path: Path) -> int:
+    """Total apparent size of every regular file under ``path``, in bytes.
+
+    Used to credit space that a command is about to free (e.g. the existing
+    database directory that ``download --force`` removes before extracting
+    the replacement). Symlinks are not followed and unreadable entries are
+    skipped; both would only make the estimate less conservative.
+    """
+    total = 0
+    if not path.is_dir():
+        return 0
+    for root, _dirs, files in os.walk(path, followlinks=False):
+        root_path = Path(root)
+        for name in files:
+            try:
+                total += (root_path / name).lstat().st_size
+            except OSError:
+                continue
+    return total
+
+
+def require_free_space(
+    path: Path,
+    required_bytes: float,
+    *,
+    what: str,
+    margin: float = DEFAULT_MARGIN,
+    credit_bytes: int = 0,
+    estimated: bool = False,
+    hint: str | None = None,
+    skip: bool = False,
+) -> None:
+    """Fail unless the filesystem holding ``path`` can hold ``required_bytes``.
+
+    Parameters
+    ----------
+    path
+        A file or directory on the filesystem that will be written to. It
+        does not need to exist yet.
+    required_bytes
+        Peak bytes the operation needs simultaneously on that filesystem.
+    what
+        Short description of the operation, used in the message — e.g.
+        ``"installing HKS_human_CHM13_v2"``.
+    margin
+        Fractional headroom added on top of ``required_bytes``.
+    credit_bytes
+        Bytes the operation is about to free on the same filesystem before
+        it needs the space (e.g. an old install that gets removed first).
+    estimated
+        Whether ``required_bytes`` is a projection rather than a known
+        figure. Only changes the wording, so the user knows how much to
+        trust the number.
+    hint
+        Extra command-specific advice appended to the error.
+    skip
+        If True, log the numbers at INFO and return without raising. Wired
+        to the ``--no-space-check`` flags.
+
+    Raises
+    ------
+    InsufficientDiskSpaceError
+        If free space (plus ``credit_bytes``) is below the requirement.
+    """
+    needed = int(required_bytes * (1.0 + margin))
+    available = free_bytes(path) + credit_bytes
+    filesystem = _nearest_existing(path)
+
+    if skip:
+        logger.info(
+            "space check skipped for %s: need ~%s, %s free on %s",
+            what,
+            format_bytes(needed),
+            format_bytes(available),
+            filesystem,
+        )
+        return
+
+    logger.debug(
+        "space check for %s: need ~%s (incl. %.0f%% margin), %s available on %s",
+        what,
+        format_bytes(needed),
+        margin * 100,
+        format_bytes(available),
+        filesystem,
+    )
+    if available >= needed:
+        return
+
+    qualifier = "an estimated " if estimated else ""
+    lines = [
+        f"not enough free disk space for {what}.",
+        f"  Needs:     {qualifier}{format_bytes(needed)} "
+        f"(includes a {margin * 100:.0f}% safety margin)",
+        f"  Available: {format_bytes(available)} on {filesystem}",
+        f"  Short by:  {format_bytes(needed - available)}",
+    ]
+    if hint:
+        lines.append("")
+        lines.append(hint)
+    raise InsufficientDiskSpaceError("\n".join(lines))
+
+
+def enospc_error(
+    exc: OSError, *, what: str, path: Path | None = None
+) -> InsufficientDiskSpaceError:
+    """Build a readable error for an ``ENOSPC`` that escaped mid-run.
+
+    The originating ``OSError`` says only "No space left on device"; this
+    adds what we were doing, which filesystem is full, and how much is
+    left on it (usually ~0, but a quota or a reserved-blocks setting can
+    make it non-zero, which is itself worth showing).
+    """
+    target = Path(getattr(exc, "filename", None) or path or Path.cwd())
+    filesystem = _nearest_existing(target)
+    return InsufficientDiskSpaceError(
+        f"ran out of disk space while {what}.\n"
+        f"  Filesystem: {filesystem} ({format_bytes(free_bytes(filesystem))} free)\n"
+        f"  Failed on:  {target}\n"
+        "Free up space (or point the command at a larger filesystem) and "
+        "re-run. Partial output files from this run can be deleted."
+    )
+
+
+def is_enospc(exc: BaseException) -> bool:
+    """True if ``exc`` is an OSError meaning "the disk is full"."""
+    return isinstance(exc, OSError) and exc.errno in (errno.ENOSPC, errno.EDQUOT)
+
+
+def reframe_enospc(exc: OSError, *, what: str, path: Path | None = None) -> BaseException:
+    """Return the exception to raise for ``exc``, translating ENOSPC.
+
+    Non-ENOSPC errors are returned unchanged so callers can ``raise`` the
+    result unconditionally.
+    """
+    if is_enospc(exc):
+        return enospc_error(exc, what=what, path=path)
+    return exc

--- a/src/karyoscope/download.py
+++ b/src/karyoscope/download.py
@@ -18,6 +18,7 @@ import logging
 import tarfile
 from pathlib import Path
 
+from karyoscope import diskspace
 from karyoscope._fetch import fetch
 from karyoscope._version import __version__
 from karyoscope.exceptions import (
@@ -208,6 +209,55 @@ def _safe_extract_tar(archive: Path, dest_dir: Path, expected_top_level: str) ->
     return extracted
 
 
+def _check_install_space(entry: DatabaseEntry, db_root: Path, *, skip: bool) -> None:
+    """Verify ``db_root`` can hold the archive *and* its extracted form.
+
+    Installing peaks at ``download + installed`` bytes: :func:`fetch` writes
+    the whole ``.tar.gz`` into ``db_root`` first, and it is only unlinked
+    after :func:`_safe_extract_tar` returns. For the human databases that is
+    ~33 GB (KMC) or ~36 GB (HKS) — well above what the archive size alone
+    suggests, which is exactly the trap this check exists to close.
+
+    Two adjustments make the number honest rather than merely conservative:
+
+    * a partially-downloaded archive from an interrupted run is credited
+      back, since :func:`fetch` resumes into it rather than re-fetching;
+    * an existing install being replaced is credited back, since it is
+      removed before the download starts.
+    """
+    archive_path = db_root / f".{entry.id}.tar.gz"
+    partial_path = Path(str(archive_path) + ".part")
+    credit = 0
+    for staged in (archive_path, partial_path):
+        if staged.is_file():
+            credit += staged.stat().st_size
+    target_dir = db_root / entry.id
+    credit += diskspace.directory_size(target_dir)
+
+    hint_lines = [
+        "Free up space, or install elsewhere with:",
+        "    karyoscope download --db-root /path/on/a/larger/disk " + entry.id,
+        "  (set $KARYOSCOPE_DB to that path to make it the default).",
+    ]
+    if not entry.download_size_is_declared:
+        hint_lines.append(
+            "  This registry entry does not declare a download_size_gb, so the "
+            "archive was assumed to be the same size as the extracted database. "
+            "Refresh the registry with --refresh-registry."
+        )
+    hint_lines.append("  Pass --no-space-check to attempt the install anyway.")
+
+    diskspace.require_free_space(
+        db_root,
+        entry.peak_install_bytes,
+        what=f"installing {entry.id}",
+        credit_bytes=credit,
+        estimated=not entry.download_size_is_declared,
+        hint="\n".join(hint_lines),
+        skip=skip,
+    )
+
+
 def install_database(
     entry: DatabaseEntry,
     db_root: Path,
@@ -215,6 +265,7 @@ def install_database(
     verify_checksum: bool = True,
     show_progress: bool = True,
     force: bool = False,
+    check_space: bool = True,
 ) -> Path:
     """Download, verify, extract, and register a single database.
 
@@ -233,6 +284,10 @@ def install_database(
     force
         If True, re-download and re-extract even if the database appears to
         be already installed.
+    check_space
+        If True (the default), refuse to start when ``db_root``'s filesystem
+        cannot hold the archive and its extracted form at once. Set to False
+        to attempt the install regardless.
 
     Returns
     -------
@@ -243,6 +298,9 @@ def install_database(
     ------
     IncompatibleVersionError
         If the database requires a newer KaryoScope than this one.
+    InsufficientDiskSpaceError
+        If ``check_space`` is True and there isn't room for the install, or
+        if the filesystem fills up part-way through it anyway.
     ChecksumError
         If verification fails (only raised when ``verify_checksum=True``).
     DatabaseLayoutError
@@ -260,6 +318,11 @@ def install_database(
     if not force and target_dir.is_dir() and is_installed(db_root, entry.id):
         logger.debug("%s already installed at %s; skipping", entry.id, target_dir)
         return target_dir
+
+    # Space check goes here: after the "already installed" short-circuit (no
+    # point checking for work we won't do) but before the rmtree below, so a
+    # doomed install can never destroy a working one.
+    _check_install_space(entry, db_root, skip=not check_space)
 
     # If the directory exists but isn't recorded (or force=True), clean it up
     # so we don't merge old and new file sets.
@@ -293,6 +356,12 @@ def install_database(
 
         logger.debug("extracting %s into %s", archive_path.name, db_root)
         _safe_extract_tar(archive_path, db_root, expected_top_level=entry.id)
+    except OSError as exc:
+        # The up-front check uses registry-declared sizes; a filesystem that
+        # was already close to full, or shared with another job, can still
+        # fill up here. Report that as a disk-space problem rather than a
+        # bare "[Errno 28]" traceback out of tarfile.
+        raise diskspace.reframe_enospc(exc, what=f"installing {entry.id}", path=db_root) from exc
     finally:
         archive_path.unlink(missing_ok=True)
 

--- a/src/karyoscope/download.py
+++ b/src/karyoscope/download.py
@@ -19,7 +19,7 @@ import tarfile
 from pathlib import Path
 
 from karyoscope import diskspace
-from karyoscope._fetch import fetch
+from karyoscope._fetch import fetch, sha256_file
 from karyoscope._version import __version__
 from karyoscope.exceptions import (
     DatabaseLayoutError,
@@ -209,6 +209,65 @@ def _safe_extract_tar(archive: Path, dest_dir: Path, expected_top_level: str) ->
     return extracted
 
 
+def staged_archive_path(db_root: Path, db_id: str) -> Path:
+    """Where :func:`install_database` stages a database's ``.tar.gz``.
+
+    Public so the CLI can report on a leftover archive without duplicating
+    the naming convention.
+    """
+    return db_root / f".{db_id}.tar.gz"
+
+
+def _archive_is_reusable(
+    archive_path: Path, entry: DatabaseEntry, *, verify_checksum: bool
+) -> bool:
+    """Whether a staged archive from an earlier run can be extracted as-is.
+
+    An install that gets as far as extraction has already paid for the
+    whole download. When extraction then fails — a full disk, an
+    interrupted run — throwing the archive away costs the user the entire
+    transfer again (25 minutes for the human databases). A SHA-256 match
+    against the registry proves the bytes are exactly what a fresh
+    download would produce, so there is nothing to gain by re-fetching.
+
+    With ``--no-checksum`` there is no way to tell a good archive from a
+    truncated one, so we reuse it (consistent with what that flag means
+    elsewhere) but say so — if extraction then fails on a corrupt file,
+    the error points at the archive.
+    """
+    if not archive_path.is_file():
+        return False
+
+    size = archive_path.stat().st_size
+    if not verify_checksum:
+        logger.warning(
+            "reusing staged archive %s (%s) without verifying it: --no-checksum was "
+            "passed. Delete it and re-run if extraction fails.",
+            archive_path,
+            diskspace.format_bytes(size),
+        )
+        return True
+
+    logger.info(
+        "found a staged archive from an earlier run (%s); verifying its SHA-256 "
+        "before deciding whether to re-download",
+        diskspace.format_bytes(size),
+    )
+    actual = sha256_file(archive_path)
+    if actual.lower() == entry.sha256.lower():
+        logger.info("staged archive verified; skipping the download")
+        return True
+
+    logger.warning(
+        "staged archive %s does not match the registry SHA-256 (expected %s, got %s); "
+        "discarding it and downloading again",
+        archive_path,
+        entry.sha256.lower(),
+        actual,
+    )
+    return False
+
+
 def _check_install_space(entry: DatabaseEntry, db_root: Path, *, skip: bool) -> None:
     """Verify ``db_root`` can hold the archive *and* its extracted form.
 
@@ -225,7 +284,7 @@ def _check_install_space(entry: DatabaseEntry, db_root: Path, *, skip: bool) -> 
     * an existing install being replaced is credited back, since it is
       removed before the download starts.
     """
-    archive_path = db_root / f".{entry.id}.tar.gz"
+    archive_path = staged_archive_path(db_root, entry.id)
     partial_path = Path(str(archive_path) + ".part")
     credit = 0
     for staged in (archive_path, partial_path):
@@ -340,29 +399,68 @@ def install_database(
         shutil.rmtree(target_dir)
 
     # Stage the download to a temp file inside db_root.
-    archive_path = db_root / f".{entry.id}.tar.gz"
+    archive_path = staged_archive_path(db_root, entry.id)
     try:
-        logger.info("fetching %s from %s", entry.id, entry.url)
-        fetch(
-            entry.url,
-            archive_path,
-            expected_sha256=entry.sha256 if verify_checksum else None,
-            show_progress=show_progress,
-        )
-        if verify_checksum:
-            logger.debug("SHA-256 verified: %s", entry.sha256)
+        if _archive_is_reusable(archive_path, entry, verify_checksum=verify_checksum):
+            logger.info("reusing staged archive %s", archive_path)
         else:
-            logger.warning("SHA-256 verification skipped for %s", entry.id)
+            logger.info("fetching %s from %s", entry.id, entry.url)
+            fetch(
+                entry.url,
+                archive_path,
+                expected_sha256=entry.sha256 if verify_checksum else None,
+                show_progress=show_progress,
+            )
+            if verify_checksum:
+                logger.debug("SHA-256 verified: %s", entry.sha256)
+            else:
+                logger.warning("SHA-256 verification skipped for %s", entry.id)
 
         logger.debug("extracting %s into %s", archive_path.name, db_root)
         _safe_extract_tar(archive_path, db_root, expected_top_level=entry.id)
-    except OSError as exc:
+    except BaseException as exc:
+        # Everything from here to the `else` runs only when the install
+        # failed. Two clean-up decisions, and they go in opposite
+        # directions on purpose:
+        #
+        #   - KEEP the archive. It is the expensive part (25 minutes for
+        #     the human databases) and, when checksummed, provably
+        #     complete. Deleting it here is what made a failed extraction
+        #     cost a second full download.
+        #   - DISCARD whatever was extracted. A half-written database
+        #     directory is unusable, is deleted at the top of the next
+        #     attempt anyway, and — when the failure was ENOSPC — is
+        #     sitting on exactly the space needed to retry.
+        reclaimed = diskspace.directory_size(target_dir)
+        if reclaimed:
+            import shutil
+
+            shutil.rmtree(target_dir, ignore_errors=True)
+            logger.warning(
+                "removed the partially-extracted %s, reclaiming %s",
+                target_dir,
+                diskspace.format_bytes(reclaimed),
+            )
+        if archive_path.is_file():
+            logger.warning(
+                "keeping the downloaded archive at %s (%s); re-running "
+                "`karyoscope download %s` will verify and reuse it instead of "
+                "downloading again. Delete it to reclaim that space.",
+                archive_path,
+                diskspace.format_bytes(archive_path.stat().st_size),
+                entry.id,
+            )
         # The up-front check uses registry-declared sizes; a filesystem that
         # was already close to full, or shared with another job, can still
         # fill up here. Report that as a disk-space problem rather than a
         # bare "[Errno 28]" traceback out of tarfile.
-        raise diskspace.reframe_enospc(exc, what=f"installing {entry.id}", path=db_root) from exc
-    finally:
+        if isinstance(exc, OSError):
+            raise diskspace.reframe_enospc(
+                exc, what=f"installing {entry.id}", path=db_root
+            ) from exc
+        raise
+    else:
+        # Only now is the archive genuinely disposable.
         archive_path.unlink(missing_ok=True)
 
     # Validate the extracted layout. If this fails, leave the broken directory

--- a/src/karyoscope/exceptions.py
+++ b/src/karyoscope/exceptions.py
@@ -63,3 +63,22 @@ class KaryotypeError(KaryoscopeError):
 
 class BuildError(KaryoscopeError):
     """Problems building an HKS index database (spec, inputs, or construction)."""
+
+
+class InsufficientDiskSpaceError(KaryoscopeError):
+    """A command would need more free disk space than the target filesystem has.
+
+    Raised by the up-front checks in :mod:`karyoscope.diskspace`, and also
+    used to re-frame an ``OSError`` with ``errno.ENOSPC`` that escaped from
+    the middle of a run (a filesystem that filled up while we were writing).
+    """
+
+
+class MissingDependencyError(KaryoscopeError):
+    """One or more required external tools are not available.
+
+    Distinct from :class:`karyoscope.core.external.ToolNotFoundError`, which
+    reports a single tool at the point of use. This one is raised by the
+    up-front check in :mod:`karyoscope.preflight` and reports *every*
+    missing tool a command needs, before any expensive work starts.
+    """

--- a/src/karyoscope/preflight.py
+++ b/src/karyoscope/preflight.py
@@ -1,0 +1,228 @@
+"""Up-front checks that a command's external dependencies are available.
+
+KaryoScope shells out to a handful of binaries, and imports a couple of
+Python packages that wrap native libraries. Historically each was resolved
+at its point of use — which means a `karyotype` run could spend twenty
+minutes annotating and then fail because ``seqtk`` was never installed, or
+an `annotate` could finish the k-mer query and die at the bgzip step.
+
+This module resolves everything a command needs *before* it starts, and
+reports all missing dependencies in one message rather than one per rerun.
+
+The catalogue below is the single place that knows how to obtain each
+dependency, so the install hints stay consistent with ``environment.yml``
+and the README. :func:`require` is what commands call; :func:`check`
+returns the missing set without raising, for reporting contexts like
+``karyoscope version``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from karyoscope.exceptions import MissingDependencyError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Dependency:
+    """One external dependency KaryoScope may need.
+
+    ``kind`` is ``"binary"`` (looked up on ``$PATH``, unless the name has
+    an entry in :data:`_RESOLVERS`) or ``"python"`` (looked up as an
+    importable module).
+    """
+
+    name: str
+    kind: str
+    purpose: str
+    install_hint: str
+
+
+#: Every dependency KaryoScope can require, keyed by the name commands use.
+DEPENDENCIES: dict[str, Dependency] = {
+    "hks": Dependency(
+        name="hks",
+        kind="binary",
+        purpose="querying and building HKS-backend databases",
+        install_hint=(
+            "Build it from source and put it on PATH:\n"
+            "    git clone --recurse-submodules https://github.com/jnalanko/HKS.git\n"
+            '    cargo install --path HKS --root "$CONDA_PREFIX"\n'
+            "  or set $KARYOSCOPE_HKS to an existing hks binary."
+        ),
+    ),
+    "get_featureIDs": Dependency(
+        name="get_featureIDs",
+        kind="binary",
+        purpose="querying KMC-backend databases",
+        install_hint=(
+            "Compile the bundled helper from the KaryoScope source tree:\n"
+            "    make -C native/get_featureIDs\n"
+            "  or set $KARYOSCOPE_GET_FEATUREIDS to an existing binary."
+        ),
+    ),
+    "kmc": Dependency(
+        name="kmc",
+        kind="binary",
+        purpose="building KMC-backend databases",
+        install_hint="conda install -c bioconda kmc",
+    ),
+    "bgzip": Dependency(
+        name="bgzip",
+        kind="binary",
+        purpose="compressing output BEDs",
+        install_hint=(
+            "conda install -c bioconda htslib\n"
+            "  or re-run with --no-bgzip to write plain .bed files."
+        ),
+    ),
+    "tabix": Dependency(
+        name="tabix",
+        kind="binary",
+        purpose="indexing compressed BEDs",
+        install_hint="conda install -c bioconda htslib",
+    ),
+    "seqtk": Dependency(
+        name="seqtk",
+        kind="binary",
+        purpose="telomere detection",
+        install_hint="conda install -c bioconda seqtk",
+    ),
+    "samtools": Dependency(
+        name="samtools",
+        kind="binary",
+        purpose="reading BAM input",
+        install_hint="conda install -c bioconda samtools",
+    ),
+    "cairosvg": Dependency(
+        name="cairosvg",
+        kind="python",
+        purpose="rendering PDF/PNG karyotypes",
+        install_hint=(
+            "pip install cairosvg, and install the native library it wraps:\n"
+            "    conda install -c conda-forge cairo\n"
+            "  or re-run with --format svg."
+        ),
+    ),
+}
+
+
+def _hks_binary() -> str:
+    from karyoscope.core.io.hks import get_hks_binary
+
+    return get_hks_binary()
+
+
+def _get_featureids_binary() -> str:
+    from karyoscope.core.io.kmc import get_featureids_binary
+
+    return get_featureids_binary()
+
+
+#: Dependencies whose lookup is more than "is it on $PATH". Both k-mer
+#: backends accept an environment override and ``get_featureIDs`` also
+#: resolves out of the source tree for editable installs, so we must ask
+#: the backend rather than reimplement its search order — a second
+#: implementation here would reject working installs.
+#:
+#: Imported lazily inside each function: :mod:`karyoscope.core.annotate`
+#: imports this module, so a top-level import of its siblings would be a
+#: cycle.
+_RESOLVERS: dict[str, Callable[[], str]] = {
+    "hks": _hks_binary,
+    "get_featureIDs": _get_featureids_binary,
+}
+
+
+def resolve_binary(name: str) -> str | None:
+    """Return the path KaryoScope would use for ``name``, or None if absent.
+
+    The single source of truth for "can KaryoScope run this tool", used by
+    the checks below and by ``karyoscope version``. Honours each backend's
+    own lookup order rather than assuming ``$PATH``.
+    """
+    resolver = _RESOLVERS.get(name)
+    if resolver is None:
+        return shutil.which(name)
+    try:
+        return resolver()
+    except Exception as exc:  # ToolNotFoundError, or an override pointing nowhere
+        logger.debug("preflight: %s did not resolve: %s", name, exc)
+        return None
+
+
+def _binary_available(dep: Dependency) -> bool:
+    return resolve_binary(dep.name) is not None
+
+
+def _python_available(dep: Dependency) -> bool:
+    try:
+        return importlib.util.find_spec(dep.name) is not None
+    except (ImportError, ValueError):  # pragma: no cover — malformed install
+        return False
+
+
+def _available(dep: Dependency) -> bool:
+    return _binary_available(dep) if dep.kind == "binary" else _python_available(dep)
+
+
+def check(names: list[str]) -> list[Dependency]:
+    """Return the dependencies in ``names`` that are not available.
+
+    Unknown names are ignored rather than raising: the caller is asking
+    "what's missing", and an unrecognised name is a KaryoScope bug, not a
+    user-facing dependency problem.
+    """
+    missing: list[Dependency] = []
+    for name in names:
+        dep = DEPENDENCIES.get(name)
+        if dep is None:
+            logger.debug("preflight: unknown dependency %r, skipping", name)
+            continue
+        if _available(dep):
+            logger.debug("preflight: %s found", name)
+        else:
+            missing.append(dep)
+    return missing
+
+
+def require(names: list[str], *, context: str) -> None:
+    """Raise unless every dependency in ``names`` is available.
+
+    Parameters
+    ----------
+    names
+        Keys into :data:`DEPENDENCIES`.
+    context
+        What the dependencies are needed for, used in the message — e.g.
+        ``"annotate against KS_human_CHM13_v2"``.
+
+    Raises
+    ------
+    MissingDependencyError
+        Listing every missing dependency, with an install hint for each.
+    """
+    missing = check(names)
+    if not missing:
+        return
+
+    plural = "dependencies" if len(missing) > 1 else "dependency"
+    lines = [f"missing required {plural} for {context}:"]
+    for dep in missing:
+        where = "on $PATH" if dep.kind == "binary" else "as a Python module"
+        lines.append(f"\n  {dep.name} — not found {where} (needed for {dep.purpose})")
+        for hint_line in dep.install_hint.splitlines():
+            lines.append(f"    {hint_line}")
+    lines.append(
+        "\nThe conda environment shipped with KaryoScope (environment.yml) "
+        "provides all of these except hks and get_featureIDs, which are "
+        "built separately — see the Installation section of the README.\n"
+        "Run `karyoscope version` to see what KaryoScope can currently find."
+    )
+    raise MissingDependencyError("\n".join(lines))

--- a/src/karyoscope/progress.py
+++ b/src/karyoscope/progress.py
@@ -1,0 +1,174 @@
+"""Milestone reporting to stdout for long-running commands.
+
+KaryoScope keeps two output channels apart on purpose (see
+:mod:`karyoscope.cli`): *program output* on stdout via ``click.echo``, and
+*diagnostics* on stderr via ``logging``, hidden unless the user passes
+``-v``. That split is sound, but it left the two slowest commands silent:
+``download`` and ``build`` announced themselves and their results, while
+``annotate`` (7-22 minutes) and ``karyotype`` (tens of minutes) printed
+nothing at all until their closing ``Wrote:`` block. A user watching a
+blank terminal for twenty minutes cannot tell a working run from a hung
+one.
+
+This module adds a third, deliberately thin thing: a handful of
+*milestone* lines on stdout, in the same shape ``download`` and ``build``
+already use. It is not a second logging system. Milestones are the events
+a person waiting on the command cares about — "this feature set is done,
+five to go" — and nothing else. The detailed per-step timings stay at INFO
+where they were, so ``-v`` remains the way to get the full picture and
+nothing is printed twice.
+
+Core modules take a :class:`Progress` explicitly rather than reaching for
+a global, so a library caller gets silence by default (:data:`SILENT`) and
+tests can capture output without touching global state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TextIO
+
+import click
+
+
+def format_duration(seconds: float) -> str:
+    """Render a duration the way someone reading a progress line wants it.
+
+    Sub-minute durations keep a decimal (``45.3s``) because at that scale
+    the difference matters; longer ones don't (``4m05s``, ``1h02m``).
+    """
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    if seconds < 3600:
+        minutes, secs = divmod(int(seconds), 60)
+        return f"{minutes}m{secs:02d}s"
+    hours, remainder = divmod(int(seconds), 3600)
+    return f"{hours}h{remainder // 60:02d}m"
+
+
+#: Spaces per nesting level. One level is enough to read as "this
+#: happened inside the thing above it" without marching off the page.
+_INDENT = "  "
+
+
+class Tracker:
+    """Counter for one sequence of comparable items, from :meth:`Progress.track`.
+
+    The counter lives here rather than on :class:`Progress` because the
+    commands nest: ``karyotype`` tracks its renders and, part-way through,
+    calls ``annotate``, which tracks its feature sets. Sharing one counter
+    made the inner sequence overwrite the outer one's total and produced
+    impossible lines like ``[4/3]``. A tracker per sequence makes nesting
+    correct by construction.
+    """
+
+    def __init__(self, owner: Progress, labels: Sequence[str]) -> None:
+        self._owner = owner
+        self._total = len(labels)
+        self._index = 0
+        self._width = max((len(label) for label in labels), default=0)
+
+    def step(self, label: str, seconds: float) -> None:
+        """Report one item finishing, as ``[2/6] region  3m45s``."""
+        self._index += 1
+        counter = f"[{self._index}/{self._total}]"
+        self._owner._emit(f"{counter} {label.ljust(self._width)}  {format_duration(seconds)}")
+
+
+class Progress:
+    """Emits milestone lines to stdout, or nowhere when disabled.
+
+    Parameters
+    ----------
+    enabled
+        When False every method is a no-op. This is what ``--quiet``
+        and the library default use.
+    stream
+        Where to write. Defaults to stdout via ``click.echo``. Tests
+        pass a :class:`io.StringIO`.
+    depth
+        Nesting level, controlling indentation. Use :meth:`child` rather
+        than setting this directly.
+    """
+
+    def __init__(
+        self, *, enabled: bool = True, stream: TextIO | None = None, depth: int = 0
+    ) -> None:
+        self.enabled = enabled
+        self._stream = stream
+        self._depth = depth
+
+    def child(self) -> Progress:
+        """A reporter one level deeper, for work invoked by this command.
+
+        ``karyotype`` cascades into ``annotate``; indenting the inner
+        command's lines keeps its headline from reading as a second
+        top-level command that started on its own.
+        """
+        return Progress(enabled=self.enabled, stream=self._stream, depth=self._depth + 1)
+
+    def _write(self, line: str) -> None:
+        if not self.enabled:
+            return
+        if self._stream is None:
+            click.echo(line)
+        else:
+            self._stream.write(line + "\n")
+
+    def _emit(self, body: str) -> None:
+        """Write an indented detail line, one level in from this reporter's headline."""
+        self._write(f"{_INDENT * (self._depth + 1)}{body}")
+
+    def start(self, headline: str, *details: str) -> None:
+        """Announce what the command is about to do.
+
+        ``details`` are indented continuation lines — the run's shape
+        (feature sets, threads, estimated output), which is exactly what
+        a user checks before walking away from a long job.
+        """
+        self._write(f"{_INDENT * self._depth}{headline}")
+        for detail in details:
+            if detail:
+                self._emit(detail)
+
+    def track(self, labels: Sequence[str]) -> Tracker:
+        """Open a counter over ``labels`` for ``[i/N]`` reporting.
+
+        Column alignment needs the longest label up front; deriving it per
+        line instead would make the output jitter as it goes.
+        """
+        return Tracker(self, labels)
+
+    def stage(self, label: str, seconds: float) -> None:
+        """Report a named phase finishing, with no ``[i/N]`` counter.
+
+        For work that isn't a clean sequence of equivalent items — the KMC
+        backend smooths every feature set in a single streaming pass, so
+        there is no per-feature-set moment to report.
+        """
+        self._emit(f"{label}  {format_duration(seconds)}")
+
+    def note(self, text: str) -> None:
+        """Report something that isn't timed — a decision or a warning."""
+        self._emit(text)
+
+
+#: The no-op reporter. Used as the default everywhere in ``core`` so that
+#: importing KaryoScope as a library never writes to stdout.
+SILENT = Progress(enabled=False)
+
+
+def from_context() -> Progress:
+    """Build a reporter honouring the group-level ``-q/--quiet`` flag.
+
+    Reads the flag off the click context rather than adding a parameter to
+    every command signature, mirroring how ``-v`` reaches the whole
+    program through one call to ``logging`` config in
+    :func:`karyoscope.cli.main`.
+
+    Returns an enabled reporter outside a click context (a library caller
+    that asked for one explicitly wants output).
+    """
+    ctx = click.get_current_context(silent=True)
+    quiet = bool(ctx is not None and isinstance(ctx.obj, dict) and ctx.obj.get("quiet"))
+    return Progress(enabled=not quiet)

--- a/src/karyoscope/registry.py
+++ b/src/karyoscope/registry.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import yaml
 
 from karyoscope._fetch import fetch
+from karyoscope.diskspace import GB as _GB
 from karyoscope.exceptions import RegistryError
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,7 @@ class DatabaseEntry:
     karyoscope_min_version: str
     taxonomy: list[TaxonomyEntry]
     feature_sets: list[str]
+    #: Size of the *extracted* database directory, in decimal GB.
     size_gb: float
     source: str
     url: str
@@ -72,6 +74,10 @@ class DatabaseEntry:
     kmer_size: int
     kmer_type: str
     kmer_max_size: int
+    #: Size of the downloadable ``.tar.gz``, in decimal GB. Optional in the
+    #: registry schema; falls back to ``size_gb`` when absent (see
+    #: :attr:`download_size_bytes`).
+    download_size_gb: float | None = None
     is_default: bool = False
     description: str | None = None
     release_date: str | None = None
@@ -83,6 +89,45 @@ class DatabaseEntry:
     recommended_smoothing_window_bp: int | None = None
     # 'official' if from the top-level 'databases' list, 'community' otherwise.
     source_category: str = "official"
+
+    # -- Size accessors -----------------------------------------------
+    #
+    # A database has two sizes that matter and they can differ by a lot:
+    # HKS_human_CHM13_v2 is a 13.3 GB download that occupies 22.7 GB once
+    # extracted. ``size_gb`` is the extracted size — the one a user has to
+    # keep free permanently — and ``download_size_gb`` is the transfer.
+    # Entries predating the split omit the latter, so these accessors
+    # collapse to ``size_gb`` for both rather than failing.
+
+    @property
+    def installed_size_bytes(self) -> int:
+        """Bytes the extracted database occupies on disk."""
+        return int(self.size_gb * _GB)
+
+    @property
+    def download_size_bytes(self) -> int:
+        """Bytes to transfer for this database."""
+        gb = self.download_size_gb if self.download_size_gb is not None else self.size_gb
+        return int(gb * _GB)
+
+    @property
+    def download_size_is_declared(self) -> bool:
+        """Whether the archive size came from the registry, not the fallback.
+
+        When False, ``download_size_bytes`` reuses the extracted size, so
+        the peak-install figure is a guess. Callers say so rather than
+        presenting it as measured.
+        """
+        return self.download_size_gb is not None
+
+    @property
+    def peak_install_bytes(self) -> int:
+        """Peak bytes needed on the database filesystem during install.
+
+        The archive is downloaded in full and only deleted *after*
+        extraction succeeds, so both exist simultaneously.
+        """
+        return self.download_size_bytes + self.installed_size_bytes
 
 
 @dataclass
@@ -169,6 +214,18 @@ def _parse_database_entry(raw: dict, source_category: str) -> DatabaseEntry:
         raise RegistryError(f"'size_gb' in {where} must be a number")
     size_gb = float(size_gb_raw)
 
+    def _optional_size(key: str) -> float | None:
+        v = raw.get(key)
+        if v is None:
+            return None
+        if not isinstance(v, int | float):
+            raise RegistryError(f"'{key}' in {where} must be a number")
+        if v < 0:
+            raise RegistryError(f"'{key}' in {where} must not be negative")
+        return float(v)
+
+    download_size_gb = _optional_size("download_size_gb")
+
     taxonomy = _parse_taxonomy(_require(raw, "taxonomy", where), where)
 
     fs_raw = _require(raw, "feature_sets", where)
@@ -220,6 +277,7 @@ def _parse_database_entry(raw: dict, source_category: str) -> DatabaseEntry:
         taxonomy=taxonomy,
         feature_sets=list(fs_raw),
         size_gb=size_gb,
+        download_size_gb=download_size_gb,
         source=source or "",
         url=url or "",
         sha256=sha256 or "",

--- a/tests/test_annotate_footprint.py
+++ b/tests/test_annotate_footprint.py
@@ -1,0 +1,155 @@
+"""Tests for annotate's output-size estimate and dependency preflight.
+
+The estimate exists so a user learns their disk is too small in a second
+rather than twenty minutes. It only has to be roughly right, but "roughly"
+is pinned here against a real measured run so a future change to the
+constants can't silently drift by an order of magnitude.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from karyoscope.core.annotate import (
+    GZIP_EXPANSION_FACTOR,
+    _annotate_dependencies,
+    estimate_input_bases,
+    estimate_output_bytes,
+)
+
+#: The reference measurement, from a full HG002 v1.1 run against
+#: HKS_human_CHM13_v2 at 16 threads (2026-07, --no-bgzip, six feature sets):
+#: 5,999,424,718 bases in; 21.70 GB of presmoothed BED plus 7.26 GB of
+#: smoothed BED out, with a largest-single-set lookup TSV of 5.42 GB live
+#: at peak.
+_HG002_BASES = 5_999_424_718
+_HG002_MEASURED_PEAK = 34_400_000_000
+
+
+# --- input size -------------------------------------------------------
+
+
+def test_bases_come_from_a_fai_when_one_exists(tmp_path: Path) -> None:
+    """An exact count beats any heuristic, and assemblies usually ship one."""
+    fasta = tmp_path / "asm.fasta.gz"
+    fasta.write_bytes(b"not actually gzip")
+    (tmp_path / "asm.fasta.gz.fai").write_text(
+        "chr1\t248956422\t112\t60\t61\nchr2\t242193529\t9000\t60\t61\n"
+    )
+    assert estimate_input_bases(fasta) == 248956422 + 242193529
+
+
+def test_a_malformed_fai_falls_back_rather_than_raising(tmp_path: Path) -> None:
+    fasta = tmp_path / "asm.fasta"
+    fasta.write_bytes(b"A" * 1000)
+    (tmp_path / "asm.fasta.fai").write_text("this is not a fai\n")
+    assert estimate_input_bases(fasta) == pytest.approx(980, rel=0.01)
+
+
+def test_plain_fasta_size_is_close_to_its_base_count(tmp_path: Path) -> None:
+    fasta = tmp_path / "asm.fasta"
+    fasta.write_bytes(b"A" * 1_000_000)
+    assert estimate_input_bases(fasta) == pytest.approx(1_000_000, rel=0.05)
+
+
+def test_fastq_is_discounted_for_quality_strings(tmp_path: Path) -> None:
+    """A FASTQ carries one quality character per base, so ~half its bytes."""
+    fq = tmp_path / "reads.fastq"
+    fq.write_bytes(b"A" * 1_000_000)
+    assert estimate_input_bases(fq) < 600_000
+
+
+def test_gzipped_input_is_expanded_before_scaling(tmp_path: Path) -> None:
+    plain = tmp_path / "asm.fasta"
+    gz = tmp_path / "other.fasta.gz"
+    plain.write_bytes(b"A" * 1_000_000)
+    gz.write_bytes(b"A" * 1_000_000)
+    assert estimate_input_bases(gz) == pytest.approx(
+        estimate_input_bases(plain) * GZIP_EXPANSION_FACTOR, rel=0.01
+    )
+
+
+def test_missing_input_estimates_zero_rather_than_raising(tmp_path: Path) -> None:
+    assert estimate_input_bases(tmp_path / "gone.fasta") == 0
+
+
+def test_gz_heuristic_lands_near_the_real_hg002_file() -> None:
+    """1.77 GB of gzip -> 6.0 Gbp. The constant must stay in that ballpark."""
+    hg002_gz_bytes = 1_769_801_343
+    estimated = hg002_gz_bytes * GZIP_EXPANSION_FACTOR * 0.98
+    assert estimated == pytest.approx(_HG002_BASES, rel=0.05)
+
+
+# --- output size ------------------------------------------------------
+
+
+def test_estimate_matches_the_measured_hg002_run() -> None:
+    estimate = estimate_output_bytes(
+        input_bases=_HG002_BASES,
+        n_feature_sets=6,
+        keep_presmoothed=True,
+        smooth=True,
+    )
+    assert estimate == pytest.approx(_HG002_MEASURED_PEAK, rel=0.10)
+
+
+def test_estimate_scales_with_feature_set_count() -> None:
+    """--feature-set is one of the escapes we suggest, so it must matter."""
+    one = estimate_output_bytes(
+        input_bases=_HG002_BASES, n_feature_sets=1, keep_presmoothed=True, smooth=True
+    )
+    six = estimate_output_bytes(
+        input_bases=_HG002_BASES, n_feature_sets=6, keep_presmoothed=True, smooth=True
+    )
+    assert six > one * 3
+
+
+def test_dropping_an_output_lowers_the_estimate() -> None:
+    both = estimate_output_bytes(
+        input_bases=_HG002_BASES, n_feature_sets=6, keep_presmoothed=True, smooth=True
+    )
+    smoothed_only = estimate_output_bytes(
+        input_bases=_HG002_BASES, n_feature_sets=6, keep_presmoothed=False, smooth=True
+    )
+    presmoothed_only = estimate_output_bytes(
+        input_bases=_HG002_BASES, n_feature_sets=6, keep_presmoothed=True, smooth=False
+    )
+    assert smoothed_only < both
+    assert presmoothed_only < both
+    # Presmoothed BEDs are the bulk of the output (0.60 vs 0.20 bytes/base).
+    assert presmoothed_only > smoothed_only
+
+
+def test_transient_intermediate_is_always_counted() -> None:
+    """Even a single feature set needs room for its lookup TSV alongside."""
+    single = estimate_output_bytes(
+        input_bases=1_000_000_000, n_feature_sets=1, keep_presmoothed=False, smooth=True
+    )
+    outputs_only = 1_000_000_000 * 0.20
+    assert single > outputs_only * 2
+
+
+# --- dependency selection ---------------------------------------------
+
+
+def test_hks_database_asks_for_hks_not_kmc() -> None:
+    deps = _annotate_dependencies(index_type="hks", input_path=Path("a.fasta"), bgzip=False)
+    assert deps == ["hks"]
+
+
+def test_kmc_database_asks_for_get_featureids() -> None:
+    deps = _annotate_dependencies(index_type="kmc", input_path=Path("a.fasta"), bgzip=False)
+    assert deps == ["get_featureIDs"]
+
+
+def test_bam_input_adds_samtools_and_bgzip_adds_bgzip() -> None:
+    deps = _annotate_dependencies(index_type="hks", input_path=Path("a.bam"), bgzip=True)
+    assert set(deps) == {"hks", "samtools", "bgzip"}
+
+
+def test_fasta_input_does_not_require_samtools() -> None:
+    """Users shouldn't be told to install a tool their run will never call."""
+    deps = _annotate_dependencies(index_type="hks", input_path=Path("a.fasta.gz"), bgzip=True)
+    assert "samtools" not in deps

--- a/tests/test_command_annotate.py
+++ b/tests/test_command_annotate.py
@@ -985,3 +985,79 @@ def test_scaffold_rejects_fastq_input(
     output_lower = result.output.lower()
     assert "fasta" in output_lower
     assert "annotate" in output_lower
+
+
+# --- progress output ----------------------------------------------------
+
+
+def test_annotate_announces_the_run_before_working(
+    cli_with_populated_db: tuple[CliRunner, Path, Path],
+    tmp_path: Path,
+) -> None:
+    """A long run must not present as a blank terminal.
+
+    annotate used to print nothing at all until its closing Wrote: block,
+    which on human-scale input meant ~20 minutes of silence.
+    """
+    runner, db_root, query = cli_with_populated_db
+    outdir = tmp_path / "out"
+    result = runner.invoke(
+        main,
+        [
+            "annotate",
+            "-i",
+            str(query),
+            "-o",
+            str(outdir),
+            "--db-root",
+            str(db_root),
+            "-t",
+            "1",
+            "--no-bgzip",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert "Annotating" in result.output
+    assert query.name in result.output
+    # At least one timed milestone lands before the results. The shape
+    # differs by backend on purpose: HKS reports "[1/6] chromosome" per
+    # feature set, KMC named phases ("k-mer query"), because KMC smooths
+    # every set in one pass and has no per-set moment to count.
+    head = result.output.split("Wrote:")[0]
+    assert result.output.index("Annotating") < result.output.index("Wrote:")
+    assert any(line.startswith("  ") and line.rstrip().endswith("s") for line in head.splitlines())
+
+
+def test_quiet_silences_narration_but_keeps_the_result(
+    cli_with_populated_db: tuple[CliRunner, Path, Path],
+    tmp_path: Path,
+) -> None:
+    """-q suppresses progress, not the list of files produced.
+
+    The Wrote: block is the command's actual output and scripts read it;
+    the narration is the part a quiet run wants gone.
+    """
+    runner, db_root, query = cli_with_populated_db
+    outdir = tmp_path / "out"
+    result = runner.invoke(
+        main,
+        [
+            "-q",
+            "annotate",
+            "-i",
+            str(query),
+            "-o",
+            str(outdir),
+            "--db-root",
+            str(db_root),
+            "-t",
+            "1",
+            "--no-bgzip",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert "Annotating" not in result.output
+    assert "[1/" not in result.output
+    assert "Wrote:" in result.output

--- a/tests/test_diskspace.py
+++ b/tests/test_diskspace.py
@@ -1,0 +1,176 @@
+"""Tests for :mod:`karyoscope.diskspace`.
+
+The behaviour under test is arithmetic and message formatting, so free
+space is stubbed rather than actually exhausted -- filling a real
+filesystem in a test is neither portable nor kind to the machine running
+it.
+"""
+
+from __future__ import annotations
+
+import errno
+from pathlib import Path
+
+import pytest
+
+from karyoscope import diskspace
+from karyoscope.exceptions import InsufficientDiskSpaceError
+
+
+@pytest.fixture
+def stub_free(monkeypatch: pytest.MonkeyPatch):
+    """Return a setter that pins :func:`diskspace.free_bytes` to a value."""
+
+    def _set(n: int) -> None:
+        monkeypatch.setattr(diskspace, "free_bytes", lambda _path: n)
+
+    return _set
+
+
+# --- format_bytes -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("n", "expected"),
+    [
+        (0, "0 B"),
+        (512, "512 B"),
+        (1_500, "1.5 kB"),
+        (2_500_000, "2.5 MB"),
+        (13_337_554_753, "13.3 GB"),  # the real HKS archive
+        (22_695_262_463, "22.7 GB"),  # the real extracted HKS database
+        (2_500 * diskspace.GB, "2.5 TB"),
+    ],
+)
+def test_format_bytes(n: int, expected: str) -> None:
+    assert diskspace.format_bytes(n) == expected
+
+
+# --- free_bytes / _nearest_existing -----------------------------------
+
+
+def test_free_bytes_works_for_a_path_that_does_not_exist_yet(tmp_path: Path) -> None:
+    """An --outdir is routinely checked before it's created."""
+    missing = tmp_path / "not" / "created" / "yet"
+    assert diskspace.free_bytes(missing) > 0
+
+
+def test_nearest_existing_walks_up_to_a_real_directory(tmp_path: Path) -> None:
+    assert diskspace._nearest_existing(tmp_path / "a" / "b" / "c") == tmp_path.resolve()
+
+
+# --- directory_size ---------------------------------------------------
+
+
+def test_directory_size_sums_files_recursively(tmp_path: Path) -> None:
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "a.bin").write_bytes(b"x" * 100)
+    (tmp_path / "sub" / "b.bin").write_bytes(b"y" * 250)
+    assert diskspace.directory_size(tmp_path) == 350
+
+
+def test_directory_size_of_a_missing_directory_is_zero(tmp_path: Path) -> None:
+    assert diskspace.directory_size(tmp_path / "nope") == 0
+
+
+# --- require_free_space -----------------------------------------------
+
+
+def test_require_free_space_passes_when_there_is_room(tmp_path: Path, stub_free) -> None:
+    stub_free(100 * diskspace.GB)
+    diskspace.require_free_space(tmp_path, 10 * diskspace.GB, what="testing")
+
+
+def test_require_free_space_raises_when_short(tmp_path: Path, stub_free) -> None:
+    stub_free(12 * diskspace.GB)
+    with pytest.raises(InsufficientDiskSpaceError) as excinfo:
+        diskspace.require_free_space(tmp_path, 36 * diskspace.GB, what="installing a database")
+    message = str(excinfo.value)
+    assert "installing a database" in message
+    assert "Short by:" in message
+    assert str(tmp_path.resolve()) in message
+
+
+def test_margin_is_applied_on_top_of_the_requirement(tmp_path: Path, stub_free) -> None:
+    """A request that exactly matches free space must still fail.
+
+    Driving a filesystem to precisely zero free bytes is how you get an
+    ENOSPC on the very last write, which is the failure this check exists
+    to avoid -- so "just barely fits" has to count as not fitting.
+    """
+    stub_free(10 * diskspace.GB)
+    with pytest.raises(InsufficientDiskSpaceError):
+        diskspace.require_free_space(
+            tmp_path, 10 * diskspace.GB, what="testing", margin=diskspace.DEFAULT_MARGIN
+        )
+    # ...but with no margin requested, it is allowed through.
+    diskspace.require_free_space(tmp_path, 10 * diskspace.GB, what="testing", margin=0.0)
+
+
+def test_credit_bytes_counts_toward_available(tmp_path: Path, stub_free) -> None:
+    """Space the operation frees first is space the operation can use.
+
+    ``download --force`` removes the old install before fetching the new
+    one, so a same-size reinstall must not be rejected on a full disk.
+    """
+    stub_free(1 * diskspace.GB)
+    with pytest.raises(InsufficientDiskSpaceError):
+        diskspace.require_free_space(tmp_path, 20 * diskspace.GB, what="reinstalling")
+    diskspace.require_free_space(
+        tmp_path, 20 * diskspace.GB, what="reinstalling", credit_bytes=25 * diskspace.GB
+    )
+
+
+def test_skip_bypasses_the_check(tmp_path: Path, stub_free) -> None:
+    """--no-space-check must let a run through even when clearly short."""
+    stub_free(0)
+    diskspace.require_free_space(tmp_path, 100 * diskspace.GB, what="testing", skip=True)
+
+
+def test_estimated_wording_appears_only_when_requested(tmp_path: Path, stub_free) -> None:
+    stub_free(0)
+    with pytest.raises(InsufficientDiskSpaceError) as measured:
+        diskspace.require_free_space(tmp_path, diskspace.GB, what="testing")
+    with pytest.raises(InsufficientDiskSpaceError) as guessed:
+        diskspace.require_free_space(tmp_path, diskspace.GB, what="testing", estimated=True)
+    assert "an estimated" not in str(measured.value)
+    assert "an estimated" in str(guessed.value)
+
+
+def test_hint_is_included_in_the_message(tmp_path: Path, stub_free) -> None:
+    stub_free(0)
+    with pytest.raises(InsufficientDiskSpaceError) as excinfo:
+        diskspace.require_free_space(
+            tmp_path, diskspace.GB, what="testing", hint="Try --outdir elsewhere."
+        )
+    assert "Try --outdir elsewhere." in str(excinfo.value)
+
+
+# --- ENOSPC translation -----------------------------------------------
+
+
+def test_is_enospc_recognises_disk_full_and_quota() -> None:
+    assert diskspace.is_enospc(OSError(errno.ENOSPC, "No space left on device"))
+    assert diskspace.is_enospc(OSError(errno.EDQUOT, "Disk quota exceeded"))
+    assert not diskspace.is_enospc(OSError(errno.ENOENT, "No such file"))
+    assert not diskspace.is_enospc(ValueError("unrelated"))
+
+
+def test_enospc_error_names_the_file_that_failed(tmp_path: Path) -> None:
+    target = tmp_path / "output.bed"
+    exc = OSError(errno.ENOSPC, "No space left on device", str(target))
+    message = str(diskspace.enospc_error(exc, what="annotating"))
+    assert "annotating" in message
+    assert str(target) in message
+
+
+def test_reframe_enospc_passes_other_errors_through_untouched() -> None:
+    """Only disk-full errors get reworded; everything else must not be masked."""
+    original = OSError(errno.EACCES, "Permission denied")
+    assert diskspace.reframe_enospc(original, what="testing") is original
+
+
+def test_reframe_enospc_converts_disk_full() -> None:
+    original = OSError(errno.ENOSPC, "No space left on device")
+    reframed = diskspace.reframe_enospc(original, what="testing")
+    assert isinstance(reframed, InsufficientDiskSpaceError)

--- a/tests/test_download_core.py
+++ b/tests/test_download_core.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from karyoscope import diskspace
 from karyoscope.download import (
     _looks_like_sha256,
     _looks_like_url,
@@ -19,6 +20,7 @@ from karyoscope.exceptions import (
     DatabaseLayoutError,
     FetchError,
     IncompatibleVersionError,
+    InsufficientDiskSpaceError,
 )
 from karyoscope.installed import load
 from karyoscope.registry import DatabaseEntry, TaxonomyEntry
@@ -369,3 +371,126 @@ def test_install_version_compat_fires_before_hygiene(tmp_path: Path) -> None:
     # Compat error fires first.
     with pytest.raises(IncompatibleVersionError, match=r"999\.0\.0"):
         install_database(entry, db_root, show_progress=False)
+
+
+# --- Free-space precheck ------------------------------------------------
+
+
+def test_install_refuses_when_the_database_root_is_too_small(
+    tmp_path: Path,
+    dummy_db_url: str,
+    dummy_db_sha256: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reported bug: a 13 GB download that needs 36 GB of free space.
+
+    The old code only learned this at the very end, when tarfile hit
+    ENOSPC after a 25-minute transfer had already completed.
+    """
+    db_root = tmp_path / "db"
+    entry = _entry_from_dummy(dummy_db_url, dummy_db_sha256, size_gb=22.7, download_size_gb=13.3)
+    monkeypatch.setattr(diskspace, "free_bytes", lambda _p: 12 * 1024**3)
+
+    with pytest.raises(InsufficientDiskSpaceError) as excinfo:
+        install_database(entry, db_root, show_progress=False)
+    message = str(excinfo.value)
+    assert "KS_dummy_test_v1" in message
+    # The peak, not either individual size, is what the user must have free.
+    assert "36" in message or "37" in message
+    assert not is_installed(db_root, entry.id)
+
+
+def test_space_check_is_skippable(
+    tmp_path: Path,
+    dummy_db_url: str,
+    dummy_db_sha256: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--no-space-check exists for entries whose declared sizes are wrong."""
+    db_root = tmp_path / "db"
+    entry = _entry_from_dummy(dummy_db_url, dummy_db_sha256, size_gb=999.0)
+    monkeypatch.setattr(diskspace, "free_bytes", lambda _p: 1024**3)
+
+    target = install_database(entry, db_root, show_progress=False, check_space=False)
+    assert target.is_dir()
+    assert is_installed(db_root, entry.id)
+
+
+def test_space_check_runs_before_an_existing_install_is_removed(
+    tmp_path: Path,
+    dummy_db_url: str,
+    dummy_db_sha256: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A doomed --force reinstall must not destroy the working install first.
+
+    install_database rmtree's the target directory before downloading, so
+    ordering the check after it would leave a user with neither the old
+    database nor the new one.
+    """
+    db_root = tmp_path / "db"
+    entry = _entry_from_dummy(dummy_db_url, dummy_db_sha256)
+    install_database(entry, db_root, show_progress=False)
+    target = db_root / entry.id
+    assert target.is_dir()
+
+    huge = _entry_from_dummy(dummy_db_url, dummy_db_sha256, size_gb=999.0)
+    monkeypatch.setattr(diskspace, "free_bytes", lambda _p: 1024**3)
+    with pytest.raises(InsufficientDiskSpaceError):
+        install_database(huge, db_root, show_progress=False, force=True)
+
+    assert target.is_dir(), "the existing install was destroyed by a check that came too late"
+    assert is_installed(db_root, entry.id)
+
+
+def test_space_check_credits_the_install_being_replaced(
+    tmp_path: Path,
+    dummy_db_url: str,
+    dummy_db_sha256: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reinstalling the same database frees its own space first.
+
+    Without the credit, `--force` on a nearly-full disk would be rejected
+    even though the replacement is the same size as what it removes.
+    """
+    db_root = tmp_path / "db"
+    entry = _entry_from_dummy(dummy_db_url, dummy_db_sha256)
+    install_database(entry, db_root, show_progress=False)
+    existing = diskspace.directory_size(db_root / entry.id)
+    assert existing > 0
+
+    # Free space is zero; only the credit for the outgoing install can
+    # make room for the incoming one.
+    big = _entry_from_dummy(
+        dummy_db_url,
+        dummy_db_sha256,
+        size_gb=existing / diskspace.GB / 4,
+        download_size_gb=existing / diskspace.GB / 4,
+    )
+    monkeypatch.setattr(diskspace, "free_bytes", lambda _p: 0)
+    install_database(big, db_root, show_progress=False, force=True)
+    assert is_installed(db_root, entry.id)
+
+
+def test_enospc_during_extraction_is_reported_as_a_space_problem(
+    tmp_path: Path,
+    dummy_db_url: str,
+    dummy_db_sha256: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A disk that fills up mid-extract must not surface as a tarfile traceback."""
+    import errno
+
+    from karyoscope import download as download_module
+
+    db_root = tmp_path / "db"
+    entry = _entry_from_dummy(dummy_db_url, dummy_db_sha256)
+
+    def boom(*_args: object, **_kwargs: object) -> Path:
+        raise OSError(errno.ENOSPC, "No space left on device", str(db_root / "x"))
+
+    monkeypatch.setattr(download_module, "_safe_extract_tar", boom)
+    with pytest.raises(InsufficientDiskSpaceError) as excinfo:
+        install_database(entry, db_root, show_progress=False)
+    assert "ran out of disk space" in str(excinfo.value)

--- a/tests/test_download_core.py
+++ b/tests/test_download_core.py
@@ -494,3 +494,140 @@ def test_enospc_during_extraction_is_reported_as_a_space_problem(
     with pytest.raises(InsufficientDiskSpaceError) as excinfo:
         install_database(entry, db_root, show_progress=False)
     assert "ran out of disk space" in str(excinfo.value)
+
+
+# --- Archive reuse after a failed install -------------------------------
+
+
+def _staged(db_root: Path, db_id: str = "KS_dummy_test_v1") -> Path:
+    from karyoscope.download import staged_archive_path
+
+    return staged_archive_path(db_root, db_id)
+
+
+def test_failed_extraction_keeps_the_downloaded_archive(
+    tmp_path: Path,
+    dummy_db_url: str,
+    dummy_db_sha256: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reported bug: a failed extraction cost a second full download.
+
+    The archive used to be removed in a `finally`, so a run that got all
+    the way through a 25-minute transfer and then hit ENOSPC during
+    extraction left nothing to resume from.
+    """
+    import errno
+
+    from karyoscope import download as download_module
+
+    db_root = tmp_path / "db"
+    entry = _entry_from_dummy(dummy_db_url, dummy_db_sha256)
+
+    def boom(*_args: object, **_kwargs: object) -> Path:
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    monkeypatch.setattr(download_module, "_safe_extract_tar", boom)
+    with pytest.raises(InsufficientDiskSpaceError):
+        install_database(entry, db_root, show_progress=False)
+
+    assert _staged(db_root).is_file(), "the verified archive was discarded on failure"
+
+
+def test_a_retry_reuses_the_staged_archive_instead_of_downloading(
+    tmp_path: Path,
+    dummy_db_url: str,
+    dummy_db_sha256: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After the failure above, re-running must not re-fetch."""
+    import errno
+
+    from karyoscope import download as download_module
+
+    db_root = tmp_path / "db"
+    entry = _entry_from_dummy(dummy_db_url, dummy_db_sha256)
+
+    real_extract = download_module._safe_extract_tar
+
+    def boom(*_args: object, **_kwargs: object) -> Path:
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    monkeypatch.setattr(download_module, "_safe_extract_tar", boom)
+    with pytest.raises(InsufficientDiskSpaceError):
+        install_database(entry, db_root, show_progress=False)
+
+    # Second attempt: extraction works again, but any fetch is a failure.
+    monkeypatch.setattr(download_module, "_safe_extract_tar", real_extract)
+
+    def no_fetching(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("re-downloaded an archive that was already on disk")
+
+    monkeypatch.setattr(download_module, "fetch", no_fetching)
+    target = install_database(entry, db_root, show_progress=False)
+
+    assert target.is_dir()
+    assert is_installed(db_root, entry.id)
+    # A successful install disposes of the archive; only failure keeps it.
+    assert not _staged(db_root).exists()
+
+
+def test_a_corrupt_staged_archive_is_discarded_and_refetched(
+    tmp_path: Path,
+    dummy_db_url: str,
+    dummy_db_sha256: str,
+) -> None:
+    """Reuse is gated on the checksum, not merely on the file existing.
+
+    A truncated leftover must not be extracted as if it were complete.
+    """
+    db_root = tmp_path / "db"
+    db_root.mkdir(parents=True)
+    _staged(db_root).write_bytes(b"this is not the archive you are looking for")
+
+    entry = _entry_from_dummy(dummy_db_url, dummy_db_sha256)
+    target = install_database(entry, db_root, show_progress=False)
+
+    assert target.is_dir()
+    assert is_installed(db_root, entry.id)
+
+
+def test_partially_extracted_directory_is_removed_on_failure(
+    tmp_path: Path,
+    dummy_db_url: str,
+    dummy_db_sha256: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Half an extracted database is unusable and, on ENOSPC, in the way.
+
+    It occupies exactly the space the retry needs, and the next attempt
+    deletes it regardless.
+    """
+    import errno
+
+    from karyoscope import download as download_module
+
+    db_root = tmp_path / "db"
+    entry = _entry_from_dummy(dummy_db_url, dummy_db_sha256)
+    target_dir = db_root / entry.id
+
+    def half_extract(*_args: object, **_kwargs: object) -> Path:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        (target_dir / "manifest.yaml").write_bytes(b"x" * 4096)
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    monkeypatch.setattr(download_module, "_safe_extract_tar", half_extract)
+    with pytest.raises(InsufficientDiskSpaceError):
+        install_database(entry, db_root, show_progress=False)
+
+    assert not target_dir.exists(), "partial extraction left gigabytes behind"
+    assert _staged(db_root).is_file(), "the archive should still be reusable"
+
+
+def test_a_successful_install_removes_the_archive(
+    tmp_path: Path, dummy_db_url: str, dummy_db_sha256: str
+) -> None:
+    db_root = tmp_path / "db"
+    entry = _entry_from_dummy(dummy_db_url, dummy_db_sha256)
+    install_database(entry, db_root, show_progress=False)
+    assert not _staged(db_root).exists()

--- a/tests/test_karyotype.py
+++ b/tests/test_karyotype.py
@@ -1200,3 +1200,86 @@ class TestColorsFilenameTag:
         assert _colors_filename_tag(Path("/x/colors_chromosome.tsv")) == ".colors_chromosome"
         # A custom file and the default produce different tags -> different filenames.
         assert _colors_filename_tag(Path("/x/my_palette.tsv")) != _colors_filename_tag(None)
+
+
+# --- scaffolding prerequisite note --------------------------------------
+
+
+def test_prereq_note_names_the_role_set_pulled_in_by_scaffolding() -> None:
+    """Asking for 2 feature sets and seeing annotate report 3 is baffling.
+
+    Scaffolding needs the chromosome- and region-assignment sets to place
+    and orient contigs regardless of what is being plotted, so the count
+    in the progress output exceeds --feature-set. The note explains which
+    extra set appeared and why.
+    """
+    from karyoscope.core.karyotype_run import _scaffolding_prereq_note
+
+    note = _scaffolding_prereq_note(
+        requested=["chromosome", "repeat"],
+        scaffold_manifest_roles={
+            "chromosome_assignment": "chromosome",
+            "region_assignment": "region",
+        },
+        scaffold_available=["chromosome", "region", "repeat"],
+        centromere_fs=None,
+        scaffold_db_id=None,
+    )
+    assert "region" in note
+    assert "not rendered" in note
+    # The already-requested role set must not be listed as an extra.
+    assert "chromosome" not in note
+
+
+def test_prereq_note_is_empty_when_the_roles_were_requested() -> None:
+    """No note when nothing extra is pulled in -- keep the common case clean."""
+    from karyoscope.core.karyotype_run import _scaffolding_prereq_note
+
+    assert (
+        _scaffolding_prereq_note(
+            requested=["chromosome", "region"],
+            scaffold_manifest_roles={
+                "chromosome_assignment": "chromosome",
+                "region_assignment": "region",
+            },
+            scaffold_available=["chromosome", "region"],
+            centromere_fs=None,
+            scaffold_db_id=None,
+        )
+        == ""
+    )
+
+
+def test_prereq_note_includes_the_centromere_set_and_names_a_layout_db() -> None:
+    from karyoscope.core.karyotype_run import _scaffolding_prereq_note
+
+    note = _scaffolding_prereq_note(
+        requested=["cytoband"],
+        scaffold_manifest_roles={
+            "chromosome_assignment": "chromosome",
+            "region_assignment": "region",
+        },
+        scaffold_available=["chromosome", "region"],
+        centromere_fs="region",
+        scaffold_db_id="KS_human_CHM13_v2",
+    )
+    assert "chromosome, region" in note
+    assert "KS_human_CHM13_v2" in note
+    # centromere_fs duplicates region_assignment here; it must not repeat.
+    assert note.count("region") == 1
+
+
+def test_prereq_note_stays_silent_when_roles_cannot_be_resolved() -> None:
+    """A plot-only database has no roles; that is the cascade's error to report."""
+    from karyoscope.core.karyotype_run import _scaffolding_prereq_note
+
+    assert (
+        _scaffolding_prereq_note(
+            requested=["cytoband"],
+            scaffold_manifest_roles={},
+            scaffold_available=["cytoband"],
+            centromere_fs=None,
+            scaffold_db_id=None,
+        )
+        == ""
+    )

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,141 @@
+"""Tests for :mod:`karyoscope.preflight`.
+
+The point of this module is that it must agree with the backends about
+what "installed" means -- a second, simpler lookup here would reject
+working installs. Several tests below pin that agreement.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from karyoscope import preflight
+from karyoscope.exceptions import MissingDependencyError
+
+# --- resolve_binary ---------------------------------------------------
+
+
+def test_resolve_binary_finds_something_on_path() -> None:
+    # Not a KaryoScope dependency, but guaranteed present and not in the
+    # resolver table, so it exercises the plain $PATH branch.
+    assert preflight.resolve_binary("python") is not None
+
+
+def test_resolve_binary_returns_none_for_a_missing_tool() -> None:
+    assert preflight.resolve_binary("karyoscope_definitely_not_a_real_tool") is None
+
+
+def test_resolve_binary_delegates_to_the_backend_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``hks`` and ``get_featureIDs`` must not be resolved with a bare which().
+
+    Both accept an environment override, and ``get_featureIDs`` also
+    resolves out of the source tree for editable installs. Re-implementing
+    that here would report "not installed" for a perfectly good install.
+    """
+    assert "hks" in preflight._RESOLVERS
+    assert "get_featureIDs" in preflight._RESOLVERS
+
+    called: list[str] = []
+
+    def fake() -> str:
+        called.append("hks")
+        return "/somewhere/hks"
+
+    monkeypatch.setitem(preflight._RESOLVERS, "hks", fake)
+    assert preflight.resolve_binary("hks") == "/somewhere/hks"
+    assert called == ["hks"]
+
+
+def test_resolve_binary_treats_a_raising_resolver_as_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom() -> str:
+        raise RuntimeError("not found")
+
+    monkeypatch.setitem(preflight._RESOLVERS, "hks", boom)
+    assert preflight.resolve_binary("hks") is None
+
+
+def test_get_featureids_resolves_from_the_source_tree() -> None:
+    """Regression: an editable install has no get_featureIDs on $PATH.
+
+    It lives at ``native/get_featureIDs/build/get_featureIDs`` instead. A
+    preflight that only checked $PATH blocked every source install.
+    """
+    from karyoscope.core.io import kmc
+
+    try:
+        expected = kmc.get_featureids_binary()
+    except Exception:
+        pytest.skip("get_featureIDs is not built in this checkout")
+    assert preflight.resolve_binary("get_featureIDs") == expected
+
+
+# --- check / require --------------------------------------------------
+
+
+def test_check_reports_only_the_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        preflight, "resolve_binary", lambda name: None if name == "seqtk" else "/bin/" + name
+    )
+    missing = preflight.check(["bgzip", "seqtk", "tabix"])
+    assert [d.name for d in missing] == ["seqtk"]
+
+
+def test_check_ignores_unknown_names() -> None:
+    """An unrecognised key is a KaryoScope bug, not a user dependency problem."""
+    assert preflight.check(["not_a_dependency"]) == []
+
+
+def test_require_is_silent_when_everything_is_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(preflight, "resolve_binary", lambda name: "/bin/" + name)
+    preflight.require(["bgzip", "seqtk"], context="testing")
+
+
+def test_require_reports_every_missing_dependency_at_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One message, not one per rerun.
+
+    Discovering missing tools one at a time means a user pays a full
+    pipeline run for each.
+    """
+    monkeypatch.setattr(preflight, "resolve_binary", lambda name: None)
+    with pytest.raises(MissingDependencyError) as excinfo:
+        preflight.require(["bgzip", "seqtk", "samtools"], context="annotate against DB_x")
+    message = str(excinfo.value)
+    assert "annotate against DB_x" in message
+    for name in ("bgzip", "seqtk", "samtools"):
+        assert name in message
+    # Each one carries an actionable install hint.
+    assert message.count("conda install") >= 3
+
+
+def test_require_mentions_karyoscope_version_for_diagnosis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(preflight, "resolve_binary", lambda name: None)
+    with pytest.raises(MissingDependencyError) as excinfo:
+        preflight.require(["bgzip"], context="testing")
+    assert "karyoscope version" in str(excinfo.value)
+
+
+def test_python_dependencies_are_checked_by_import_not_path() -> None:
+    """cairosvg is a Python package; $PATH would never find it."""
+    assert preflight.DEPENDENCIES["cairosvg"].kind == "python"
+    # click is definitely importable, so the python branch resolves it.
+    assert preflight._python_available(
+        preflight.Dependency(name="click", kind="python", purpose="x", install_hint="y")
+    )
+    assert not preflight._python_available(
+        preflight.Dependency(
+            name="no_such_module_xyz", kind="python", purpose="x", install_hint="y"
+        )
+    )
+
+
+def test_every_dependency_declares_a_kind_and_a_hint() -> None:
+    for name, dep in preflight.DEPENDENCIES.items():
+        assert dep.name == name
+        assert dep.kind in ("binary", "python")
+        assert dep.purpose and dep.install_hint

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,142 @@
+"""Tests for :mod:`karyoscope.progress`."""
+
+from __future__ import annotations
+
+import io
+
+from karyoscope.progress import SILENT, Progress, format_duration
+
+
+def _reporter() -> tuple[Progress, io.StringIO]:
+    buf = io.StringIO()
+    return Progress(stream=buf), buf
+
+
+# --- format_duration --------------------------------------------------
+
+
+def test_format_duration_keeps_a_decimal_under_a_minute() -> None:
+    assert format_duration(0.4) == "0.4s"
+    assert format_duration(24.94) == "24.9s"
+
+
+def test_format_duration_switches_to_minutes_and_zero_pads_seconds() -> None:
+    assert format_duration(60) == "1m00s"
+    assert format_duration(245.3) == "4m05s"
+
+
+def test_format_duration_switches_to_hours() -> None:
+    assert format_duration(3600) == "1h00m"
+    assert format_duration(3720) == "1h02m"
+
+
+# --- basic emission ---------------------------------------------------
+
+
+def test_start_writes_a_headline_and_indented_details() -> None:
+    p, buf = _reporter()
+    p.start("Annotating x.fa against DB", "6 feature set(s), 16 threads")
+    assert buf.getvalue() == "Annotating x.fa against DB\n  6 feature set(s), 16 threads\n"
+
+
+def test_empty_details_are_skipped() -> None:
+    p, buf = _reporter()
+    p.start("Headline", "")
+    assert buf.getvalue() == "Headline\n"
+
+
+def test_step_numbers_and_pads_to_the_longest_label() -> None:
+    p, buf = _reporter()
+    tracker = p.track(["chromosome", "gene"])
+    tracker.step("chromosome", 245.3)
+    tracker.step("gene", 12.0)
+    assert buf.getvalue() == ("  [1/2] chromosome  4m05s\n  [2/2] gene        12.0s\n")
+
+
+def test_stage_has_no_counter() -> None:
+    """The KMC backend has phases, not a countable sequence of equals."""
+    p, buf = _reporter()
+    p.stage("k-mer query", 50.0)
+    assert buf.getvalue() == "  k-mer query  50.0s\n"
+
+
+def test_note_is_untimed() -> None:
+    p, buf = _reporter()
+    p.note("reusing the combined BED from a previous run")
+    assert buf.getvalue() == "  reusing the combined BED from a previous run\n"
+
+
+# --- disabled reporter ------------------------------------------------
+
+
+def test_disabled_reporter_writes_nothing() -> None:
+    buf = io.StringIO()
+    p = Progress(enabled=False, stream=buf)
+    p.start("Headline", "detail")
+    p.track(["a"]).step("a", 1.0)
+    p.stage("phase", 1.0)
+    p.note("note")
+    assert buf.getvalue() == ""
+
+
+def test_silent_is_disabled() -> None:
+    """core defaults to SILENT so importing KaryoScope never prints."""
+    assert SILENT.enabled is False
+
+
+def test_child_of_a_disabled_reporter_stays_disabled() -> None:
+    """--quiet must survive the cascade, not just the outermost command."""
+    assert Progress(enabled=False).child().enabled is False
+
+
+# --- nesting ----------------------------------------------------------
+
+
+def test_nested_trackers_keep_separate_counters() -> None:
+    """Regression: a nested sequence used to clobber the outer counter.
+
+    ``karyotype`` tracks its renders, then calls ``annotate`` part-way
+    through, which tracks its feature sets. With one shared counter the
+    outer sequence resumed from the inner one's index against the inner
+    one's total and printed impossible lines like ``[4/3]``.
+    """
+    p, buf = _reporter()
+    outer = p.track(["genome/chromosome", "genome/repeat"])
+    inner = p.child().track(["chromosome", "repeat", "region"])
+    for label in ("chromosome", "repeat", "region"):
+        inner.step(label, 1.0)
+    outer.step("genome/chromosome", 1.0)
+    outer.step("genome/repeat", 1.0)
+
+    lines = buf.getvalue().splitlines()
+    assert [line.strip().split()[0] for line in lines] == [
+        "[1/3]",
+        "[2/3]",
+        "[3/3]",
+        "[1/2]",
+        "[2/2]",
+    ]
+
+
+def test_child_indents_one_level_deeper() -> None:
+    p, buf = _reporter()
+    p.start("Rendering karyotypes", "2 render(s)")
+    child = p.child()
+    child.start("Annotating", "3 feature set(s)")
+    child.track(["chromosome"]).step("chromosome", 1.0)
+    p.track(["genome/chromosome"]).step("genome/chromosome", 1.0)
+
+    assert buf.getvalue() == (
+        "Rendering karyotypes\n"
+        "  2 render(s)\n"
+        "  Annotating\n"
+        "    3 feature set(s)\n"
+        "    [1/1] chromosome  1.0s\n"
+        "  [1/1] genome/chromosome  1.0s\n"
+    )
+
+
+def test_track_of_an_empty_sequence_does_not_crash() -> None:
+    p, buf = _reporter()
+    p.track([])
+    assert buf.getvalue() == ""

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -282,3 +282,46 @@ def test_load_registry_with_real_test_registry(dummy_registry_url: str, tmp_path
     reg = load_registry(db_root, dummy_registry_url)
     assert reg.find("KS_dummy_test_v1") is not None
     assert reg.default_database().id == "KS_dummy_test_v1"
+
+
+# --- size accounting --------------------------------------------------
+
+
+def test_size_gb_is_the_installed_size_and_download_falls_back_to_it() -> None:
+    """An entry without ``download_size_gb`` still yields usable numbers.
+
+    Older registry entries (and any cached copy fetched before the field
+    existed) only carry ``size_gb``. Rather than fail, both accessors
+    collapse onto it -- and say so, so callers can flag the peak figure as
+    a guess rather than a measurement.
+    """
+    entry = parse_registry(_MINIMAL_REGISTRY).find("KS_test_v1")
+    assert entry.installed_size_bytes == 17_000_000_000
+    assert entry.download_size_bytes == 17_000_000_000
+    assert entry.download_size_is_declared is False
+
+
+def test_explicit_download_size_is_used_when_declared() -> None:
+    """The real HKS entry: a 13.3 GB archive that unpacks to 22.7 GB.
+
+    Reporting only the download size is what let a user with 12 GB free
+    start a 25-minute install that could never have finished.
+    """
+    text = _MINIMAL_REGISTRY.replace(
+        "    size_gb: 17.0\n", "    size_gb: 22.7\n    download_size_gb: 13.3\n"
+    )
+    entry = parse_registry(text).find("KS_test_v1")
+    assert entry.download_size_is_declared is True
+    assert entry.download_size_bytes == 13_300_000_000
+    assert entry.installed_size_bytes == 22_700_000_000
+    # Both coexist on disk until extraction succeeds.
+    assert entry.peak_install_bytes == 36_000_000_000
+
+
+def test_download_size_gb_must_be_a_non_negative_number() -> None:
+    for bad in ('"lots"', "-1"):
+        text = _MINIMAL_REGISTRY.replace(
+            "    size_gb: 17.0\n", f"    size_gb: 17.0\n    download_size_gb: {bad}\n"
+        )
+        with pytest.raises(RegistryError, match="download_size_gb"):
+            parse_registry(text)


### PR DESCRIPTION
Fixes two user-reported failures, both of which were knowable in advance and both of which surfaced as a bare traceback.

## The reports

**1.** `karyoscope download HKS_human_CHM13_v2` — 25 minutes of download, then `OSError: [Errno 28] No space left on device` out of `tarfile.copyfileobj`. The user had 12 GB free and the CLI had told them the database was "13.3 GB".

**2.** `karyoscope annotate --input hg002v1.1.fasta.gz --threads 16 --no-bgzip` — same errno, 19 minutes in, from the BED writer in `convert_hks_tsv_to_bed`.

The `ModuleNotFoundError: matplotlib` in the second report is unrelated: it's `psrecord` failing at `--plot`, after annotate had already exited. KaryoScope never imports matplotlib, so `environment.yml` is unchanged.

## Root cause of #1

`size_gb` in the registry meant *extracted* for the KMC entry and *archive* for the HKS entry. And neither is the requirement — the archive isn't deleted until extraction succeeds, so both are on disk at once. Measured:

| Database | Download | Extracted | **Free space to install** |
|---|---|---|---|
| `KS_human_CHM13_v2` | 16.3 GB | 17.2 GB | **~34 GB** |
| `HKS_human_CHM13_v2` | 13.3 GB | **22.7 GB** | **~36 GB** |

Note the inversion: the HKS archive is the *smaller* download but the *larger* install.

## Disk-space preflight

New `karyoscope.diskspace`. `download` now fails in a second, before transferring anything:

```
Error: not enough free disk space for installing HKS_human_CHM13_v2.
  Needs:     37.8 GB (includes a 5% safety margin)
  Available: 12.9 GB on /Users/fbarthel/.karyoscope/db
  Short by:  24.9 GB

Free up space, or install elsewhere with:
    karyoscope download --db-root /path/on/a/larger/disk HKS_human_CHM13_v2
  (set $KARYOSCOPE_DB to that path to make it the default).
  Pass --no-space-check to attempt the install anyway.
```

Two placement details that are load-bearing and have tests pinning them:

- the check runs **before** the `rmtree` of an existing install, so a doomed reinstall can't leave you with neither the old database nor the new one;
- it **credits back** space the run frees first — a resumable `.part` file, and any install being replaced — so `--force` on a nearly-full disk isn't rejected for a same-size reinstall.

`annotate` estimates its footprint and checks `--outdir`. Calibrated against the measured HG002 v1.1 run (6.00 Gbp, 6 sets): **0.60 bytes of presmoothed and 0.20 bytes of smoothed BED per input base per feature set**, plus a transient allowance for the largest single lookup TSV. Predicts **34.2 GB against 34.4 GB measured**. Input size comes from a sibling `.fai` when one exists (exact — HG002 ships one), otherwise from file size scaled by format and a measured 3.4x gzip expansion.

Any `ENOSPC` that still escapes — from any command — is caught at the CLI group and reworded to name the filesystem that filled up.

## Dependency preflight

New `karyoscope.preflight`. Commands resolve the tools they'll actually need up front and report **every** missing one at once, instead of one per rerun at the point of use:

```
Error: missing required dependency for annotate against HKS_arabidopsis_ColCEN:

  hks — not found on $PATH (needed for querying and building HKS-backend databases)
    Build it from source and put it on PATH:
        git clone --recurse-submodules https://github.com/jnalanko/HKS.git
        cargo install --path HKS --root "$CONDA_PREFIX"
      or set $KARYOSCOPE_HKS to an existing hks binary.
```

`karyotype` additionally checks `cairosvg` when `--format pdf/png` is requested and `seqtk` when telomere detection will be auto-run — both previously surfaced only after the entire cascade had already succeeded.

Resolution delegates to each backend's own lookup order rather than reimplementing it. **The integration suite caught a real bug here**: my first version used a plain `shutil.which` and rejected the source-tree `get_featureIDs` that every editable install relies on. `karyoscope version` now uses the same resolver, so it no longer reports "not found on PATH" for a working install, and lists `get_featureIDs` (previously omitted entirely).

## Registry

Reads a new optional `download_size_gb`, with `size_gb` now defined as the extracted size. Entries without it fall back to `size_gb` for both and are labelled as estimates, so community entries and stale caches keep working. **Depends on barthel-lab/KaryoScope-registry#4** for the real values — this PR is safe to merge first, it just falls back until that lands.

## Docs

README + `download`/`annotate` command pages gain Disk space sections with the table above and annotation footprint guidance. Documents the non-obvious bit: **`--bgzip` shrinks the result but not the peak**, because compression only runs once every BED has been written in full.

## Testing

769 pass, including the integration set (`pytest -m ""`); `ruff check` and `ruff format --check` clean. 60 new tests across `test_diskspace.py`, `test_preflight.py`, `test_annotate_footprint.py`, plus additions to `test_download_core.py` and `test_registry.py`. The footprint test pins the estimate against the real HG002 measurement so the constants can't silently drift.

Verified live against `HKS_arabidopsis_ColCEN`: the missing-dependency path, the footprint log line, and a normal run completing unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)