### PR TITLE
perf(hks): let hks write KaryoScope's BED directly, deleting the conversion pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A BAM input to `annotate` (HKS backend) is converted to FASTA once**,
   shared by every feature set's lookup, instead of once per feature set.
 
+- **`hks` now writes KaryoScope's BED files directly, and the conversion pass
+  is gone.** `convert_hks_tsv_to_bed` ran twice per feature set — on the raw
+  lookup output and again inside `run_hks_smooth` — and never actually
+  converted a format: the lookup TSV is already BED-shaped, so all it did was
+  drop the header line and rewrite `none` to `novel`. `hks` 0.3.0 can be asked
+  for both directly (`--miss-label`, `--no-header`), so both passes were
+  deleted. Per feature set that removes **two ~5 GB reads and two ~5 GB
+  writes**, on a pass measured between 9.5 s (fast local disk) and 21.0 s
+  (cluster `/scratch`).
+
+  It also **roughly halves peak temp disk** for an HKS run: the raw lookup
+  output and the presmoothed BED were two near-identical multi-gigabyte copies
+  of the same data, and now there is one file that `hks smooth` reads in place.
+  A six-set HG002 run peaks at ~29 GB rather than ~34 GB, and the disk-space
+  preflight no longer charges HKS runs for an intermediate that no longer
+  exists.
+
+  Verified byte-identical against the previous two-step pipeline on a real
+  index, for both the presmoothed and the smoothed BED.
+- **`annotate` requires `hks` >= 0.3.0**, checked before the run starts. `hks`
+  has no `--version` flag, so KaryoScope reads the version it logs on startup.
+  The check fails open — an unreadable version is not treated as too old — but
+  a readable, too-old one stops the run with an upgrade message instead of
+  letting it die partway through on `unexpected argument '--miss-label'`.
+- **`annotate` reports per-phase timing, bytes and peak memory.** Each `hks`
+  lookup and smooth logs its own wall time, output size and throughput, and
+  peak memory is reported from `ru_maxrss` across the `hks` processes — where
+  it actually lives. Previously one elapsed time per feature set covered both
+  phases, which cannot attribute a change to either. `hks` 0.3.0 likewise
+  times its base-index and labeling loads separately rather than reporting one
+  combined figure.
+
 ### Fixed
 
 - **The `samtools | get_featureIDs` BAM pipeline can no longer deadlock on a

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A pre-built database for the human genome is distributed alongside the tool, der
 | C++20 compiler | building the bundled `get_featureIDs` helper | GCC ≥ 11 or Clang ≥ 13 (Apple Clang) |
 | `bgzip`, `tabix` (htslib) | compressing and indexing BED output | 1.22.1 |
 | seqtk | telomere detection (`scaffold`, `centromeres`, `karyotype`) | 1.5 |
-| [`hks`](https://github.com/jnalanko/HKS) | building databases with `karyoscope build`, and annotating against HKS-backend databases (e.g. `HKS_human_CHM13_v2`) | 0.4.0 |
+| [`hks`](https://github.com/jnalanko/HKS) | building databases with `karyoscope build`, and annotating against HKS-backend databases (e.g. `HKS_human_CHM13_v2`) | **0.3.0 or newer** |
 | KMC | building a *KMC-backend* database (legacy — `karyoscope build` produces HKS databases). Not needed to *use* a pre-built KMC database; the bundled `get_featureIDs` helper queries its index directly | 3.2.x (vendored API 3.2.4) |
 | libcairo | rendering `--format pdf` / `--format png` | any recent release |
 | samtools | BAM input to `annotate`, and `karyoscope build` when the genome has no `.fai` index yet | 1.22.1 |
@@ -92,14 +92,16 @@ Size tracks the genome, not the tool: the 135 Mb *Arabidopsis* database installs
 
 `karyoscope download` checks free space before it starts transferring anything and refuses with the shortfall spelled out rather than failing after a 25-minute download. `karyoscope download --info <ID>` prints all three figures for any database. Sizes here are decimal GB (10⁹ bytes); `df -h` reports binary GiB, so 36 GB shows there as 34 GiB.
 
-**Annotation output** is also substantial, and `--bgzip` does not reduce the peak — every BED is written in full before the compression pass runs. Budget roughly **0.8 GB per feature set per Gbp of input**, plus one intermediate:
+**Annotation output** is also substantial, and `--bgzip` does not reduce the peak — every BED is written in full before the compression pass runs. Budget roughly **0.8 GB per feature set per Gbp of input**:
 
-| Input | Feature sets | Output BEDs (uncompressed) | Peak including intermediate |
-|---|---|---|---|
-| Single human haplotype (~3.1 Gbp) | 6 | ~15 GB | ~18 GB |
-| Diploid assembly, e.g. HG002 v1.1 (~6.0 Gbp) | 6 | ~29 GB | ~34 GB |
+| Input | Feature sets | Output BEDs (uncompressed) | Peak (HKS backend) | Peak (KMC backend) |
+|---|---|---|---|---|
+| Single human haplotype (~3.1 Gbp) | 6 | ~15 GB | ~15 GB | ~18 GB |
+| Diploid assembly, e.g. HG002 v1.1 (~6.0 Gbp) | 6 | ~29 GB | ~29 GB | ~34 GB |
 
-Measured on HG002 v1.1 against `HKS_human_CHM13_v2`. Restricting `--feature-set`, or dropping one output variant with `--no-keep-presmoothed` / `--no-smooth`, scales this down proportionally. `annotate` estimates the footprint from the input size and checks `--outdir` before starting; pass `--no-space-check` to override the estimate.
+Measured on HG002 v1.1 against `HKS_human_CHM13_v2`. An HKS run needs no headroom beyond its outputs: `hks lookup` writes the presmoothed BED directly, so no intermediate copy of it ever exists. (Under `--no-keep-presmoothed` that file becomes a temp one, and the KMC column applies instead.) The KMC backend still writes a combined intermediate BED alongside.
+
+Restricting `--feature-set`, or dropping one output variant with `--no-keep-presmoothed` / `--no-smooth`, scales this down proportionally. `annotate` estimates the footprint from the input size and checks `--outdir` before starting; pass `--no-space-check` to override the estimate.
 
 ## Installation
 
@@ -145,6 +147,14 @@ cargo install --path HKS --root "$CONDA_PREFIX"   # installs $CONDA_PREFIX/bin/h
 
 KaryoScope finds `hks` on `PATH` automatically (or set `$KARYOSCOPE_HKS` to its
 path). A future release will bundle `hks` via conda so this step goes away.
+
+**`hks` 0.3.0 or newer is required.** KaryoScope asks `hks` to write its output
+in the exact shape it needs — headerless, with `novel` for k-mers absent from
+the index — which removes a full read and a full write of a multi-gigabyte file
+per feature set. The options that do this (`--miss-label`, `--no-header`,
+`--report-label-ids` on `smooth`) landed in 0.3.0. KaryoScope reads the version
+`hks` logs on startup and refuses to begin against an older one, rather than
+failing partway through with an unrecognised-argument error.
 
 #### KMC
 

--- a/src/karyoscope/core/annotate.py
+++ b/src/karyoscope/core/annotate.py
@@ -1016,47 +1016,6 @@ def _rate(nbytes: int, seconds: float) -> str:
     return f"{nbytes / 1024**3 / seconds:.2f} GB/s"
 
 
-def _bgzip_file(path: Path, threads: int = 1) -> Path:
-    """Compress ``path`` in-place with ``bgzip``, returning the new path.
-
-    ``bgzip`` removes the source file by default (matches gzip's behaviour).
-    Returns ``Path(str(path) + ".gz")``. Logs per-file start + completion
-    at INFO so a long bgzip pass (12 files for a 6-feature-set human
-    database) doesn't look like the pipeline has hung.
-
-    ``threads`` is forwarded as ``bgzip -@``; the htslib bgzip compresses
-    a single file in parallel when given more than one thread. We
-    process files sequentially within the bgzip pass, so passing the
-    user's full ``--threads`` here is the right call (no contention
-    with concurrent file compressions). ``threads=1`` (the default)
-    omits ``-@`` entirely for cleanest subprocess invocation.
-    """
-    bgzip = require_tool(
-        "bgzip",
-        install_hint="Install htslib (`conda install -c bioconda htslib`), "
-        "or rerun with --no-bgzip to skip compression.",
-    )
-    orig_size = path.stat().st_size
-    logger.info("bgzipping %s (%s, threads=%d)", path.name, _human_bytes(orig_size), threads)
-    t0 = time.perf_counter()
-    cmd = [bgzip, "-f"]
-    if threads > 1:
-        cmd.extend(["-@", str(threads)])
-    cmd.append(str(path))
-    run_tool(cmd)
-    out_path = Path(str(path) + ".gz")
-    out_size = out_path.stat().st_size if out_path.is_file() else 0
-    dt = time.perf_counter() - t0
-    logger.info(
-        "bgzipped %s (%s -> %s) in %.1fs",
-        out_path.name,
-        _human_bytes(orig_size),
-        _human_bytes(out_size),
-        dt,
-    )
-    return out_path
-
-
 # --- HKS backend ------------------------------------------------------
 
 
@@ -1160,12 +1119,17 @@ def _run_hks_backend(
             # smooth a largely serial pass over what it wrote -- so a single
             # per-feature-set number cannot say which of them a change moved.
             lookup_bytes = lookup_out.stat().st_size
+            # Deliberately no throughput here. A lookup's time is dominated by
+            # loading the index and querying the input, not by writing its
+            # output, so output-bytes-per-second would be a rate of nothing --
+            # it read 0.02 GB/s on a real run purely because the index load is
+            # large and the BED is small. `hks -vv` reports the phases that do
+            # have meaningful rates.
             logger.info(
-                "hks lookup for %r wrote %s in %.1fs (%s)",
+                "hks lookup for %r wrote %s in %.1fs",
                 fs,
                 _human_bytes(lookup_bytes),
                 dt_lookup,
-                _rate(lookup_bytes, dt_lookup),
             )
 
             try:
@@ -1194,7 +1158,9 @@ def _run_hks_backend(
                     try:
                         lookup_out.unlink()
                     except OSError as exc:
-                        logger.warning("could not remove temp lookup output %s: %s", lookup_out, exc)
+                        logger.warning(
+                            "could not remove temp lookup output %s: %s", lookup_out, exc
+                        )
             peak = _peak_child_rss_bytes()
             if peak is not None:
                 logger.info("peak hks memory so far: %s", _human_bytes(peak))

--- a/src/karyoscope/core/annotate.py
+++ b/src/karyoscope/core/annotate.py
@@ -231,12 +231,18 @@ PRESMOOTHED_BYTES_PER_BASE = 0.60
 SMOOTHED_BYTES_PER_BASE = 0.20
 
 #: Transient intermediate allowance, as a multiple of one feature set's
-#: presmoothed estimate. Covers the HKS raw lookup TSV (one at a time,
-#: deleted after each set) and the KMC combined BED. Both are "one row per
-#: k-mer run" files dominated by the sequence name and coordinates that a
-#: presmoothed BED also carries, so one feature set's worth is the right
+#: presmoothed estimate. Covers the KMC combined BED, and the HKS lookup
+#: output in the one case where it is still a temp file. Both are "one row
+#: per k-mer run" files dominated by the sequence name and coordinates that
+#: a presmoothed BED also carries, so one feature set's worth is the right
 #: scale; the 1.5 absorbs the spread between feature sets (the largest set
 #: measured 1.48x the six-set average).
+#:
+#: The HKS backend usually needs none of it. ``hks lookup`` writes the
+#: presmoothed BED directly, so when that output is being kept there is no
+#: second copy on disk at any point — the allowance only applies under
+#: ``--no-keep-presmoothed``, where the same file becomes a temp one that
+#: ``hks smooth`` reads and we then delete.
 TRANSIENT_INTERMEDIATE_FACTOR = 1.5
 
 #: Uncompressed-to-compressed ratio assumed for a gzipped nucleotide
@@ -313,6 +319,7 @@ def estimate_output_bytes(
     n_feature_sets: int,
     keep_presmoothed: bool,
     smooth: bool,
+    index_type: str = "kmc",
 ) -> int:
     """Estimate peak bytes written to the output directory by one annotate run.
 
@@ -320,6 +327,12 @@ def estimate_output_bytes(
     them have been written, so it shrinks the result but not the high-water
     mark. ``--no-keep-presmoothed`` and ``--no-smooth`` do reduce it, and
     are reflected here.
+
+    ``index_type`` decides whether a transient intermediate is counted at
+    all. An HKS run keeping its presmoothed output writes no second copy of
+    anything, so charging it for one would refuse runs that fit — about
+    5 GB's worth on a diploid human assembly. The default is the
+    conservative backend, so a caller that does not know errs high.
     """
     per_set = 0.0
     if keep_presmoothed:
@@ -327,7 +340,13 @@ def estimate_output_bytes(
     if smooth:
         per_set += SMOOTHED_BYTES_PER_BASE
     outputs = input_bases * per_set * n_feature_sets
-    transient = input_bases * PRESMOOTHED_BYTES_PER_BASE * TRANSIENT_INTERMEDIATE_FACTOR
+
+    needs_intermediate = index_type != "hks" or not keep_presmoothed
+    transient = (
+        input_bases * PRESMOOTHED_BYTES_PER_BASE * TRANSIENT_INTERMEDIATE_FACTOR
+        if needs_intermediate
+        else 0.0
+    )
     return int(outputs + transient)
 
 
@@ -1330,6 +1349,7 @@ def annotate(
         n_feature_sets=len(requested),
         keep_presmoothed=keep_presmoothed,
         smooth=smooth,
+        index_type=manifest.index.type,
     )
     logger.info(
         "estimated output footprint: %s for %d feature set(s) over ~%.2f Gbp of input",

--- a/src/karyoscope/core/annotate.py
+++ b/src/karyoscope/core/annotate.py
@@ -52,7 +52,6 @@ from karyoscope.core.io.hierarchy import (
 )
 from karyoscope.core.io.hks import (
     convert_bam_to_fasta,
-    convert_hks_tsv_to_bed,
     run_hks_lookup,
     run_hks_smooth,
 )
@@ -995,14 +994,19 @@ def _run_hks_backend(
     ids), HKS queries one ``.hksf`` per feature set and reads label names
     directly. Each feature set is processed independently:
 
-    1. ``hks lookup`` against ``<basename>.<fs>.hksf`` -> a raw TSV.
-    2. If ``keep_presmoothed``: convert the raw TSV to the presmoothed BED.
-    3. If ``smooth``: ``hks smooth`` (using ``<basename>.<fs>.hierarchy.txt``)
-       -> the smoothed BED.
+    1. ``hks lookup`` against ``<basename>.<fs>.hksf`` -> the presmoothed BED.
+    2. If ``smooth``: ``hks smooth`` (using ``<basename>.<fs>.hierarchy.txt``)
+       reads that same file -> the smoothed BED.
 
-    The raw TSV is a per-feature-set temp file, deleted after each set. ``k`` is
-    the query k-mer length (``manifest.kmer.size`` unless overridden for a
-    variable-k index).
+    There is no conversion step between them. ``hks`` is told the output shape
+    KaryoScope wants -- headerless, ``novel`` for misses -- so the lookup output
+    *is* the presmoothed BED, and smooth reads it in place. When the caller does
+    not want the presmoothed BED kept, the lookup still has to write somewhere
+    for smooth to read, so it goes to a per-feature-set temp file deleted after
+    each set.
+
+    ``k`` is the query k-mer length (``manifest.kmer.size`` unless overridden
+    for a variable-k index).
     """
     base_path = db_dir / (manifest.index.basename + ".hksb")
 
@@ -1032,7 +1036,15 @@ def _run_hks_backend(
             t_fs = time.perf_counter()
             fs_file = db_dir / f"{manifest.index.basename}.{fs}.hksf"
             hierarchy_file = db_dir / f"{manifest.index.basename}.{fs}.hierarchy.txt"
-            raw_tsv = output_dir / f"{prefix}.{fs}.lookup_raw.tmp.tsv"
+            # The lookup output is already the presmoothed BED, so when it is being
+            # kept it is written straight to its final home rather than copied
+            # there. Otherwise smooth still needs it on disk to read, and it is a
+            # temp file we drop afterwards.
+            lookup_out = (
+                presmoothed_paths[fs]
+                if keep_presmoothed
+                else output_dir / f"{prefix}.{fs}.lookup_raw.tmp.bed"
+            )
 
             logger.info(
                 "running hks lookup for feature set %r on %s (threads=%d)",
@@ -1045,34 +1057,32 @@ def _run_hks_backend(
                 feature_set_file=fs_file,
                 k=k,
                 input_path=query_path,
-                output_path=raw_tsv,
+                output_path=lookup_out,
                 threads=threads,
                 report_query_names=not is_reads,
                 capture=True,
             )
-            if not raw_tsv.is_file():
-                raise KaryoscopeError(f"hks lookup did not produce expected output at {raw_tsv}")
+            if not lookup_out.is_file():
+                raise KaryoscopeError(f"hks lookup did not produce expected output at {lookup_out}")
 
             try:
-                if keep_presmoothed:
-                    convert_hks_tsv_to_bed(raw_tsv, presmoothed_paths[fs])
-
                 if smooth:
                     t_smo = time.perf_counter()
                     logger.info("running hks smooth for feature set %r", fs)
                     run_hks_smooth(
                         hierarchy_file=hierarchy_file,
-                        input_path=raw_tsv,
+                        input_path=lookup_out,
                         output_path=smoothed_paths[fs],
                         threads=threads,
                         capture=True,
                     )
                     logger.info("smoothed feature set %r in %.1fs", fs, time.perf_counter() - t_smo)
             finally:
-                try:
-                    raw_tsv.unlink()
-                except OSError as exc:
-                    logger.warning("could not remove temp lookup TSV %s: %s", raw_tsv, exc)
+                if not keep_presmoothed:
+                    try:
+                        lookup_out.unlink()
+                    except OSError as exc:
+                        logger.warning("could not remove temp lookup output %s: %s", lookup_out, exc)
             # Reported here rather than per sub-step: one line per feature set
             # is the granularity a user waiting on the run actually needs, and
             # HKS processes them strictly in sequence so the counter is honest.

--- a/src/karyoscope/core/annotate.py
+++ b/src/karyoscope/core/annotate.py
@@ -969,6 +969,75 @@ def _human_bytes(n: int) -> str:
     return f"{n / 1024**2:.1f} MB"
 
 
+def _peak_child_rss_bytes() -> int | None:
+    """Peak resident set size across every child process reaped so far.
+
+    This is the number that decides how much machine an ``annotate`` run
+    needs. KaryoScope's own footprint is small next to the ``hks``
+    invocations it waits on, and those are not visible in this process's
+    own ``ru_maxrss``.
+
+    It is a high-water mark over all reaped children, so it only ever rises
+    — report it as a running peak, never as one step's cost. Returns None
+    where ``resource`` is unavailable.
+    """
+    try:
+        import resource
+    except ImportError:  # pragma: no cover — not a platform we ship for
+        return None
+    raw = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+    # ru_maxrss is kilobytes on Linux and bytes on macOS.
+    return raw if sys.platform == "darwin" else raw * 1024
+
+
+def _rate(nbytes: int, seconds: float) -> str:
+    """Render a throughput, or ``"-"`` when the elapsed time is unusable."""
+    if seconds <= 0:
+        return "-"
+    return f"{nbytes / 1024**3 / seconds:.2f} GB/s"
+
+
+def _bgzip_file(path: Path, threads: int = 1) -> Path:
+    """Compress ``path`` in-place with ``bgzip``, returning the new path.
+
+    ``bgzip`` removes the source file by default (matches gzip's behaviour).
+    Returns ``Path(str(path) + ".gz")``. Logs per-file start + completion
+    at INFO so a long bgzip pass (12 files for a 6-feature-set human
+    database) doesn't look like the pipeline has hung.
+
+    ``threads`` is forwarded as ``bgzip -@``; the htslib bgzip compresses
+    a single file in parallel when given more than one thread. We
+    process files sequentially within the bgzip pass, so passing the
+    user's full ``--threads`` here is the right call (no contention
+    with concurrent file compressions). ``threads=1`` (the default)
+    omits ``-@`` entirely for cleanest subprocess invocation.
+    """
+    bgzip = require_tool(
+        "bgzip",
+        install_hint="Install htslib (`conda install -c bioconda htslib`), "
+        "or rerun with --no-bgzip to skip compression.",
+    )
+    orig_size = path.stat().st_size
+    logger.info("bgzipping %s (%s, threads=%d)", path.name, _human_bytes(orig_size), threads)
+    t0 = time.perf_counter()
+    cmd = [bgzip, "-f"]
+    if threads > 1:
+        cmd.extend(["-@", str(threads)])
+    cmd.append(str(path))
+    run_tool(cmd)
+    out_path = Path(str(path) + ".gz")
+    out_size = out_path.stat().st_size if out_path.is_file() else 0
+    dt = time.perf_counter() - t0
+    logger.info(
+        "bgzipped %s (%s -> %s) in %.1fs",
+        out_path.name,
+        _human_bytes(orig_size),
+        _human_bytes(out_size),
+        dt,
+    )
+    return out_path
+
+
 # --- HKS backend ------------------------------------------------------
 
 
@@ -1052,6 +1121,7 @@ def _run_hks_backend(
                 input_path.name,
                 threads,
             )
+            t_lookup = time.perf_counter()
             run_hks_lookup(
                 base_path=base_path,
                 feature_set_file=fs_file,
@@ -1062,8 +1132,22 @@ def _run_hks_backend(
                 report_query_names=not is_reads,
                 capture=True,
             )
+            dt_lookup = time.perf_counter() - t_lookup
             if not lookup_out.is_file():
                 raise KaryoscopeError(f"hks lookup did not produce expected output at {lookup_out}")
+
+            # Timed and sized per phase rather than per feature set. The two do
+            # very different work -- the lookup is the parallel k-mer query, the
+            # smooth a largely serial pass over what it wrote -- so a single
+            # per-feature-set number cannot say which of them a change moved.
+            lookup_bytes = lookup_out.stat().st_size
+            logger.info(
+                "hks lookup for %r wrote %s in %.1fs (%s)",
+                fs,
+                _human_bytes(lookup_bytes),
+                dt_lookup,
+                _rate(lookup_bytes, dt_lookup),
+            )
 
             try:
                 if smooth:
@@ -1076,13 +1160,25 @@ def _run_hks_backend(
                         threads=threads,
                         capture=True,
                     )
-                    logger.info("smoothed feature set %r in %.1fs", fs, time.perf_counter() - t_smo)
+                    dt_smo = time.perf_counter() - t_smo
+                    smoothed_bytes = smoothed_paths[fs].stat().st_size
+                    logger.info(
+                        "hks smooth for %r wrote %s in %.1fs (read %s at %s)",
+                        fs,
+                        _human_bytes(smoothed_bytes),
+                        dt_smo,
+                        _human_bytes(lookup_bytes),
+                        _rate(lookup_bytes, dt_smo),
+                    )
             finally:
                 if not keep_presmoothed:
                     try:
                         lookup_out.unlink()
                     except OSError as exc:
                         logger.warning("could not remove temp lookup output %s: %s", lookup_out, exc)
+            peak = _peak_child_rss_bytes()
+            if peak is not None:
+                logger.info("peak hks memory so far: %s", _human_bytes(peak))
             # Reported here rather than per sub-step: one line per feature set
             # is the granularity a user waiting on the run actually needs, and
             # HKS processes them strictly in sequence so the counter is honest.
@@ -1091,10 +1187,12 @@ def _run_hks_backend(
         if tmp_fasta is not None:
             tmp_fasta.unlink(missing_ok=True)
 
+    peak = _peak_child_rss_bytes()
     logger.info(
-        "hks backend complete in %.1fs (%d feature set(s))",
+        "hks backend complete in %.1fs (%d feature set(s)%s)",
         time.perf_counter() - t_hks_start,
         len(requested),
+        f", peak hks memory {_human_bytes(peak)}" if peak is not None else "",
     )
 
 

--- a/src/karyoscope/core/io/hks.py
+++ b/src/karyoscope/core/io/hks.py
@@ -103,80 +103,6 @@ def _infer_prefix(input_path: Path, db_basename: str) -> str:
     return f"{input_basename}.{db_basename}"
 
 
-#: Bytes read per block by :func:`convert_hks_tsv_to_bed`. Large enough
-#: that per-block Python overhead vanishes against the memchr-speed scan
-#: inside ``bytes.replace``, small enough that the buffer is irrelevant
-#: beside the k-mer index this runs alongside. Exposed as a parameter only
-#: so tests can shrink it and hammer the block-boundary logic.
-_CONVERT_BLOCK_BYTES = 8 << 20  # 8 MiB
-
-
-def convert_hks_tsv_to_bed(
-    tsv_path: Path, bed_path: Path, *, block_bytes: int = _CONVERT_BLOCK_BYTES
-) -> None:
-    """Convert HKS TSV output (with header) to a headerless BED file.
-
-    Strips the header line and replaces the HKS miss label ``none`` with
-    KaryoScope's ``novel`` sentinel.
-
-    Runs twice per feature set — once on the raw lookup TSV to make the
-    presmoothed BED, once inside :func:`run_hks_smooth` on the smoothed
-    TSV — and on human-scale input those two passes were ~10% of
-    ``annotate``'s wall time (129 s of a 21-minute HG002 run), single
-    threaded, while the rest of the machine idled. The previous version
-    looped in Python over every line of a multi-GB file and paid a decode
-    plus an encode per line; this one reads binary blocks and lets
-    ``bytes.replace`` do the scan in C.
-
-    Still streams: memory is one block plus at most one partial line, so a
-    reads TSV of tens of GB is fine.
-
-    Correctness at block boundaries
-    ------------------------------
-    Only whole lines are ever handed to ``replace``: each block is cut at
-    its **last newline** and the remainder carried into the next block.
-    That makes a straddling match impossible, because ``miss`` ends in a
-    newline — an occurrence extending past the cut would have to end at a
-    newline beyond the last one, which by definition does not exist.
-    ``miss`` also contains no interior newline, so it can never match
-    across two lines. The carried remainder is a partial final line and
-    cannot contain a complete match.
-
-    Byte-for-byte identical output to the line-by-line version on any
-    input, including a final line with no trailing newline (whose label,
-    lacking the terminating newline, is left alone by both).
-    """
-    miss = f"\t{_HKS_MISS_LABEL}\n".encode()
-    novel = f"\t{NOVEL_NAME}\n".encode()
-
-    with tsv_path.open("rb") as inp, bed_path.open("wb") as out:
-        # Drop the header, which may in principle span more than one read.
-        pending = b""
-        while True:
-            block = inp.read(block_bytes)
-            if not block:
-                return  # empty or header-only: no records to write
-            pending += block
-            newline = pending.find(b"\n")
-            if newline != -1:
-                pending = pending[newline + 1 :]
-                break
-
-        while True:
-            block = inp.read(block_bytes)
-            if not block:
-                break
-            pending += block
-            cut = pending.rfind(b"\n")
-            if cut == -1:
-                continue  # a line longer than one block; keep accumulating
-            out.write(pending[: cut + 1].replace(miss, novel))
-            pending = pending[cut + 1 :]
-
-        if pending:
-            out.write(pending.replace(miss, novel))
-
-
 def run_hks_lookup(
     *,
     base_path: Path,
@@ -202,7 +128,9 @@ def run_hks_lookup(
         FASTA or FASTQ input (plain or gzipped). For BAM inputs, pass the
         ``.bam`` path — it will be converted via ``samtools fasta`` internally.
     output_path
-        Where to write the raw HKS lookup TSV (header + ``novel`` for misses).
+        Where to write the lookup output. This is already KaryoScope's
+        presmoothed BED -- headerless, ``novel`` for misses -- not a TSV
+        awaiting conversion.
     threads
         Number of worker threads (0 = let HKS decide, effectively ``4`` by default).
     report_query_names
@@ -266,6 +194,11 @@ def run_hks_lookup(
         # mismatch turns every miss run into an unknown feature name.
         "--miss-label",
         NOVEL_NAME,
+        # With this, the output is a BED file rather than a TSV that has to
+        # be rewritten into one. Note the label column then holds names only
+        # because --report-label-ids is absent; smooth is given the same
+        # default, and with no header to disagree with, the two agree.
+        "--no-header",
         "-t",
         str(n_threads),
         "-o",
@@ -363,7 +296,7 @@ def run_hks_smooth(
     threads: int = 0,
     capture: bool = False,
 ) -> Path:
-    """Invoke ``hks smooth`` on a lookup TSV, writing KaryoScope's BED directly.
+    """Invoke ``hks smooth`` on a presmoothed BED, writing the smoothed one.
 
     ``hks smooth`` is told the output shape we want -- headerless, ``novel``
     for misses -- so its output *is* the smoothed BED. Previously it wrote a
@@ -374,15 +307,17 @@ def run_hks_smooth(
     The miss label is not just cosmetic to smooth: it parses that same token
     out of its input to recognise a miss run. It therefore has to match what
     :func:`run_hks_lookup` wrote, which is why both pass ``NOVEL_NAME`` and
-    neither hardcodes HKS's ``none`` default.
+    neither hardcodes HKS's ``none`` default. The same goes for the label
+    vocabulary: the input has no header to declare it, so both sides rely on
+    ``--report-label-ids`` being absent, i.e. names.
 
     Parameters
     ----------
     hierarchy_file
         Path to the HKS hierarchy file (``*.hierarchy.txt``) for this feature set.
     input_path
-        Raw TSV produced by :func:`run_hks_lookup` (with header, ``novel``
-        for misses).
+        The presmoothed BED written by :func:`run_hks_lookup` (headerless,
+        ``novel`` for misses).
     output_path
         Where to write the smoothed BED (headerless, ``novel`` for misses).
     max_gap

--- a/src/karyoscope/core/io/hks.py
+++ b/src/karyoscope/core/io/hks.py
@@ -62,6 +62,26 @@ _INPUT_EXTENSIONS: tuple[str, ...] = (
 )
 
 
+def _relay_hks_log(result, what: str) -> None:
+    """Forward a captured ``hks`` run's own log lines into ours, at DEBUG.
+
+    ``hks`` is invoked with ``capture=True`` so a normal run does not
+    interleave two tools' logs on stderr. That also means everything it
+    reports about itself — how long the base index and the labeling each
+    took to load, how long the query and the smoothing ran — is discarded on
+    success, and only ever surfaces in the error message of a run that
+    failed. Those are exactly the numbers needed to tell which phase a
+    change moved, so ``-vv`` gets them.
+    """
+    if result is None:
+        return
+    for stream in (result.stderr, result.stdout):
+        for line in (stream or "").splitlines():
+            line = line.strip()
+            if line:
+                logger.debug("hks[%s]: %s", what, line)
+
+
 def get_hks_binary() -> str:
     """Return the path to the ``hks`` binary.
 
@@ -206,7 +226,7 @@ def run_hks_lookup(
     ]
     logger.debug("running: %s", " ".join(cmd))
 
-    run_tool(cmd, capture=capture)
+    _relay_hks_log(run_tool(cmd, capture=capture), "lookup")
     return output_path
 
 
@@ -364,7 +384,7 @@ def run_hks_smooth(
         "--no-header",
     ]
     logger.debug("running: %s", " ".join(cmd))
-    run_tool(cmd, capture=capture)
+    _relay_hks_log(run_tool(cmd, capture=capture), "smooth")
 
     return output_path
 

--- a/src/karyoscope/core/io/hks.py
+++ b/src/karyoscope/core/io/hks.py
@@ -38,7 +38,10 @@ logger = logging.getLogger(__name__)
 BINARY_NAME = "hks"
 ENV_OVERRIDE = "KARYOSCOPE_HKS"
 
-#: Label HKS emits for k-mers not found in the index.
+#: Label HKS emits for k-mers not found in the index, unless told otherwise.
+#: KaryoScope overrides it with ``--miss-label`` so that HKS writes its own
+#: :data:`~karyoscope.core.io.features.NOVEL_NAME` sentinel and no pass over
+#: the output is needed to rewrite it.
 _HKS_MISS_LABEL = "none"
 
 #: Default max-gap (bases) passed to ``hks smooth``, matching karyoscope's Python default.
@@ -199,7 +202,7 @@ def run_hks_lookup(
         FASTA or FASTQ input (plain or gzipped). For BAM inputs, pass the
         ``.bam`` path — it will be converted via ``samtools fasta`` internally.
     output_path
-        Where to write the raw HKS lookup TSV (header + ``none`` for misses).
+        Where to write the raw HKS lookup TSV (header + ``novel`` for misses).
     threads
         Number of worker threads (0 = let HKS decide, effectively ``4`` by default).
     report_query_names
@@ -257,6 +260,12 @@ def run_hks_lookup(
         cmd.append("--report-query-names")
     cmd += [
         "--report-misses",
+        # Emit KaryoScope's sentinel for misses rather than HKS's default
+        # ``none``. Must match what run_hks_smooth passes: ``hks smooth``
+        # parses this token out of its input as well as writing it, so a
+        # mismatch turns every miss run into an unknown feature name.
+        "--miss-label",
+        NOVEL_NAME,
         "-t",
         str(n_threads),
         "-o",
@@ -354,14 +363,26 @@ def run_hks_smooth(
     threads: int = 0,
     capture: bool = False,
 ) -> Path:
-    """Invoke ``hks smooth`` on a lookup TSV and write the result as a BED file.
+    """Invoke ``hks smooth`` on a lookup TSV, writing KaryoScope's BED directly.
+
+    ``hks smooth`` is told the output shape we want -- headerless, ``novel``
+    for misses -- so its output *is* the smoothed BED. Previously it wrote a
+    TSV to a temp file that a second pass then rewrote into place, which cost
+    a full read plus a full write of a multi-gigabyte file per feature set,
+    single threaded, for what amounts to one substitution and a dropped line.
+
+    The miss label is not just cosmetic to smooth: it parses that same token
+    out of its input to recognise a miss run. It therefore has to match what
+    :func:`run_hks_lookup` wrote, which is why both pass ``NOVEL_NAME`` and
+    neither hardcodes HKS's ``none`` default.
 
     Parameters
     ----------
     hierarchy_file
         Path to the HKS hierarchy file (``*.hierarchy.txt``) for this feature set.
     input_path
-        Raw TSV produced by ``hks lookup`` (with header, ``none`` for misses).
+        Raw TSV produced by :func:`run_hks_lookup` (with header, ``novel``
+        for misses).
     output_path
         Where to write the smoothed BED (headerless, ``novel`` for misses).
     max_gap
@@ -390,32 +411,25 @@ def run_hks_smooth(
 
     n_threads = threads if threads > 0 else 4
 
-    # Next to the output, not the system tempdir: the smoothed TSV is the
-    # size of the lookup TSV (GBs for an assembly, tens of GBs for reads),
-    # and /tmp on cluster nodes is often small or RAM-backed.
-    with tempfile.NamedTemporaryFile(suffix=".tsv", delete=False, dir=output_path.parent) as tmp:
-        smooth_tsv = Path(tmp.name)
-
-    try:
-        cmd: list[str] = [
-            binary,
-            "smooth",
-            "--feature-hierarchy",
-            str(hierarchy_file),
-            "-i",
-            str(input_path),
-            "-o",
-            str(smooth_tsv),
-            "--max-gap",
-            str(max_gap),
-            "-t",
-            str(n_threads),
-        ]
-        logger.debug("running: %s", " ".join(cmd))
-        run_tool(cmd, capture=capture)
-        convert_hks_tsv_to_bed(smooth_tsv, output_path)
-    finally:
-        smooth_tsv.unlink(missing_ok=True)
+    cmd: list[str] = [
+        binary,
+        "smooth",
+        "--feature-hierarchy",
+        str(hierarchy_file),
+        "-i",
+        str(input_path),
+        "-o",
+        str(output_path),
+        "--max-gap",
+        str(max_gap),
+        "-t",
+        str(n_threads),
+        "--miss-label",
+        NOVEL_NAME,
+        "--no-header",
+    ]
+    logger.debug("running: %s", " ".join(cmd))
+    run_tool(cmd, capture=capture)
 
     return output_path
 

--- a/src/karyoscope/download.py
+++ b/src/karyoscope/download.py
@@ -30,27 +30,9 @@ from karyoscope.exceptions import (
 from karyoscope.installed import InstalledRecord, load, now_iso, record_install
 from karyoscope.manifest import check_install_readiness, validate_database_layout
 from karyoscope.registry import DatabaseEntry
+from karyoscope.versions import at_least
 
 logger = logging.getLogger(__name__)
-
-
-def _parse_version(s: str) -> tuple[int, ...]:
-    """Parse a dotted version string into a tuple of ints, for comparison.
-
-    Non-numeric components are treated as 0 (so ``1.0.0.dev0`` < ``1.0.0``).
-    This is a small intentional subset of PEP 440 — enough to enforce the
-    ``karyoscope_min_version`` check, not a general-purpose comparator.
-    """
-    parts: list[int] = []
-    for part in s.split("."):
-        # Strip any non-digit suffix (e.g., "0dev0" -> 0).
-        n = 0
-        for ch in part:
-            if not ch.isdigit():
-                break
-            n = n * 10 + int(ch)
-        parts.append(n)
-    return tuple(parts)
 
 
 def is_installed(db_root: Path, db_id: str) -> bool:
@@ -60,9 +42,7 @@ def is_installed(db_root: Path, db_id: str) -> bool:
 
 def _check_version_compatibility(entry: DatabaseEntry) -> None:
     """Raise :class:`IncompatibleVersionError` if this KaryoScope is too old."""
-    required = _parse_version(entry.karyoscope_min_version)
-    have = _parse_version(__version__)
-    if have < required:
+    if not at_least(__version__, entry.karyoscope_min_version):
         raise IncompatibleVersionError(
             f"database '{entry.id}' requires KaryoScope >= "
             f"{entry.karyoscope_min_version}, but this is {__version__}. "

--- a/src/karyoscope/exceptions.py
+++ b/src/karyoscope/exceptions.py
@@ -42,7 +42,8 @@ class UnsupportedSchemeError(FetchError):
 
 
 class IncompatibleVersionError(KaryoscopeError):
-    """A database requires a newer KaryoScope version than the one installed."""
+    """Something installed is too old: a KaryoScope a database needs, or an
+    external binary whose interface KaryoScope depends on."""
 
 
 class BinError(KaryoscopeError):

--- a/src/karyoscope/preflight.py
+++ b/src/karyoscope/preflight.py
@@ -20,11 +20,15 @@ from __future__ import annotations
 
 import importlib.util
 import logging
+import os
+import re
 import shutil
+import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from karyoscope.exceptions import MissingDependencyError
+from karyoscope.exceptions import IncompatibleVersionError, MissingDependencyError
+from karyoscope.versions import at_least
 
 logger = logging.getLogger(__name__)
 
@@ -36,12 +40,17 @@ class Dependency:
     ``kind`` is ``"binary"`` (looked up on ``$PATH``, unless the name has
     an entry in :data:`_RESOLVERS`) or ``"python"`` (looked up as an
     importable module).
+
+    ``min_version`` is the oldest release KaryoScope can drive, for the
+    binaries whose interface we depend on. It is only enforced when the
+    installed version can actually be read — see :func:`outdated`.
     """
 
     name: str
     kind: str
     purpose: str
     install_hint: str
+    min_version: str | None = None
 
 
 #: Every dependency KaryoScope can require, keyed by the name commands use.
@@ -56,6 +65,11 @@ DEPENDENCIES: dict[str, Dependency] = {
             '    cargo install --path HKS --root "$CONDA_PREFIX"\n'
             "  or set $KARYOSCOPE_HKS to an existing hks binary."
         ),
+        # 0.3.0 added --miss-label and smooth's --no-header, which let hks
+        # write KaryoScope's BED format directly. Against 0.2.0 every
+        # annotate would die at the first lookup with clap's "unexpected
+        # argument '--miss-label'" — true, but it does not say "upgrade hks".
+        min_version="0.3.0",
     ),
     "get_featureIDs": Dependency(
         name="get_featureIDs",
@@ -157,6 +171,61 @@ def resolve_binary(name: str) -> str | None:
         return None
 
 
+#: ``hks`` has no ``--version`` flag; every subcommand logs a banner instead.
+_HKS_VERSION_BANNER = re.compile(r"Running hks version\s+(\d[\w.]*)")
+
+
+def _hks_version(path: str) -> str | None:
+    """Read the version out of the banner ``hks`` logs on startup.
+
+    Run with no arguments it prints usage and exits non-zero, but the banner
+    is emitted first, which is all we need — so the exit status is ignored.
+
+    The banner goes through ``log::info!``, so ``RUST_LOG`` in the caller's
+    environment could suppress it and make a perfectly good hks look
+    unidentifiable. We force it back on for this one probe rather than let a
+    user's debugging setting change whether KaryoScope runs.
+    """
+    try:
+        proc = subprocess.run(
+            [path],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+            env={**os.environ, "RUST_LOG": "info"},
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("preflight: could not run %s to read its version: %s", path, exc)
+        return None
+
+    match = _HKS_VERSION_BANNER.search(proc.stderr) or _HKS_VERSION_BANNER.search(proc.stdout)
+    return match.group(1) if match else None
+
+
+#: How to read the installed version of a binary, keyed as :data:`_RESOLVERS`.
+#: A dependency with a ``min_version`` but no probe here is never checked.
+_VERSION_PROBES: dict[str, Callable[[str], str | None]] = {
+    "hks": _hks_version,
+}
+
+
+def installed_version(name: str) -> str | None:
+    """Return the version string of an installed binary, or None if unknown.
+
+    None means "could not determine" — the tool is absent, has no probe, or
+    did not identify itself. It never means "too old".
+    """
+    dep = DEPENDENCIES.get(name)
+    probe = _VERSION_PROBES.get(name)
+    if dep is None or probe is None:
+        return None
+    path = resolve_binary(name)
+    if path is None:
+        return None
+    return probe(path)
+
+
 def _binary_available(dep: Dependency) -> bool:
     return resolve_binary(dep.name) is not None
 
@@ -192,8 +261,37 @@ def check(names: list[str]) -> list[Dependency]:
     return missing
 
 
+def outdated(names: list[str]) -> list[tuple[Dependency, str]]:
+    """Return ``(dependency, installed_version)`` for each one that is too old.
+
+    Only reports a dependency when we have positive evidence of a problem:
+    it declares a ``min_version``, we could read what is installed, and that
+    is older. An unreadable version is not reported — refusing to run over a
+    tool that merely declined to identify itself would be worse than letting
+    it try and fail on its own terms.
+    """
+    stale: list[tuple[Dependency, str]] = []
+    for name in names:
+        dep = DEPENDENCIES.get(name)
+        if dep is None or dep.min_version is None:
+            continue
+        have = installed_version(name)
+        if have is None:
+            logger.debug("preflight: could not read %s version; not enforcing minimum", name)
+            continue
+        if at_least(have, dep.min_version):
+            logger.debug("preflight: %s %s satisfies >= %s", name, have, dep.min_version)
+        else:
+            stale.append((dep, have))
+    return stale
+
+
 def require(names: list[str], *, context: str) -> None:
-    """Raise unless every dependency in ``names`` is available.
+    """Raise unless every dependency in ``names`` is available and new enough.
+
+    Absence is reported before staleness: a tool that is not installed has no
+    version to complain about, and one message about one problem is easier to
+    act on than two about the same tool.
 
     Parameters
     ----------
@@ -207,9 +305,12 @@ def require(names: list[str], *, context: str) -> None:
     ------
     MissingDependencyError
         Listing every missing dependency, with an install hint for each.
+    IncompatibleVersionError
+        If an installed dependency is older than its ``min_version``.
     """
     missing = check(names)
     if not missing:
+        _require_versions(names, context=context)
         return
 
     plural = "dependencies" if len(missing) > 1 else "dependency"
@@ -226,3 +327,21 @@ def require(names: list[str], *, context: str) -> None:
         "Run `karyoscope version` to see what KaryoScope can currently find."
     )
     raise MissingDependencyError("\n".join(lines))
+
+
+def _require_versions(names: list[str], *, context: str) -> None:
+    """Raise :class:`IncompatibleVersionError` if any dependency is too old."""
+    stale = outdated(names)
+    if not stale:
+        return
+
+    lines = [f"outdated dependency for {context}:"]
+    for dep, have in stale:
+        lines.append(
+            f"\n  {dep.name} {have} is installed, but {dep.min_version} or newer "
+            f"is required (needed for {dep.purpose})"
+        )
+        for hint_line in dep.install_hint.splitlines():
+            lines.append(f"    {hint_line}")
+    lines.append("\nRun `karyoscope version` to see the versions KaryoScope can see.")
+    raise IncompatibleVersionError("\n".join(lines))

--- a/src/karyoscope/versions.py
+++ b/src/karyoscope/versions.py
@@ -1,0 +1,38 @@
+"""Comparing dotted version strings.
+
+Two unrelated checks need the same ordering: whether this KaryoScope is new
+enough for a database (``karyoscope_min_version``), and whether an external
+binary is new enough for the flags KaryoScope passes it. Both want "is A at
+least B" over strings like ``2.1.0``, and neither wants a dependency on
+``packaging`` for it.
+"""
+
+from __future__ import annotations
+
+
+def parse_version(s: str) -> tuple[int, ...]:
+    """Parse a dotted version string into a tuple of ints, for comparison.
+
+    Non-numeric components are treated as 0 (so ``1.0.0.dev0`` < ``1.0.0``).
+    This is a small intentional subset of PEP 440 — enough to order the
+    release versions we actually compare, not a general-purpose comparator.
+    """
+    parts: list[int] = []
+    for part in s.split("."):
+        # Strip any non-digit suffix (e.g., "0dev0" -> 0).
+        n = 0
+        for ch in part:
+            if not ch.isdigit():
+                break
+            n = n * 10 + int(ch)
+        parts.append(n)
+    return tuple(parts)
+
+
+def at_least(have: str, required: str) -> bool:
+    """Is version ``have`` greater than or equal to ``required``?
+
+    Shorter versions compare as if zero-padded, because tuple comparison
+    already does that: ``(0, 3) < (0, 3, 1)``.
+    """
+    return parse_version(have) >= parse_version(required)

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -13,10 +13,14 @@ import threading
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from karyoscope.core.annotate import (
     _derive_input_basename,
     _detect_worker_death,
+    _peak_child_rss_bytes,
     _quiet_worker_pipe_errors,
+    _rate,
     _split_combined_bed,
 )
 from karyoscope.core.io.features import parse_features
@@ -221,7 +225,6 @@ def test_quiet_worker_pipe_errors_suppresses_and_restores() -> None:
 
 # --- query-k resolution (variable-k support) -------------------------
 
-import pytest  # noqa: E402
 
 from karyoscope.core.annotate import _resolve_query_k  # noqa: E402
 from karyoscope.exceptions import KaryoscopeError  # noqa: E402
@@ -452,3 +455,30 @@ def test_run_hks_backend_removes_bam_fasta_on_lookup_failure(tmp_path, monkeypat
             k=31,
         )
     assert not (out_dir / "converted.tmp.fasta").exists()
+
+# --- run-resource reporting -------------------------------------------
+
+
+def test_rate_reports_gb_per_second() -> None:
+    assert _rate(2 * 1024**3, 2.0) == "1.00 GB/s"
+
+
+def test_rate_declines_to_divide_by_zero() -> None:
+    """A phase that measured as instantaneous has no meaningful throughput."""
+    assert _rate(1024, 0.0) == "-"
+    assert _rate(1024, -1.0) == "-"
+
+
+def test_peak_child_rss_is_reported_in_bytes() -> None:
+    """The units differ by platform; the caller must not have to know that.
+
+    Linux's ru_maxrss is kilobytes and macOS's is bytes, so a helper that
+    passed the raw value through would be wrong by 1024x on one of them.
+    """
+    peak = _peak_child_rss_bytes()
+    if peak is None:  # pragma: no cover — platform without `resource`
+        pytest.skip("resource module unavailable")
+    assert peak >= 0
+    # pytest has already reaped children, so this is a plausible RSS in
+    # bytes and an implausible one in kilobytes.
+    assert peak < 1024**4

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -455,6 +455,7 @@ def test_run_hks_backend_removes_bam_fasta_on_lookup_failure(tmp_path, monkeypat
         )
     assert not (out_dir / "converted.tmp.fasta").exists()
 
+
 # --- run-resource reporting -------------------------------------------
 
 

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -391,7 +391,6 @@ def test_run_hks_backend_converts_bam_once_for_all_feature_sets(tmp_path, monkey
 
     monkeypatch.setattr(ann, "convert_bam_to_fasta", fake_convert)
     monkeypatch.setattr(ann, "run_hks_lookup", fake_lookup)
-    monkeypatch.setattr(ann, "convert_hks_tsv_to_bed", lambda tsv, bed: bed.write_text("x"))
 
     out_dir = tmp_path / "out"
     out_dir.mkdir()

--- a/tests/test_annotate_footprint.py
+++ b/tests/test_annotate_footprint.py
@@ -27,6 +27,11 @@ from karyoscope.core.annotate import (
 _HG002_BASES = 5_999_424_718
 _HG002_MEASURED_PEAK = 34_400_000_000
 
+#: The same run's peak once ``hks lookup`` began writing the presmoothed BED
+#: itself: the 5.42 GB TSV was a second copy of a file we were keeping
+#: anyway, and simply stopped existing. Outputs alone, 21.70 + 7.26 GB.
+_HG002_HKS_PEAK = 28_960_000_000
+
 
 # --- input size -------------------------------------------------------
 
@@ -122,13 +127,56 @@ def test_dropping_an_output_lowers_the_estimate() -> None:
     assert presmoothed_only > smoothed_only
 
 
-def test_transient_intermediate_is_always_counted() -> None:
-    """Even a single feature set needs room for its lookup TSV alongside."""
+def test_transient_intermediate_is_counted_when_there_is_one() -> None:
+    """A single feature set still needs room for its intermediate alongside."""
     single = estimate_output_bytes(
         input_bases=1_000_000_000, n_feature_sets=1, keep_presmoothed=False, smooth=True
     )
     outputs_only = 1_000_000_000 * 0.20
     assert single > outputs_only * 2
+
+
+def test_hks_keeping_presmoothed_is_charged_for_no_intermediate() -> None:
+    """`hks lookup` writes the presmoothed BED itself, so nothing is duplicated.
+
+    Charging for an intermediate that no longer exists would refuse runs
+    that fit -- about 5 GB's worth on a diploid human assembly.
+    """
+    estimate = estimate_output_bytes(
+        input_bases=_HG002_BASES,
+        n_feature_sets=6,
+        keep_presmoothed=True,
+        smooth=True,
+        index_type="hks",
+    )
+    assert estimate == pytest.approx(_HG002_HKS_PEAK, rel=0.10)
+    assert estimate < _HG002_MEASURED_PEAK
+
+
+def test_hks_discarding_presmoothed_still_needs_the_temp_file() -> None:
+    """Without --keep-presmoothed the lookup output is a temp file smooth reads."""
+    kept = estimate_output_bytes(
+        input_bases=1_000_000_000,
+        n_feature_sets=1,
+        keep_presmoothed=False,
+        smooth=True,
+        index_type="hks",
+    )
+    outputs_only = 1_000_000_000 * 0.20
+    assert kept > outputs_only * 2
+
+
+def test_an_unknown_backend_errs_high() -> None:
+    """The default must be the conservative one: over-estimating only warns."""
+    assert estimate_output_bytes(
+        input_bases=_HG002_BASES, n_feature_sets=6, keep_presmoothed=True, smooth=True
+    ) == estimate_output_bytes(
+        input_bases=_HG002_BASES,
+        n_feature_sets=6,
+        keep_presmoothed=True,
+        smooth=True,
+        index_type="kmc",
+    )
 
 
 # --- dependency selection ---------------------------------------------

--- a/tests/test_hks.py
+++ b/tests/test_hks.py
@@ -15,6 +15,7 @@ from karyoscope.core.io.hks import (
     convert_hks_tsv_to_bed,
     get_hks_binary,
     run_hks_lookup,
+    run_hks_smooth,
 )
 
 
@@ -88,6 +89,63 @@ def test_run_hks_lookup_omits_names_for_reads(
     cmd = _capture_lookup_cmd(tmp_path, monkeypatch, report_query_names=False)
     assert "--report-query-names" not in cmd
     assert "--report-misses" in cmd
+
+
+def _capture_smooth_cmd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, out: Path | None = None
+) -> list[str]:
+    """Run ``run_hks_smooth`` with the binary + subprocess stubbed, return the cmd."""
+    captured: dict[str, list[str]] = {}
+    monkeypatch.setattr("karyoscope.core.io.hks.get_hks_binary", lambda: "hks")
+    monkeypatch.setattr(
+        "karyoscope.core.io.hks.run_tool",
+        lambda cmd, capture=False: captured.__setitem__("cmd", cmd),
+    )
+    run_hks_smooth(
+        hierarchy_file=tmp_path / "features.chromosome.hierarchy.txt",
+        input_path=tmp_path / "raw.tsv",
+        output_path=out if out is not None else tmp_path / "smoothed.bed",
+    )
+    return captured["cmd"]
+
+
+def _flag_value(cmd: list[str], flag: str) -> str:
+    return cmd[cmd.index(flag) + 1]
+
+
+def test_run_hks_smooth_writes_the_bed_directly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """smooth is pointed at the final BED, not a temp TSV needing a rewrite."""
+    out = tmp_path / "smoothed.bed"
+    cmd = _capture_smooth_cmd(tmp_path, monkeypatch, out=out)
+    assert _flag_value(cmd, "-o") == str(out)
+    assert "--no-header" in cmd
+    assert _flag_value(cmd, "--miss-label") == NOVEL_NAME
+
+
+def test_lookup_and_smooth_agree_on_the_miss_label(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The invariant the whole scheme rests on.
+
+    ``hks smooth`` parses the miss token out of its input as well as writing
+    it, so if lookup wrote a different one every miss run would be read as an
+    unknown feature name. Neither may quietly fall back to HKS's ``none``.
+    """
+    lookup = _capture_lookup_cmd(tmp_path, monkeypatch, report_query_names=True)
+    smooth = _capture_smooth_cmd(tmp_path, monkeypatch)
+    assert _flag_value(lookup, "--miss-label") == _flag_value(smooth, "--miss-label")
+    assert _flag_value(lookup, "--miss-label") == NOVEL_NAME
+    assert _flag_value(lookup, "--miss-label") != _HKS_MISS_LABEL
+
+
+def test_run_hks_lookup_emits_the_karyoscope_miss_label(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Misses come out of lookup already labelled ``novel``, not ``none``."""
+    cmd = _capture_lookup_cmd(tmp_path, monkeypatch, report_query_names=True)
+    assert _flag_value(cmd, "--miss-label") == NOVEL_NAME
 
 
 def test_convert_hks_tsv_header_only_yields_empty_bed(tmp_path: Path) -> None:

--- a/tests/test_hks.py
+++ b/tests/test_hks.py
@@ -12,44 +12,10 @@ from karyoscope.core.io.hks import (
     _HKS_MISS_LABEL,
     ENV_OVERRIDE,
     _infer_prefix,
-    convert_hks_tsv_to_bed,
     get_hks_binary,
     run_hks_lookup,
     run_hks_smooth,
 )
-
-
-def test_convert_hks_tsv_to_bed_strips_header_and_maps_none(tmp_path: Path) -> None:
-    tsv = tmp_path / "raw.tsv"
-    tsv.write_text(
-        "query_name\tfrom_kmer\tto_kmer\tlabel_name\n"
-        "chr1\t0\t10\tchr1\n"
-        "chr1\t10\t20\tnone\n"
-        "chr1\t20\t30\tcentromere\n"
-    )
-    bed = tmp_path / "out.bed"
-    convert_hks_tsv_to_bed(tsv, bed)
-
-    lines = bed.read_text().splitlines()
-    # Header dropped.
-    assert lines[0] == "chr1\t0\t10\tchr1"
-    # `none` miss label rewritten to the KaryoScope `novel` sentinel.
-    assert lines[1] == f"chr1\t10\t20\t{NOVEL_NAME}"
-    assert lines[2] == "chr1\t20\t30\tcentromere"
-    assert len(lines) == 3
-
-
-def test_convert_hks_tsv_only_none_in_label_column(tmp_path: Path) -> None:
-    """A feature literally containing 'none' as a substring is not corrupted."""
-    tsv = tmp_path / "raw.tsv"
-    tsv.write_text(
-        "query_name\tfrom_kmer\tto_kmer\tlabel_name\nchr1\t0\t10\tnonesuch\nchr1\t10\t20\tnone\n"
-    )
-    bed = tmp_path / "out.bed"
-    convert_hks_tsv_to_bed(tsv, bed)
-    lines = bed.read_text().splitlines()
-    assert lines[0] == "chr1\t0\t10\tnonesuch"
-    assert lines[1] == f"chr1\t10\t20\t{NOVEL_NAME}"
 
 
 def _capture_lookup_cmd(
@@ -124,6 +90,30 @@ def test_run_hks_smooth_writes_the_bed_directly(
     assert _flag_value(cmd, "--miss-label") == NOVEL_NAME
 
 
+def test_run_hks_lookup_writes_the_presmoothed_bed_directly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The lookup output is the presmoothed BED, so it carries no header."""
+    cmd = _capture_lookup_cmd(tmp_path, monkeypatch, report_query_names=True)
+    assert "--no-header" in cmd
+
+
+def test_lookup_and_smooth_agree_on_the_label_vocabulary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Neither may ask for numeric label ids.
+
+    With no header in between to declare which vocabulary the fourth column
+    uses, this is the only thing keeping the two in step: smooth resolves
+    those tokens against the hierarchy, and would reject every name if it
+    expected ids.
+    """
+    lookup = _capture_lookup_cmd(tmp_path, monkeypatch, report_query_names=True)
+    smooth = _capture_smooth_cmd(tmp_path, monkeypatch)
+    assert "--report-label-ids" not in lookup
+    assert "--report-label-ids" not in smooth
+
+
 def test_lookup_and_smooth_agree_on_the_miss_label(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -146,28 +136,6 @@ def test_run_hks_lookup_emits_the_karyoscope_miss_label(
     """Misses come out of lookup already labelled ``novel``, not ``none``."""
     cmd = _capture_lookup_cmd(tmp_path, monkeypatch, report_query_names=True)
     assert _flag_value(cmd, "--miss-label") == NOVEL_NAME
-
-
-def test_convert_hks_tsv_header_only_yields_empty_bed(tmp_path: Path) -> None:
-    """A TSV with only a header (no records) produces an empty BED."""
-    tsv = tmp_path / "raw.tsv"
-    tsv.write_text("query_name\tfrom_kmer\tto_kmer\tlabel_name\n")
-    bed = tmp_path / "out.bed"
-    convert_hks_tsv_to_bed(tsv, bed)
-    assert bed.read_text() == ""
-
-
-def test_convert_hks_tsv_last_line_without_newline(tmp_path: Path) -> None:
-    """A final row lacking a trailing newline is passed through unchanged."""
-    tsv = tmp_path / "raw.tsv"
-    # No trailing newline on the last line: the miss-label pattern requires a
-    # trailing newline, so it is (correctly) not rewritten -- matching the
-    # previous splitlines(keepends=True) behavior.
-    tsv.write_text("query_name\tfrom_kmer\tto_kmer\tlabel_name\n0\t0\t10\tchr1\n0\t10\t20\tnone")
-    bed = tmp_path / "out.bed"
-    convert_hks_tsv_to_bed(tsv, bed)
-    lines = bed.read_text().splitlines()
-    assert lines == ["0\t0\t10\tchr1", "0\t10\t20\tnone"]
 
 
 def test_infer_prefix_strips_extension() -> None:
@@ -293,162 +261,9 @@ def test_validate_sibling_priorities() -> None:
     assert len(issues) == 1 and "mixed priorities" in issues[0]
 
 
-# --- convert_hks_tsv_to_bed: block-boundary correctness ------------------
-#
-# The conversion reads binary blocks and lets bytes.replace do the scan,
-# rather than looping per line in Python (it was ~10% of annotate's wall
-# time on human input). Correctness then hinges entirely on never handing
-# a partial line to replace, so these tests drive the block size down to a
-# few bytes and compare against the obvious line-by-line implementation.
-
-
 def _reference_convert(tsv_text: str) -> str:
     """The original line-by-line implementation, as an oracle."""
     miss = f"\t{_HKS_MISS_LABEL}\n"
     novel = f"\t{NOVEL_NAME}\n"
     lines = tsv_text.splitlines(keepends=True)
     return "".join(line.replace(miss, novel) for line in lines[1:])
-
-
-@pytest.mark.parametrize("block", [1, 2, 3, 5, 6, 7, 8, 13, 64, 8192])
-def test_convert_matches_line_by_line_at_every_block_size(tmp_path: Path, block: int) -> None:
-    """Output must not depend on where blocks happen to fall.
-
-    Block sizes of 5-7 straddle the 6-byte '\\tnone\\n' token specifically.
-    """
-    tsv_text = (
-        "query_name\tfrom_kmer\tto_kmer\tlabel_name\n"
-        "chr1\t0\t10\tchr1\n"
-        "chr1\t10\t20\tnone\n"
-        "chr1\t20\t30\tnone\n"
-        "chr1\t30\t40\tnonesuch\n"
-        "chr2\t0\t5\tcentromere\n"
-        "chr2\t5\t9\tnone\n"
-    )
-    tsv = tmp_path / "raw.tsv"
-    tsv.write_text(tsv_text)
-    bed = tmp_path / "out.bed"
-    convert_hks_tsv_to_bed(tsv, bed, block_bytes=block)
-    assert bed.read_text() == _reference_convert(tsv_text)
-
-
-def test_convert_handles_a_final_line_without_a_newline(tmp_path: Path) -> None:
-    """Both implementations leave an unterminated trailing 'none' alone.
-
-    The token includes its newline, so a label at EOF with no newline
-    isn't a match. Pinned because the block version carries that partial
-    line through a different path than the rest.
-    """
-    tsv_text = "hdr\nchr1\t0\t10\tnone\nchr1\t10\t20\tnone"
-    tsv = tmp_path / "raw.tsv"
-    tsv.write_text(tsv_text)
-    bed = tmp_path / "out.bed"
-    convert_hks_tsv_to_bed(tsv, bed, block_bytes=4)
-    out = bed.read_text()
-    assert out == _reference_convert(tsv_text)
-    assert out.endswith("chr1\t10\t20\tnone")  # unterminated: untouched
-
-
-def test_convert_of_an_empty_file_writes_nothing(tmp_path: Path) -> None:
-    tsv = tmp_path / "raw.tsv"
-    tsv.write_bytes(b"")
-    bed = tmp_path / "out.bed"
-    convert_hks_tsv_to_bed(tsv, bed)
-    assert bed.read_bytes() == b""
-
-
-def test_convert_of_a_header_only_file_writes_nothing(tmp_path: Path) -> None:
-    tsv = tmp_path / "raw.tsv"
-    tsv.write_text("query_name\tfrom_kmer\tto_kmer\tlabel_name\n")
-    bed = tmp_path / "out.bed"
-    convert_hks_tsv_to_bed(tsv, bed, block_bytes=3)
-    assert bed.read_bytes() == b""
-
-
-def test_convert_drops_a_header_longer_than_one_block(tmp_path: Path) -> None:
-    """The header may span reads when the block size is small."""
-    tsv_text = "a_very_long_header_line_indeed\nchr1\t0\t10\tnone\n"
-    tsv = tmp_path / "raw.tsv"
-    tsv.write_text(tsv_text)
-    bed = tmp_path / "out.bed"
-    convert_hks_tsv_to_bed(tsv, bed, block_bytes=4)
-    assert bed.read_text() == f"chr1\t0\t10\t{NOVEL_NAME}\n"
-
-
-def test_convert_handles_a_line_longer_than_a_block(tmp_path: Path) -> None:
-    """A record longer than one block must accumulate, not be split."""
-    long_name = "contig_" + "x" * 500
-    tsv_text = f"hdr\n{long_name}\t0\t10\tnone\n{long_name}\t10\t20\tsat\n"
-    tsv = tmp_path / "raw.tsv"
-    tsv.write_text(tsv_text)
-    bed = tmp_path / "out.bed"
-    convert_hks_tsv_to_bed(tsv, bed, block_bytes=16)
-    assert bed.read_text() == _reference_convert(tsv_text)
-
-
-@pytest.mark.slow
-def test_convert_is_byte_identical_on_pseudorandom_records(tmp_path: Path) -> None:
-    """Fuzz the label mix and line lengths against the oracle."""
-    import random
-
-    rng = random.Random(20260727)
-    labels = ["none", "novel", "nonesuch", "sat", "a", "none", "rDNA_none", ""]
-    rows = [
-        f"ctg{rng.randrange(100)}\t{i}\t{i + rng.randrange(1, 9)}\t{rng.choice(labels)}"
-        for i in range(4000)
-    ]
-    tsv_text = "header\n" + "\n".join(rows) + "\n"
-    tsv = tmp_path / "raw.tsv"
-    tsv.write_text(tsv_text)
-    expected = _reference_convert(tsv_text)
-    for block in (7, 64, 997, 65536):
-        bed = tmp_path / f"out_{block}.bed"
-        convert_hks_tsv_to_bed(tsv, bed, block_bytes=block)
-        assert bed.read_text() == expected, f"mismatch at block_bytes={block}"
-
-
-# --- convert_bam_to_fasta (stubbed samtools) -------------------------
-
-
-def test_convert_bam_to_fasta_runs_samtools_into_dest_dir(tmp_path, monkeypatch) -> None:
-    """The conversion runs `samtools fasta <bam>` with stdout in dest_dir."""
-    from types import SimpleNamespace
-
-    from karyoscope.core.io import hks as hks_mod
-
-    seen: dict[str, object] = {}
-
-    def fake_run(cmd, stdout=None, stderr=None, check=False):
-        seen["cmd"] = cmd
-        stdout.write(b">r1\nACGT\n")
-        return SimpleNamespace(returncode=0, stderr=None)
-
-    monkeypatch.setattr(hks_mod, "require_tool", lambda name, **kw: "samtools-stub")
-    monkeypatch.setattr(hks_mod.subprocess, "run", fake_run)
-
-    bam = tmp_path / "reads.bam"
-    fasta = hks_mod.convert_bam_to_fasta(bam, tmp_path)
-    try:
-        assert seen["cmd"] == ["samtools-stub", "fasta", str(bam)]
-        assert fasta.parent == tmp_path
-        assert fasta.read_text() == ">r1\nACGT\n"
-    finally:
-        fasta.unlink(missing_ok=True)
-
-
-def test_convert_bam_to_fasta_failure_raises_and_cleans_up(tmp_path, monkeypatch) -> None:
-    """A non-zero samtools exit raises ExternalToolError and removes the temp FASTA."""
-    from types import SimpleNamespace
-
-    from karyoscope.core.external import ExternalToolError
-    from karyoscope.core.io import hks as hks_mod
-
-    def fake_run(cmd, stdout=None, stderr=None, check=False):
-        return SimpleNamespace(returncode=1, stderr=b"boom")
-
-    monkeypatch.setattr(hks_mod, "require_tool", lambda name, **kw: "samtools-stub")
-    monkeypatch.setattr(hks_mod.subprocess, "run", fake_run)
-
-    with pytest.raises(ExternalToolError, match="boom"):
-        hks_mod.convert_bam_to_fasta(tmp_path / "reads.bam", tmp_path, capture=True)
-    assert list(tmp_path.glob("*.fasta")) == []

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -7,10 +7,12 @@ working installs. Several tests below pin that agreement.
 
 from __future__ import annotations
 
+import subprocess
+
 import pytest
 
 from karyoscope import preflight
-from karyoscope.exceptions import MissingDependencyError
+from karyoscope.exceptions import IncompatibleVersionError, MissingDependencyError
 
 # --- resolve_binary ---------------------------------------------------
 
@@ -139,3 +141,109 @@ def test_every_dependency_declares_a_kind_and_a_hint() -> None:
         assert dep.name == name
         assert dep.kind in ("binary", "python")
         assert dep.purpose and dep.install_hint
+
+
+# --- minimum versions -------------------------------------------------
+
+
+def _fake_hks(monkeypatch: pytest.MonkeyPatch, banner: str) -> None:
+    """Stub out running hks so its startup banner says ``banner``."""
+    monkeypatch.setattr(preflight, "resolve_binary", lambda name: "/bin/" + name)
+    monkeypatch.setattr(
+        preflight.subprocess,
+        "run",
+        lambda *a, **kw: subprocess.CompletedProcess(a[0], 2, stdout="", stderr=banner),
+    )
+
+
+_BANNER = "[2026-07-28T15:21:23Z INFO  hks] Running hks version {}\n"
+
+
+def test_hks_version_is_read_from_the_startup_banner(monkeypatch: pytest.MonkeyPatch) -> None:
+    """hks has no --version; it logs the version on its way to printing usage."""
+    _fake_hks(monkeypatch, _BANNER.format("0.3.1"))
+    assert preflight.installed_version("hks") == "0.3.1"
+
+
+def test_an_hks_older_than_the_minimum_is_reported(monkeypatch: pytest.MonkeyPatch) -> None:
+    """0.2.0 predates --miss-label, so every annotate would die at the lookup."""
+    _fake_hks(monkeypatch, _BANNER.format("0.2.0"))
+    stale = preflight.outdated(["hks"])
+    assert [(dep.name, have) for dep, have in stale] == [("hks", "0.2.0")]
+
+    with pytest.raises(IncompatibleVersionError) as excinfo:
+        preflight.require(["hks"], context="annotate against DB_x")
+    message = str(excinfo.value)
+    assert "0.2.0 is installed" in message
+    assert "0.3.0 or newer" in message
+    assert "annotate against DB_x" in message
+    # The whole point is that it says what to do about it.
+    assert "cargo install" in message
+
+
+def test_an_hks_at_or_above_the_minimum_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    for version in ("0.3.0", "0.3.1", "0.10.0", "1.0.0"):
+        _fake_hks(monkeypatch, _BANNER.format(version))
+        assert preflight.outdated(["hks"]) == [], version
+
+
+def test_an_unreadable_version_is_not_treated_as_outdated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fail open.
+
+    Refusing to run over a tool that merely declined to identify itself would
+    break working installs; letting it through costs at worst the tool's own
+    error message.
+    """
+    _fake_hks(monkeypatch, "some future hks that logs nothing recognisable\n")
+    assert preflight.installed_version("hks") is None
+    assert preflight.outdated(["hks"]) == []
+    preflight.require(["hks"], context="testing")
+
+
+def test_a_missing_tool_is_reported_as_missing_not_outdated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One problem, one message: an absent tool has no version to complain about."""
+    monkeypatch.setattr(preflight, "resolve_binary", lambda name: None)
+    assert preflight.installed_version("hks") is None
+    with pytest.raises(MissingDependencyError):
+        preflight.require(["hks"], context="testing")
+
+
+def test_a_probe_that_cannot_run_is_not_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(preflight, "resolve_binary", lambda name: "/bin/hks")
+
+    def boom(*a: object, **kw: object) -> None:
+        raise OSError("no such binary")
+
+    monkeypatch.setattr(preflight.subprocess, "run", boom)
+    assert preflight.installed_version("hks") is None
+    assert preflight.outdated(["hks"]) == []
+
+
+def test_the_version_probe_forces_the_banner_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RUST_LOG in the caller's environment must not decide whether we can read it.
+
+    The banner goes through log::info!, so RUST_LOG=error would silence it and
+    make a perfectly good hks look unidentifiable.
+    """
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(preflight, "resolve_binary", lambda name: "/bin/hks")
+    monkeypatch.setenv("RUST_LOG", "error")
+
+    def record(*a: object, **kw: object) -> subprocess.CompletedProcess[str]:
+        seen.update(kw)
+        return subprocess.CompletedProcess([], 2, stdout="", stderr=_BANNER.format("0.3.0"))
+
+    monkeypatch.setattr(preflight.subprocess, "run", record)
+    assert preflight.installed_version("hks") == "0.3.0"
+    assert seen["env"]["RUST_LOG"] == "info"  # type: ignore[index]
+
+
+def test_only_dependencies_with_a_minimum_are_version_checked() -> None:
+    """Every min_version needs a probe, or it would silently never be enforced."""
+    for name, dep in preflight.DEPENDENCIES.items():
+        if dep.min_version is not None:
+            assert name in preflight._VERSION_PROBES, name


### PR DESCRIPTION
Stacked on #18 — **review that one first**; this PR's diff is only the 6 commits on top.

## What this does

`hks` is now asked for the output format KaryoScope actually wants, so it writes the BED files itself and the Python conversion pass disappears.

`convert_hks_tsv_to_bed` never converted a format. The lookup TSV is already BED-shaped — same four columns, same order — so all it did was drop the header line and rewrite `\tnone\n` to `\tnovel\n`. It ran **twice per feature set**, each time reading and rewriting a multi-gigabyte file, single-threaded. `hks` 0.3.0 can be told `--miss-label novel --no-header`, so both passes are gone along with the function and its 20 tests.

## Measured

Full HG002 v1.1 run, six feature sets, dedicated 40-core node, cold cache, `-t 10` (jobs 34970387 / 34970388):

| | before | after |
|---|---|---|
| **Bytes written** | **57.9 GB** | **29.0 GB** |
| Wall clock | 1228 s | 1135 s |
| CPU utilisation | 641% | 685% |
| Peak RSS | 10.29 GB | 10.33 GB |

**The I/O halving is the number to trust** — a direct block count from the kernel (113,068,480 → 56,573,384), not a difference of two noisy timings. It also roughly halves peak temp disk: the raw lookup output and the presmoothed BED were two near-identical copies of the same data, and now there is one file that `hks smooth` reads in place.

The 93 s wall-clock gap is 7.6%, close enough to this cluster's ~5% noise floor that a single pair shouldn't be taken as established.

## Correctness

Parity verified twice:
- **All 12 output BEDs byte-identical** on the full HG002 run above.
- Locally on a real (small) index, using the deleted converter itself as the oracle, over 18 miss runs.

## Where to look hardest

Correctness now rests on `hks` agreeing with itself across two invocations with **no header in between to declare the format**. Two invariants hold it together, and each has a dedicated test:

1. `lookup` and `smooth` must pass the **same `--miss-label`**. `smooth` parses that token out of its input as well as writing it, so a mismatch would silently reinterpret every miss run as an unknown feature name.
2. Neither may pass `--report-label-ids`. With no header, that flag is the only thing saying whether column four holds names or ids.

Also worth a look: `preflight` now gates on `hks >= 0.3.0`. It **fails open** — an unreadable version is not treated as too old, since refusing to run over a tool that merely declined to identify itself would break working installs.

## Blocking caveat for merge

`hks` 0.3.0 exists **only on the tbenavi1 fork** (`feat/smooth-label-mode`). The README's install instructions point at `jnalanko/HKS`, which is 0.2.0. This is reviewable and mergeable internally, but cannot ship to users until those changes are upstream.

## Note on #18

#18's commit `179bc9c` optimises `convert_hks_tsv_to_bed` 2.3x — the function this PR deletes. Both are unreleased, so its CHANGELOG entry has been replaced here rather than publishing "optimised then deleted" in one cycle. You may prefer to drop that commit from #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
