### PR TITLE
feat(preflight): check memory up front, and explain SIGKILL when it happens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`annotate` now checks available memory before it starts**, not just disk.
+  For the HKS backend the requirement is knowable exactly rather than
+  estimated: `hks` holds the shared base index plus one feature set's labeling
+  at a time, so the peak is the sum of two file sizes read off disk (measured
+  9.73 GB predicted vs 10.04 GB observed on the human database). It resolves
+  the limit from `$SLURM_MEM_PER_NODE`/`_PER_CPU`, then the cgroup limit, then
+  `MemAvailable` — and fails open if either the index or the limit cannot be
+  determined, so it can only stop a run that would have been killed anyway.
+- **A process killed by a signal now says so.** `subprocess` reports `-N` for
+  signal N, so an out-of-memory kill surfaced as `command failed with exit code
+  -9` — not an exit code at all, and unsearchable. Failures now read `killed by
+  SIGKILL (signal 9)`, including the shell-style `137` that SLURM and Docker
+  report, with backend-specific advice on how much memory to request. This
+  previously existed for the KMC backend only; it now applies to every external
+  tool KaryoScope runs.
+
 - **`karyoscope prep-bed pave` — a papillomavirus `gene` feature set from PaVE
   genome records.** Leaves are the ORFs — `E6`, `E7`, `E1`, `E2`, the
   genus-specific `E5_*`, `E10`, `L2`, `L1` — plus the `URR`, grouped `early` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.2.0] - 2026-08-04
 
+### Changed
+- **`--no-space-check` is now `--no-resource-check`** on `annotate` and
+  `download`. The flag governs the memory check as well as the disk one, so
+  "space" had become the wrong word. `--no-space-check` still works as a
+  hidden alias and warns; it will be removed in a future release. Supplying
+  both is a usage error.
+
 ### Added
 
 - **`docs/recipes/` — reproducible recipes for the shipped databases.** One page

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Size tracks the genome, not the tool: the 135 Mb *Arabidopsis* database installs
 
 Measured on HG002 v1.1 against `HKS_human_CHM13_v2`. An HKS run needs no headroom beyond its outputs: `hks lookup` writes the presmoothed BED directly, so no intermediate copy of it ever exists. (Under `--no-keep-presmoothed` that file becomes a temp one, and the KMC column applies instead.) The KMC backend still writes a combined intermediate BED alongside.
 
-Restricting `--feature-set`, or dropping one output variant with `--no-keep-presmoothed` / `--no-smooth`, scales this down proportionally. `annotate` estimates the footprint from the input size and checks `--outdir` before starting; pass `--no-space-check` to override the estimate.
+Restricting `--feature-set`, or dropping one output variant with `--no-keep-presmoothed` / `--no-smooth`, scales this down proportionally. `annotate` estimates the footprint from the input size and checks `--outdir` before starting; pass `--no-resource-check` to override the estimate.
 
 ## Installation
 

--- a/docs/commands/annotate.md
+++ b/docs/commands/annotate.md
@@ -28,7 +28,7 @@ karyoscope annotate -i INPUT [OPTIONS]
 | `--keep-intermediates` | Keep the combined `.featureIDs.bed` from the C++ step (useful for debugging). |
 | `--force` | Regenerate the combined intermediate even if a complete one already exists. By default a rerun reuses a verified combined BED left by a previous (e.g. OOM-killed) run and skips the `get_featureIDs` step, resuming straight into smoothing. A partial file from a killed run is never reused regardless of this flag. |
 | `--bgzip` / `--no-bgzip` | bgzip the per-feature-set output BEDs. Pass `--no-bgzip` to write plain `.bed` files. Note this shrinks the final output but not peak disk usage: compression runs after every BED has been written in full. [default: `bgzip`] |
-| `--no-space-check` | Skip the up-front free-space check on `--outdir`. See [Disk space](#disk-space). |
+| `--no-resource-check` | Skip the up-front disk **and memory** checks. Disk: the output footprint on `--outdir`, see [Disk space](#disk-space). Memory: HKS databases must hold their index resident (~10 GB for a human database), so an under-allocated run is killed by the OS mid-query; the check reads the requirement from the index files themselves. |
 | `--preserve-order` / `--no-preserve-order` | Write output BEDs with sequences in the same order as the input. Pass `--no-preserve-order` for the fastest path when order doesn't matter downstream (typically read data). [default: `preserve-order`] |
 | `-h`, `--help` | Show this message and exit. |
 
@@ -94,7 +94,7 @@ Measured on HG002 v1.1 against `HKS_human_CHM13_v2`: 21.7 GB of presmoothed BED,
 - `--no-keep-presmoothed` (drops the larger of the two variants, ~0.6 of the 0.8 GB) or `--no-smooth`
 - splitting a diploid assembly into per-haplotype runs
 
-`annotate` estimates this footprint before starting and refuses if `--outdir` can't hold it, so a full disk is caught in a second rather than after the k-mer query. The estimate uses an exact base count from a sibling `.fai` when one exists, and otherwise scales the input file size. Pass `--no-space-check` if the estimate is wrong for your input.
+`annotate` estimates this footprint before starting and refuses if `--outdir` can't hold it, so a full disk is caught in a second rather than after the k-mer query. The estimate uses an exact base count from a sibling `.fai` when one exists, and otherwise scales the input file size. Pass `--no-resource-check` if the estimate is wrong for your input.
 
 ## See also
 

--- a/docs/commands/download.md
+++ b/docs/commands/download.md
@@ -24,7 +24,7 @@ A database has two sizes, and for the HKS databases they differ substantially:
 | `HKS_human_CHM13_v2` | 13.3 GB | 22.7 GB | **~36 GB** |
 | `HKS_arabidopsis_ColCEN` | 0.46 GB | 0.68 GB | **~1.1 GB** |
 
-Installing needs the sum of the two columns, because the archive is only deleted once extraction succeeds. `download` verifies that up front and refuses with the exact shortfall rather than filling the disk part-way through extraction; `--no-space-check` overrides it. Reinstalling over an existing copy credits the space that copy will free, and a staged or partially-downloaded archive is credited too, so a retry doesn't require room for the archive twice.
+Installing needs the sum of the two columns, because the archive is only deleted once extraction succeeds. `download` verifies that up front and refuses with the exact shortfall rather than filling the disk part-way through extraction; `--no-resource-check` overrides it. Reinstalling over an existing copy credits the space that copy will free, and a staged or partially-downloaded archive is credited too, so a retry doesn't require room for the archive twice.
 
 Sizes come from the registry's `size_gb` (extracted) and `download_size_gb` (archive) fields, in decimal GB. `df -h` reports binary GiB, so 36 GB appears there as 34 GiB. An entry that predates `download_size_gb` falls back to `size_gb` for both, and the resulting figure is labelled as an estimate.
 
@@ -44,7 +44,7 @@ Sizes come from the registry's `size_gb` (extracted) and `download_size_gb` (arc
 | `--refresh-registry` | Force a fresh fetch of the registry, ignoring any cached copy. |
 | `--force` | Re-download and re-install even if the database is already present. |
 | `--no-checksum` | Skip SHA-256 verification (not recommended; useful for debugging). |
-| `--no-space-check` | Install even if the database root looks too small to hold the archive and its extracted contents. Only useful when the registry's declared sizes are wrong for your copy of the database. |
+| `--no-resource-check` | Install even if the database root looks too small to hold the archive and its extracted contents. Only useful when the registry's declared sizes are wrong for your copy of the database. |
 | `-y, --yes` | Assume 'yes' to interactive prompts (e.g. `--remove`). |
 | `-q, --quiet` | Suppress progress bars. |
 | `-h, --help` | Show this message and exit. |

--- a/src/karyoscope/commands/_options.py
+++ b/src/karyoscope/commands/_options.py
@@ -61,3 +61,37 @@ def resolve_db_root_flag(
         command,
     )
     return legacy_db
+
+
+def resolve_resource_check_flag(
+    no_resource_check: bool,
+    no_space_check: bool,
+    *,
+    command: str,
+) -> bool:
+    """Reconcile ``--no-resource-check`` with the deprecated ``--no-space-check``.
+
+    The escape hatch originally skipped one check, on free disk. ``annotate``
+    now also refuses to start when there is not enough *memory* to hold the
+    index, and one flag governs both — so "space" had become the wrong word
+    for what it does. ``--no-space-check`` remains a hidden alias for one
+    release, per the CLI stability promise in the README.
+
+    Returns True if the resource checks should be skipped. Raises
+    :class:`click.UsageError` if both flags are supplied, and warns when the
+    legacy one is used.
+    """
+    if not no_space_check:
+        return no_resource_check
+    if no_resource_check:
+        raise click.UsageError(
+            f"`{command}`: pass --no-resource-check, not both it and "
+            "--no-space-check (the latter is a deprecated alias)."
+        )
+    logger.warning(
+        "`--no-space-check` is deprecated for `%s` and will be removed in a "
+        "future release; use `--no-resource-check` instead. It now covers "
+        "memory as well as disk.",
+        command,
+    )
+    return True

--- a/src/karyoscope/commands/annotate.py
+++ b/src/karyoscope/commands/annotate.py
@@ -37,6 +37,7 @@ import click
 
 from karyoscope import paths
 from karyoscope import progress as _progress
+from karyoscope.commands._options import resolve_resource_check_flag
 from karyoscope.core.annotate import annotate_batch
 from karyoscope.exceptions import (
     KaryoscopeError,
@@ -152,13 +153,23 @@ logger = logging.getLogger(__name__)
     "after every BED has been written in full.",
 )
 @click.option(
+    "--no-resource-check",
+    is_flag=True,
+    default=False,
+    help="Skip the up-front disk and memory checks. Disk: the output footprint "
+    "is estimated from the input size (roughly 0.8 GB per feature set per Gbp), "
+    "so pass this if that estimate is wrong for your input -- it is calibrated "
+    "on human data and can be well off for other organisms. Memory: HKS "
+    "databases need the index resident (~10 GB for a human database), read from "
+    "the index files themselves; skipping that check risks the run being killed "
+    "by the OS instead.",
+)
+@click.option(
     "--no-space-check",
     is_flag=True,
     default=False,
-    help="Skip the up-front free-space check on --outdir. The check estimates the "
-    "output footprint from the input size (roughly 0.8 GB per feature set per Gbp "
-    "of input, plus one intermediate); pass this if that estimate is wrong for "
-    "your input.",
+    hidden=True,
+    help="Deprecated alias for --no-resource-check.",
 )
 @click.option(
     "--preserve-order/--no-preserve-order",
@@ -187,6 +198,7 @@ def cmd(
     keep_presmoothed: bool,
     keep_intermediates: bool,
     bgzip: bool,
+    no_resource_check: bool,
     no_space_check: bool,
     preserve_input_order: bool,
     force: bool,
@@ -211,6 +223,7 @@ def cmd(
         karyoscope annotate -i reads.fa.gz --db KS_human_CHM13_v2 \\
                             --feature-set chromosome
     """
+    skip_checks = resolve_resource_check_flag(no_resource_check, no_space_check, command="annotate")
     db_root = paths.ensure_db_root(db_root_arg)
     inputs = list(input_paths)
     if output_dir is None:
@@ -235,7 +248,7 @@ def cmd(
         bgzip=bgzip,
         preserve_input_order=preserve_input_order,
         force=force,
-        check_space=not no_space_check,
+        check_space=not skip_checks,
         progress=_progress.from_context(),
     )
 

--- a/src/karyoscope/commands/download.py
+++ b/src/karyoscope/commands/download.py
@@ -23,7 +23,10 @@ from karyoscope import diskspace, paths
 from karyoscope import download as _download
 from karyoscope import installed as _installed
 from karyoscope import registry as _registry
-from karyoscope.commands._options import resolve_db_root_flag
+from karyoscope.commands._options import (
+    resolve_db_root_flag,
+    resolve_resource_check_flag,
+)
 from karyoscope.exceptions import (
     DatabaseNotFoundError,
     KaryoscopeError,
@@ -361,11 +364,18 @@ def _action_install(
     help="Skip SHA-256 verification (not recommended; useful for debugging).",
 )
 @click.option(
-    "--no-space-check",
+    "--no-resource-check",
     is_flag=True,
     help="Install even if the database root looks too small to hold the archive "
     "and its extracted contents. Only useful when the registry's declared "
-    "sizes are wrong for your copy of the database.",
+    "sizes are wrong for your copy of the database. (Named for consistency with "
+    "the other commands; `download` only ever checks disk.)",
+)
+@click.option(
+    "--no-space-check",
+    is_flag=True,
+    hidden=True,
+    help="Deprecated alias for --no-resource-check.",
 )
 @click.option(
     "-y",
@@ -394,6 +404,7 @@ def cmd(
     refresh_registry: bool,
     force: bool,
     no_checksum: bool,
+    no_resource_check: bool,
     no_space_check: bool,
     yes: bool,
     quiet: bool,
@@ -418,6 +429,7 @@ def cmd(
         # Remove an installed database
         karyoscope download --remove KS_mouse_v1
     """
+    skip_checks = resolve_resource_check_flag(no_resource_check, no_space_check, command="download")
     db_root = paths.ensure_db_root(resolve_db_root_flag(db_root_arg, db_alias, command="download"))
     effective_registry_url = registry_url or _registry.DEFAULT_REGISTRY_URL
 
@@ -461,7 +473,7 @@ def cmd(
             force=force,
             verify_checksum=not no_checksum,
             show_progress=not quiet,
-            check_space=not no_space_check,
+            check_space=not skip_checks,
         )
     except KaryoscopeError as e:
         # Convert known KaryoScope errors to clean user-facing messages.

--- a/src/karyoscope/core/annotate.py
+++ b/src/karyoscope/core/annotate.py
@@ -41,7 +41,7 @@ from pathlib import Path
 from typing import TextIO
 
 from karyoscope import cpus as _cpus
-from karyoscope import diskspace, preflight
+from karyoscope import diskspace, memory, preflight
 from karyoscope import installed as _installed
 from karyoscope.core.io.bgzip import bgzip_file
 from karyoscope.core.io.features import NOVEL_NAME, Features, parse_features, render_feature
@@ -51,6 +51,7 @@ from karyoscope.core.io.hierarchy import (
     validate_hierarchy,
 )
 from karyoscope.core.io.hks import (
+    estimate_hks_memory_bytes,
     run_hks_lookup_batch,
     run_hks_smooth,
 )
@@ -347,6 +348,50 @@ def estimate_output_bytes(
         else 0.0
     )
     return int(outputs + transient)
+
+
+def _require_hks_memory(
+    *,
+    manifest,
+    db_dir: Path,
+    requested: list[str],
+    what: str,
+    check: bool,
+) -> None:
+    """Refuse to start an HKS run that cannot fit its index in memory.
+
+    Only meaningful for the HKS backend, whose requirement is the index
+    files themselves rather than a function of the input -- see
+    :func:`~karyoscope.core.io.hks.estimate_hks_memory_bytes`. The KMC
+    backend has no equivalent up-front figure; it relies on the OOM hint
+    attached to its failures instead.
+
+    Fails open twice over: once if the index cannot be sized, once if the
+    available memory cannot be determined. Between them, this can only ever
+    stop a run we are confident would be killed anyway.
+    """
+    if manifest.index.type != "hks":
+        return
+    required = estimate_hks_memory_bytes(
+        db_dir=db_dir, basename=manifest.index.basename, feature_sets=requested
+    )
+    if required is None:
+        logger.debug("could not size the HKS index; not enforcing a memory requirement")
+        return
+    memory.require_memory(
+        required,
+        what=what,
+        hint=(
+            "hks holds the shared base index plus one feature set's labeling at "
+            "a time, so this figure is set by the database and does not shrink "
+            "with fewer --threads, fewer --feature-set, or a smaller input.\n"
+            "Options:\n"
+            "  - request more memory (on SLURM, e.g. --mem=16G)\n"
+            "  - move from a login node to a compute node\n"
+            "  - pass --no-space-check to attempt the run anyway"
+        ),
+        skip=not check,
+    )
 
 
 def _annotate_dependencies(*, index_type: str, input_path: Path, bgzip: bool) -> list[str]:
@@ -1337,6 +1382,17 @@ def annotate(
         ),
         skip=not check_space,
     )
+    # Memory, after disk: an HKS run's peak is the index it must hold, which
+    # is knowable exactly from the database on disk. Without this the failure
+    # is a SIGKILL part-way through the first lookup, after the index load
+    # has already been paid for.
+    _require_hks_memory(
+        manifest=manifest,
+        db_dir=db_dir,
+        requested=requested,
+        what=f"annotating {input_path.name} against {db_id_resolved}",
+        check=check_space,
+    )
 
     # Announce the run before the first expensive step. Everything below
     # this point can take twenty minutes, and until now the terminal stayed
@@ -1771,6 +1827,17 @@ def annotate_batch(
             "  - pass --no-space-check if this estimate looks wrong for your input"
         ),
         skip=not check_space,
+    )
+    # Memory, after disk: an HKS run's peak is the index it must hold, which
+    # is knowable exactly from the database on disk. Without this the failure
+    # is a SIGKILL part-way through the first lookup, after the index load
+    # has already been paid for.
+    _require_hks_memory(
+        manifest=manifest,
+        db_dir=db_dir,
+        requested=requested,
+        what=f"annotating {len(input_paths)} input(s) against {db_id_resolved}",
+        check=check_space,
     )
 
     n_threads = _cpus.resolve_threads(threads)

--- a/src/karyoscope/core/annotate.py
+++ b/src/karyoscope/core/annotate.py
@@ -388,7 +388,7 @@ def _require_hks_memory(
             "Options:\n"
             "  - request more memory (on SLURM, e.g. --mem=16G)\n"
             "  - move from a login node to a compute node\n"
-            "  - pass --no-space-check to attempt the run anyway"
+            "  - pass --no-resource-check to attempt the run anyway"
         ),
         skip=not check,
     )
@@ -1378,7 +1378,7 @@ def annotate(
             "  - write to a larger filesystem with --outdir\n"
             "  - annotate fewer feature sets at a time with --feature-set\n"
             "  - drop one of the two outputs with --no-keep-presmoothed or --no-smooth\n"
-            "  - pass --no-space-check if this estimate looks wrong for your input"
+            "  - pass --no-resource-check if this estimate looks wrong for your input"
         ),
         skip=not check_space,
     )
@@ -1824,7 +1824,7 @@ def annotate_batch(
             "  - write to a larger filesystem with --outdir\n"
             "  - annotate fewer inputs or feature sets at a time\n"
             "  - drop one of the two outputs with --no-keep-presmoothed or --no-smooth\n"
-            "  - pass --no-space-check if this estimate looks wrong for your input"
+            "  - pass --no-resource-check if this estimate looks wrong for your input"
         ),
         skip=not check_space,
     )

--- a/src/karyoscope/core/external.py
+++ b/src/karyoscope/core/external.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+import signal
 import subprocess
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -36,12 +37,63 @@ class ToolNotFoundError(KaryoscopeError):
     """A required external tool was not found on ``$PATH``."""
 
 
+#: Exit codes that mean "killed by the OS or job scheduler" rather than a
+#: tool-internal failure. ``-9`` is SIGKILL as Python's ``subprocess``
+#: reports it (negative signal number); ``137`` is the shell-style
+#: ``128 + 9`` that SLURM, Docker and other wrappers report for the same
+#: signal. Nothing KaryoScope invokes raises SIGKILL on itself, so this is
+#: ~always the kernel OOM-killer or a scheduler memory limit.
+OOM_LIKE_EXIT_CODES: frozenset[int] = frozenset({-9, 137})
+
+
+def describe_returncode(returncode: int) -> str:
+    """Render a subprocess return code the way a user can act on it.
+
+    A negative code is not an exit status at all — it is a signal number,
+    which is exactly the confusion this exists to prevent. "exit code -9"
+    sends people searching for a code that does not exist, while "killed by
+    SIGKILL" finds the answer immediately.
+    """
+    if returncode < 0:
+        try:
+            name = signal.Signals(-returncode).name
+        except ValueError:  # pragma: no cover — signal not known to Python
+            return f"killed by signal {-returncode}"
+        return f"killed by {name} (signal {-returncode})"
+    if returncode > 128:
+        # 128 + N is how shells and schedulers report a signal death.
+        try:
+            name = signal.Signals(returncode - 128).name
+        except ValueError:
+            return f"exit code {returncode}"
+        return f"exit code {returncode} (killed by {name})"
+    return f"exit code {returncode}"
+
+
+#: Appended whenever a tool dies with an OOM-like code. The caller supplies
+#: the tool-specific part (how much memory that tool actually needs); this
+#: is the part that is true of every one of them.
+_OOM_PREAMBLE = (
+    "\n\n--- KaryoScope hint ---\n"
+    "{description} almost always means the process was killed for using too "
+    "much memory -- by the kernel OOM-killer or by the job scheduler (SLURM, "
+    "PBS, etc.). It is not an error the tool itself reported.\n"
+)
+
+
 class ExternalToolError(KaryoscopeError):
     """An external command exited with a non-zero status.
 
     The exception carries the original command, exit code, and captured
     stderr/stdout for inspection by callers that want to handle specific
     failure modes.
+
+    ``oom_hint`` is tool-specific advice appended only when the process was
+    killed by a signal that means "out of memory" — the memory figures
+    differ by an order of magnitude between backends, so the generic layer
+    cannot supply them. Ordinary failures never see it: pointing at memory
+    when the real cause is a malformed input would be worse than saying
+    nothing.
     """
 
     def __init__(
@@ -50,22 +102,34 @@ class ExternalToolError(KaryoscopeError):
         returncode: int,
         stderr: str = "",
         stdout: str = "",
+        oom_hint: str | None = None,
     ) -> None:
         self.cmd = list(cmd)
         self.returncode = returncode
         self.stderr = stderr
         self.stdout = stdout
+        self.oom_hint = oom_hint
         super().__init__(self._format_message())
+
+    @property
+    def killed_by_signal(self) -> bool:
+        """True if the process was killed rather than exiting on its own."""
+        return self.returncode in OOM_LIKE_EXIT_CODES or self.returncode < 0
 
     def _format_message(self) -> str:
         cmd_str = " ".join(str(c) for c in self.cmd)
-        msg = f"command failed with exit code {self.returncode}: {cmd_str}"
+        description = describe_returncode(self.returncode)
+        msg = f"command failed with {description}: {cmd_str}"
         if self.stderr:
             # Include the tail of stderr to help diagnose; full stderr is
             # available on the exception object for callers that want it.
             tail = "\n".join(self.stderr.strip().splitlines()[-10:])
             if tail:
                 msg += f"\n--- stderr (last 10 lines) ---\n{tail}"
+        if self.returncode in OOM_LIKE_EXIT_CODES:
+            msg += _OOM_PREAMBLE.format(description=description.capitalize())
+            if self.oom_hint:
+                msg += self.oom_hint
         return msg
 
 
@@ -109,6 +173,7 @@ def run_tool(
     env: Mapping[str, str] | None = None,
     input_text: str | None = None,
     timeout: float | None = None,
+    oom_hint: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run an external command and return its :class:`CompletedProcess`.
 
@@ -151,6 +216,9 @@ def run_tool(
     timeout
         Seconds before the subprocess is killed. On expiry,
         :class:`subprocess.TimeoutExpired` propagates to the caller.
+    oom_hint
+        Tool-specific advice appended to the error only when the process is
+        killed by an out-of-memory-like signal. See :class:`ExternalToolError`.
     """
     cmd_list = [str(c) for c in cmd]
     logger.debug("running: %s", " ".join(cmd_list))
@@ -177,6 +245,7 @@ def run_tool(
             result.returncode,
             stderr=result.stderr or "",
             stdout=result.stdout or "",
+            oom_hint=oom_hint,
         )
 
     if must_capture and not capture:

--- a/src/karyoscope/core/io/hks.py
+++ b/src/karyoscope/core/io/hks.py
@@ -44,6 +44,27 @@ ENV_OVERRIDE = "KARYOSCOPE_HKS"
 #: the output is needed to rewrite it.
 _HKS_MISS_LABEL = "none"
 
+#: Advice appended when ``hks`` is killed by an OOM-like signal. Detection
+#: lives in :mod:`karyoscope.core.external`; only the figures are backend
+#: specific, and HKS's are far below KMC's -- telling an HKS user to request
+#: 100 GB would be as unhelpful as telling them nothing.
+#:
+#: The numbers are measured, not estimated: peak RSS is the index itself --
+#: the shared base plus one feature set's labeling at a time -- so it is
+#: ~10 GB for a human database whatever is being annotated, and barely moves
+#: with --threads.
+HKS_OOM_HINT = (
+    "hks holds the index in memory: the shared base index plus one feature "
+    "set's labeling at a time. For a human-scale database that is ~10 GB, "
+    "and it does not shrink with fewer --threads or a smaller input.\n"
+    "Recommended fixes:\n"
+    "  * On a SLURM cluster: request at least 16 GB (e.g. --mem=16G).\n"
+    "  * On a login node: move to a compute node.\n"
+    "  * Check the database's index size on disk -- `du -sh <db>/index` is a "
+    "good lower bound for what one lookup needs resident.\n"
+)
+
+
 #: Default max-gap (bases) passed to ``hks smooth``, matching karyoscope's Python default.
 _DEFAULT_SMOOTH_MAX_GAP = 1000
 
@@ -111,6 +132,42 @@ def get_hks_binary() -> str:
         f"Build HKS from source (cargo build --release in the HKS repo) "
         f"and place the binary on PATH, or set {ENV_OVERRIDE} to its location."
     )
+
+
+def estimate_hks_memory_bytes(
+    *, db_dir: Path, basename: str, feature_sets: list[str]
+) -> int | None:
+    """Bytes ``hks`` must hold resident to query ``feature_sets``.
+
+    Unlike the output-size estimate, this is not extrapolated from anything:
+    ``hks`` loads the shared base index plus **one** feature set's labeling
+    at a time, so the peak is the base plus the largest labeling among those
+    requested, and both are files whose size can simply be read.
+
+    That structure is why the figure barely moves with ``--threads`` or with
+    input size, and why a single haplotype costs the same as a diploid.
+    Measured on the human database: base 6.04 GiB + largest labeling
+    3.02 GiB = 9.06 GiB, against a 10.04 GB observed peak — the remainder is
+    query buffering, covered by the caller's margin.
+
+    Returns ``None`` if the files cannot be sized, so the caller can fail
+    open rather than block on a database it could not inspect.
+    """
+    base = db_dir / f"{basename}.hksb"
+    try:
+        total = base.stat().st_size
+    except OSError:
+        return None
+
+    largest = 0
+    for fs in feature_sets:
+        try:
+            largest = max(largest, (db_dir / f"{basename}.{fs}.hksf").stat().st_size)
+        except OSError:
+            return None
+    if largest == 0:
+        return None
+    return total + largest
 
 
 def _infer_prefix(input_path: Path, db_basename: str) -> str:
@@ -254,7 +311,7 @@ def run_hks_lookup_batch(
             cmd += ["-q", str(query_path), "-o", str(output_path)]
 
         logger.debug("running (batch, %d queries): %s", len(io_pairs), " ".join(cmd))
-        _relay_hks_log(run_tool(cmd, capture=capture), "lookup-batch")
+        _relay_hks_log(run_tool(cmd, capture=capture, oom_hint=HKS_OOM_HINT), "lookup-batch")
     finally:
         for p in tmp_fastas:
             if p.exists():
@@ -338,7 +395,7 @@ def run_hks_smooth(
         "--no-header",
     ]
     logger.debug("running: %s", " ".join(cmd))
-    _relay_hks_log(run_tool(cmd, capture=capture), "smooth")
+    _relay_hks_log(run_tool(cmd, capture=capture, oom_hint=HKS_OOM_HINT), "smooth")
 
     return output_path
 
@@ -419,7 +476,7 @@ def run_hks_build_base(
         cmd.append("--forward-only")
 
     logger.debug("running: %s", " ".join(cmd))
-    run_tool(cmd, capture=capture)
+    run_tool(cmd, capture=capture, oom_hint=HKS_OOM_HINT)
     return output_path
 
 
@@ -521,7 +578,7 @@ def run_hks_add_feature_set(
     cmd += ["-t", str(n_threads)]
 
     logger.debug("running: %s", " ".join(cmd))
-    run_tool(cmd, capture=capture)
+    run_tool(cmd, capture=capture, oom_hint=HKS_OOM_HINT)
     return output_path
 
 

--- a/src/karyoscope/core/io/kmc.py
+++ b/src/karyoscope/core/io/kmc.py
@@ -70,23 +70,13 @@ _MARKER_SCHEMA = 1
 #: Environment variable users can set to override the binary location.
 ENV_OVERRIDE = "KARYOSCOPE_GET_FEATUREIDS"
 
-#: Exit codes that almost always mean "killed by the OS or job
-#: scheduler" rather than a get_featureIDs-internal failure. ``-9`` is
-#: SIGKILL as Python reports it (negative); ``137`` is the same signal
-#: as the shell-style ``128 + 9`` that SLURM and Docker report when
-#: they wrap the process. Reserved for the OOM-hint augmentation in
-#: :func:`_augment_with_oom_hint` -- a SIGKILL on get_featureIDs is
-#: ~always the OOM-killer (kernel or SLURM) because the KMC index is
-#: large and the binary doesn't ever raise SIGKILL on itself.
-_OOM_LIKE_EXIT_CODES: frozenset[int] = frozenset({-9, 137})
-
-
-_OOM_HINT_TEMPLATE = (
-    "\n\n--- KaryoScope hint ---\n"
-    "Exit code {code} almost always means get_featureIDs was killed for "
-    "using too much memory -- by the kernel OOM-killer or by the job "
-    "scheduler (SLURM, PBS, etc.). The KMC index for a human-scale "
-    "database needs ~20-30 GB to load, plus per-thread working memory.\n"
+#: Advice appended when ``get_featureIDs`` is killed by an OOM-like signal.
+#: The detection itself lives in :mod:`karyoscope.core.external`, which
+#: applies to every tool; only the memory figures are backend-specific, and
+#: KMC's are an order of magnitude above HKS's.
+KMC_OOM_HINT = (
+    "The KMC index for a human-scale database needs ~20-30 GB to load, plus "
+    "per-thread working memory.\n"
     "Recommended fixes:\n"
     "  * On a SLURM cluster: request more memory (e.g. --mem=100G) and "
     "limit threads (--cpus-per-task=16).\n"
@@ -105,23 +95,22 @@ def _augment_with_oom_hint(
     stderr: str = "",
     stdout: str = "",
 ) -> ExternalToolError:
-    """Build an :class:`ExternalToolError`, appending an OOM hint for SIGKILL.
+    """Build an :class:`ExternalToolError` carrying KMC's memory advice.
 
-    SIGKILL is unrecoverable and rare; on KaryoScope's k-mer-query
-    step it's overwhelmingly "the OS or SLURM killed the process for
-    using too much memory." Two early colleagues hit this in v0.1.0
-    testing -- both had under-allocated memory and got the bare
-    ``Error: command failed with exit code -9`` message which is
-    opaque to non-cluster-experienced users. This helper attaches an
-    actionable hint when the exit code matches.
-
-    Non-OOM exit codes (e.g. malformed input, missing files) get the
-    plain :class:`ExternalToolError` with no hint -- we don't want
-    to point at memory when the real cause is something else.
+    Used on the paths that drive ``get_featureIDs`` through raw
+    :mod:`subprocess` rather than :func:`run_tool`, so they get the same
+    hint. Whether the advice is actually shown is decided in
+    :class:`ExternalToolError` from the return code -- ordinary failures
+    (malformed input, missing files) never see it, because pointing at
+    memory when the cause is something else is worse than saying nothing.
     """
-    if returncode in _OOM_LIKE_EXIT_CODES:
-        stderr = (stderr or "") + _OOM_HINT_TEMPLATE.format(code=returncode)
-    return ExternalToolError(cmd=cmd, returncode=returncode, stderr=stderr, stdout=stdout)
+    return ExternalToolError(
+        cmd=cmd,
+        returncode=returncode,
+        stderr=stderr,
+        stdout=stdout,
+        oom_hint=KMC_OOM_HINT,
+    )
 
 
 def _editable_install_candidate() -> Path | None:
@@ -411,19 +400,10 @@ def run_get_featureids(
     if input_format is not None:
         cmd += ["--input-format", input_format]
 
-    try:
-        run_tool(cmd, capture=capture)
-    except ExternalToolError as e:
-        # Re-raise with an OOM hint if the exit code looks like a
-        # SIGKILL. Pass-through for everything else.
-        if e.returncode in _OOM_LIKE_EXIT_CODES:
-            raise _augment_with_oom_hint(
-                cmd=list(e.cmd),
-                returncode=e.returncode,
-                stderr=e.stderr,
-                stdout=e.stdout,
-            ) from e
-        raise
+    # The hint rides along on every invocation; ExternalToolError shows it
+    # only when the return code says the process was killed, so ordinary
+    # failures are unaffected.
+    run_tool(cmd, capture=capture, oom_hint=KMC_OOM_HINT)
     write_combined_marker(out_path, prefix=prefix, db_path=db_path, input_path=input_path)
     return out_path
 

--- a/src/karyoscope/diskspace.py
+++ b/src/karyoscope/diskspace.py
@@ -146,7 +146,7 @@ def require_free_space(
         Extra command-specific advice appended to the error.
     skip
         If True, log the numbers at INFO and return without raising. Wired
-        to the ``--no-space-check`` flags.
+        to the ``--no-resource-check`` flags.
 
     Raises
     ------

--- a/src/karyoscope/download.py
+++ b/src/karyoscope/download.py
@@ -284,7 +284,7 @@ def _check_install_space(entry: DatabaseEntry, db_root: Path, *, skip: bool) -> 
             "archive was assumed to be the same size as the extracted database. "
             "Refresh the registry with --refresh-registry."
         )
-    hint_lines.append("  Pass --no-space-check to attempt the install anyway.")
+    hint_lines.append("  Pass --no-resource-check to attempt the install anyway.")
 
     diskspace.require_free_space(
         db_root,

--- a/src/karyoscope/exceptions.py
+++ b/src/karyoscope/exceptions.py
@@ -75,6 +75,10 @@ class InsufficientDiskSpaceError(KaryoscopeError):
     """
 
 
+class InsufficientMemoryError(KaryoscopeError):
+    """Less memory is available than the step about to run requires."""
+
+
 class MissingDependencyError(KaryoscopeError):
     """One or more required external tools are not available.
 

--- a/src/karyoscope/memory.py
+++ b/src/karyoscope/memory.py
@@ -160,7 +160,7 @@ def require_memory(
         Extra advice appended to the failure message.
     skip
         If True, log and return without raising. Wired to the same
-        ``--no-space-check`` escape as the disk check.
+        ``--no-resource-check`` escape as the disk check.
 
     Raises
     ------

--- a/src/karyoscope/memory.py
+++ b/src/karyoscope/memory.py
@@ -172,14 +172,11 @@ def require_memory(
     resolved = available_bytes()
 
     if skip:
-        logger.info(
-            "memory check skipped for %s: need ~%.1f GB", what, needed / GB
-        )
+        logger.info("memory check skipped for %s: need ~%.1f GB", what, needed / GB)
         return
     if resolved is None:
         logger.debug(
-            "could not determine available memory; not enforcing the ~%.1f GB "
-            "%s needs",
+            "could not determine available memory; not enforcing the ~%.1f GB %s needs",
             needed / GB,
             what,
         )

--- a/src/karyoscope/memory.py
+++ b/src/karyoscope/memory.py
@@ -1,0 +1,210 @@
+"""Available-memory accounting for the steps that load a large index.
+
+KaryoScope already refuses to start when the *disk* is too small
+(:mod:`karyoscope.diskspace`). Memory had no equivalent, and it is the
+easier of the two to get wrong: the HKS backend holds the index resident,
+so a human-scale database needs ~10 GB whatever is being annotated, and a
+run that under-requests is killed by the kernel — mid-query, with no
+warning, after the index load has already been paid for.
+
+The requirement is unusually knowable here. It is not a heuristic scaled
+from the input like the output-size estimate; it is the size of the index
+files themselves, readable from disk before anything runs. See
+:func:`karyoscope.core.io.hks.estimate_hks_memory_bytes`.
+
+Fail-open by design
+===================
+
+Every resolver below can legitimately return nothing — macOS has no
+``/proc``, a bare machine has no cgroup, a user may run outside SLURM. When
+the limit cannot be determined, :func:`require_memory` logs and returns
+rather than blocking: refusing to run because we could not measure
+something would break working setups, while letting it through costs at
+worst the OOM message the tool would have produced anyway (which
+:mod:`karyoscope.core.external` now makes legible).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from karyoscope.exceptions import InsufficientMemoryError
+
+logger = logging.getLogger(__name__)
+
+#: Headroom over the measured requirement. The index is not the whole
+#: footprint — there are query buffers, the allocator's slack, and the
+#: Python parent — and a run driven to exactly its limit is killed rather
+#: than slowed. Measured overhead above the index size was ~0.3-1.0 GB on
+#: human data, comfortably inside this.
+DEFAULT_MARGIN = 0.15
+
+#: Bytes per decimal GB, matching :mod:`karyoscope.diskspace`.
+GB = 1_000_000_000
+
+_CGROUP_V2_MAX = Path("/sys/fs/cgroup/memory.max")
+_CGROUP_V1_MAX = Path("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+_MEMINFO = Path("/proc/meminfo")
+
+#: A cgroup limit at or above this is the kernel's "unlimited" sentinel in
+#: disguise rather than a real cap, so it is ignored. cgroup v1 reports
+#: something near 2^63; v2 writes the literal string ``max``.
+_EFFECTIVELY_UNLIMITED = 1 << 62
+
+
+def _read_int(path: Path) -> int | None:
+    try:
+        text = path.read_text().strip()
+    except OSError:
+        return None
+    if text == "max":
+        return None
+    try:
+        value = int(text)
+    except ValueError:
+        return None
+    return value if 0 < value < _EFFECTIVELY_UNLIMITED else None
+
+
+def _slurm_allocation_bytes() -> int | None:
+    """Memory SLURM granted this job, if it says so.
+
+    Checked before the cgroup because a site can schedule by memory without
+    enforcing it via cgroups, in which case the allocation is real but
+    invisible to every other resolver — and exceeding it still gets the job
+    killed.
+    """
+    per_node = os.environ.get("SLURM_MEM_PER_NODE")
+    if per_node and per_node.isdigit():
+        return int(per_node) * 1024 * 1024  # SLURM reports MB
+    per_cpu = os.environ.get("SLURM_MEM_PER_CPU")
+    cpus = os.environ.get("SLURM_CPUS_PER_TASK") or os.environ.get("SLURM_JOB_CPUS_PER_NODE")
+    if per_cpu and per_cpu.isdigit() and cpus and cpus.isdigit():
+        return int(per_cpu) * int(cpus) * 1024 * 1024
+    return None
+
+
+def _cgroup_limit_bytes() -> int | None:
+    """The cgroup memory ceiling, which is what actually kills the process.
+
+    Covers containers and SLURM sites that bind with cgroups. v2 first,
+    since v1 lingers only on older kernels.
+    """
+    return _read_int(_CGROUP_V2_MAX) or _read_int(_CGROUP_V1_MAX)
+
+
+def _meminfo_available_bytes() -> int | None:
+    """``MemAvailable`` from ``/proc/meminfo``.
+
+    Deliberately ``MemAvailable`` rather than ``MemFree``: the kernel's own
+    estimate of what a new allocation could obtain, counting reclaimable
+    page cache. ``MemFree`` on a busy node reads near zero because the cache
+    is doing its job, and would reject every run.
+    """
+    try:
+        for line in _MEMINFO.read_text().splitlines():
+            if line.startswith("MemAvailable:"):
+                return int(line.split()[1]) * 1024  # kB
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+def available_bytes() -> tuple[int, str] | None:
+    """Return ``(bytes, source)`` for the memory this process may use.
+
+    Resolved in order of authority, mirroring :mod:`karyoscope.cpus`:
+
+    1. ``$SLURM_MEM_PER_NODE`` / ``$SLURM_MEM_PER_CPU`` — what the scheduler
+       granted, correct even where cgroups do not enforce it.
+    2. The cgroup limit — what will actually kill the process, in a
+       container or a cgroup-bound job.
+    3. ``MemAvailable`` — the machine, for an unconstrained run.
+
+    ``None`` means "could not determine", never "no memory".
+    """
+    slurm = _slurm_allocation_bytes()
+    if slurm is not None:
+        return slurm, "$SLURM_MEM_PER_NODE/$SLURM_MEM_PER_CPU"
+    cgroup = _cgroup_limit_bytes()
+    if cgroup is not None:
+        return cgroup, "the cgroup memory limit"
+    meminfo = _meminfo_available_bytes()
+    if meminfo is not None:
+        return meminfo, "MemAvailable in /proc/meminfo"
+    return None
+
+
+def require_memory(
+    required_bytes: int,
+    *,
+    what: str,
+    margin: float = DEFAULT_MARGIN,
+    hint: str | None = None,
+    skip: bool = False,
+) -> None:
+    """Raise unless this process may use ``required_bytes`` (plus margin).
+
+    Parameters
+    ----------
+    required_bytes
+        The measured requirement — for HKS, the size of the index files
+        that must be resident.
+    what
+        What the memory is for, used in the message.
+    margin
+        Fractional headroom added on top of ``required_bytes``.
+    hint
+        Extra advice appended to the failure message.
+    skip
+        If True, log and return without raising. Wired to the same
+        ``--no-space-check`` escape as the disk check.
+
+    Raises
+    ------
+    InsufficientMemoryError
+        Only when the available memory could actually be determined and is
+        below the requirement. An undeterminable limit is never an error.
+    """
+    needed = int(required_bytes * (1 + margin))
+    resolved = available_bytes()
+
+    if skip:
+        logger.info(
+            "memory check skipped for %s: need ~%.1f GB", what, needed / GB
+        )
+        return
+    if resolved is None:
+        logger.debug(
+            "could not determine available memory; not enforcing the ~%.1f GB "
+            "%s needs",
+            needed / GB,
+            what,
+        )
+        return
+
+    have, source = resolved
+    if have >= needed:
+        logger.info(
+            "memory check passed for %s: need ~%.1f GB, %.1f GB available (per %s)",
+            what,
+            needed / GB,
+            have / GB,
+            source,
+        )
+        return
+
+    lines = [
+        f"not enough memory for {what}: "
+        f"needs ~{needed / GB:.1f} GB but only {have / GB:.1f} GB is available "
+        f"(per {source}); short by {(needed - have) / GB:.1f} GB."
+    ]
+    if hint:
+        lines.append(hint)
+    lines.append(
+        "This is checked up front because the alternative is the kernel "
+        "killing the run mid-query with no explanation."
+    )
+    raise InsufficientMemoryError("\n".join(lines))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -49,3 +52,96 @@ def test_info_command_runs(cli_runner: CliRunner) -> None:
     result = cli_runner.invoke(main, ["info"])
     assert result.exit_code == 0
     assert "database root" in result.output.lower()
+
+
+# --- --no-resource-check / --no-space-check ---------------------------
+
+
+def test_resource_check_flag_prefers_the_new_name() -> None:
+    from karyoscope.commands._options import resolve_resource_check_flag
+
+    assert resolve_resource_check_flag(True, False, command="annotate") is True
+    assert resolve_resource_check_flag(False, False, command="annotate") is False
+
+
+def test_the_deprecated_alias_still_works_and_warns(caplog: pytest.LogCaptureFixture) -> None:
+    """--no-space-check shipped in 2.1.0 and is documented, so it cannot just vanish.
+
+    The README promises deprecations ship with warnings and a back-compatible
+    transition; this is that transition.
+    """
+    from karyoscope.commands._options import resolve_resource_check_flag
+
+    with caplog.at_level("WARNING"):
+        assert resolve_resource_check_flag(False, True, command="annotate") is True
+    assert "deprecated" in caplog.text
+    assert "--no-resource-check" in caplog.text
+
+
+def test_supplying_both_spellings_is_a_usage_error() -> None:
+    from karyoscope.commands._options import resolve_resource_check_flag
+
+    with pytest.raises(click.UsageError, match="not both"):
+        resolve_resource_check_flag(True, True, command="annotate")
+
+
+def test_both_spellings_are_accepted_by_the_cli(tmp_path: Path) -> None:
+    """The alias must remain wired, not merely defined.
+
+    Deliberately does NOT use --help to prove it: --help short-circuits
+    before the command body, so it happily passes while the body raises
+    NameError on a missing import. That exact bug got through an earlier
+    version of this test.
+    """
+    from click.testing import CliRunner
+
+    from karyoscope.cli import main
+
+    help_text = CliRunner().invoke(main, ["annotate", "--help"]).output
+    assert "--no-resource-check" in help_text
+    assert "--no-space-check" not in help_text  # hidden, but still parses
+
+    fasta = tmp_path / "in.fa"
+    fasta.write_text(">c\nACGT\n")
+    for flag in ("--no-resource-check", "--no-space-check"):
+        result = CliRunner().invoke(
+            main,
+            [
+                "annotate",
+                "-i",
+                str(fasta),
+                "--outdir",
+                str(tmp_path / "out"),
+                "--db-root",
+                str(tmp_path / "nodb"),
+                flag,
+            ],
+        )
+        # It must get far enough to fail on the *database*, which proves the
+        # flag parsed and the command body ran.
+        assert "NameError" not in str(result.exception or ""), flag
+        assert result.exit_code != 0, flag
+
+
+def test_supplying_both_spellings_is_rejected_by_the_cli(tmp_path: Path) -> None:
+    from click.testing import CliRunner
+
+    from karyoscope.cli import main
+
+    fasta = tmp_path / "in.fa"
+    fasta.write_text(">c\nACGT\n")
+    result = CliRunner().invoke(
+        main,
+        [
+            "annotate",
+            "-i",
+            str(fasta),
+            "--outdir",
+            str(tmp_path / "out"),
+            "--db-root",
+            str(tmp_path / "nodb"),
+            "--no-resource-check",
+            "--no-space-check",
+        ],
+    )
+    assert "not both" in result.output

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -11,6 +11,7 @@ import pytest
 from karyoscope.core.external import (
     ExternalToolError,
     ToolNotFoundError,
+    describe_returncode,
     require_tool,
     run_tool,
 )
@@ -144,3 +145,62 @@ def test_run_tool_message_truncates_long_stderr() -> None:
     # Earlier lines should not be in the message preview (but should be on .stderr)
     assert "line 0\n" not in msg
     assert "line 0" in exc_info.value.stderr
+
+
+# --- signal / OOM reporting -------------------------------------------
+
+
+def test_negative_returncode_is_reported_as_a_signal() -> None:
+    """-9 is not an exit code, and calling it one sends users nowhere.
+
+    This is the exact message a colleague hit: `exit code -9` is
+    unsearchable, while SIGKILL points straight at the cause.
+    """
+    assert describe_returncode(-9) == "killed by SIGKILL (signal 9)"
+    assert describe_returncode(-15) == "killed by SIGTERM (signal 15)"
+
+
+def test_shell_style_signal_codes_are_translated() -> None:
+    """SLURM and Docker report 128 + N for a signal death."""
+    assert "SIGKILL" in describe_returncode(137)
+    assert "137" in describe_returncode(137)
+
+
+def test_ordinary_exit_codes_are_left_alone() -> None:
+    assert describe_returncode(1) == "exit code 1"
+    assert describe_returncode(2) == "exit code 2"
+
+
+def test_oom_hint_is_shown_only_for_oom_like_codes() -> None:
+    hint = "Request at least 16 GB.\n"
+    for code in (-9, 137):
+        e = ExternalToolError(["hks", "lookup"], code, oom_hint=hint)
+        assert "Request at least 16 GB." in str(e), code
+        assert "KaryoScope hint" in str(e), code
+    for code in (1, 2, -15):
+        e = ExternalToolError(["hks", "lookup"], code, oom_hint=hint)
+        assert "Request at least 16 GB." not in str(e), code
+
+
+def test_the_hint_never_pollutes_captured_stderr() -> None:
+    """stderr must stay exactly what the tool wrote.
+
+    An earlier version spliced the hint into stderr, so a caller inspecting
+    it programmatically saw KaryoScope's words mixed into the tool's output.
+    """
+    e = ExternalToolError(["hks"], -9, stderr="real tool output\n", oom_hint="advice\n")
+    assert e.stderr == "real tool output\n"
+    assert "advice" in str(e)
+
+
+def test_a_tool_with_no_hint_still_explains_the_signal() -> None:
+    """Every tool benefits from the translation, even without advice."""
+    e = ExternalToolError(["bgzip", "-f", "x.bed"], -9)
+    assert "SIGKILL" in str(e)
+    assert "out of memory" in str(e) or "too much memory" in str(e)
+
+
+def test_killed_by_signal_predicate() -> None:
+    assert ExternalToolError(["x"], -9).killed_by_signal
+    assert ExternalToolError(["x"], 137).killed_by_signal
+    assert not ExternalToolError(["x"], 1).killed_by_signal

--- a/tests/test_hks.py
+++ b/tests/test_hks.py
@@ -26,7 +26,7 @@ def _capture_lookup_cmd(
     monkeypatch.setattr("karyoscope.core.io.hks.get_hks_binary", lambda: "hks")
     monkeypatch.setattr(
         "karyoscope.core.io.hks.run_tool",
-        lambda cmd, capture=False: captured.__setitem__("cmd", cmd),
+        lambda cmd, capture=False, **kw: captured.__setitem__("cmd", cmd),
     )
     run_hks_lookup(
         base_path=tmp_path / "features.hksb",
@@ -65,7 +65,7 @@ def _capture_smooth_cmd(
     monkeypatch.setattr("karyoscope.core.io.hks.get_hks_binary", lambda: "hks")
     monkeypatch.setattr(
         "karyoscope.core.io.hks.run_tool",
-        lambda cmd, capture=False: captured.__setitem__("cmd", cmd),
+        lambda cmd, capture=False, **kw: captured.__setitem__("cmd", cmd),
     )
     run_hks_smooth(
         hierarchy_file=tmp_path / "features.chromosome.hierarchy.txt",
@@ -173,7 +173,7 @@ def _capture_cmd(monkeypatch: pytest.MonkeyPatch) -> dict:
     monkeypatch.setattr("karyoscope.core.io.hks.get_hks_binary", lambda: "hks")
     monkeypatch.setattr(
         "karyoscope.core.io.hks.run_tool",
-        lambda cmd, capture=False: captured.__setitem__("cmd", [str(c) for c in cmd]),
+        lambda cmd, capture=False, **kw: captured.__setitem__("cmd", [str(c) for c in cmd]),
     )
     return captured
 
@@ -277,7 +277,7 @@ def _capture_batch_cmd(
     monkeypatch.setattr("karyoscope.core.io.hks.get_hks_binary", lambda: "hks")
     monkeypatch.setattr(
         "karyoscope.core.io.hks.run_tool",
-        lambda cmd, capture=False: captured.__setitem__("cmd", cmd),
+        lambda cmd, capture=False, **kw: captured.__setitem__("cmd", cmd),
     )
     io_pairs = [(tmp_path / f"in{i}.fa", tmp_path / f"out{i}.bed") for i in range(n_inputs)]
     run_hks_lookup_batch(
@@ -341,7 +341,7 @@ def test_batch_lookup_with_no_inputs_does_nothing(
     calls: list[object] = []
     monkeypatch.setattr("karyoscope.core.io.hks.get_hks_binary", lambda: "hks")
     monkeypatch.setattr(
-        "karyoscope.core.io.hks.run_tool", lambda cmd, capture=False: calls.append(cmd)
+        "karyoscope.core.io.hks.run_tool", lambda cmd, capture=False, **kw: calls.append(cmd)
     )
     run_hks_lookup_batch(
         base_path=tmp_path / "b.hksb",

--- a/tests/test_kmc_wrapper.py
+++ b/tests/test_kmc_wrapper.py
@@ -18,10 +18,15 @@ from karyoscope.core.io.kmc import _augment_with_oom_hint, _infer_prefix
 
 
 class TestAugmentWithOomHint:
-    """The OOM hint is appended only for SIGKILL-like exit codes
-    (-9, 137). Everything else passes through with no hint, because
-    pointing the user at memory when their input is malformed (or
-    similar) would be misleading.
+    """The OOM hint is shown only for SIGKILL-like exit codes (-9, 137).
+
+    Everything else passes through with no hint, because pointing the user at
+    memory when their input is malformed (or similar) would be misleading.
+
+    Note the hint now lands in the exception *message*, not in ``stderr``.
+    The previous version spliced KaryoScope's own text into the captured
+    stderr, so any caller inspecting it programmatically saw our words mixed
+    into the tool's output. stderr is now left exactly as the tool wrote it.
     """
 
     cmd: ClassVar[list[str]] = ["get_featureIDs", "--db", "x"]
@@ -29,51 +34,56 @@ class TestAugmentWithOomHint:
     def test_sigkill_python_form_gets_hint(self) -> None:
         e = _augment_with_oom_hint(cmd=self.cmd, returncode=-9, stderr="upstream error\n")
         assert isinstance(e, ExternalToolError)
-        assert "OOM-killer" in e.stderr or "OOM" in e.stderr.upper()
-        assert "upstream error" in e.stderr  # original preserved
+        assert "OOM-killer" in str(e)
+        assert "upstream error" in str(e)  # the tool's own output is preserved
+        assert e.stderr == "upstream error\n"  # ... and left unpolluted
         assert e.returncode == -9
+
+    def test_sigkill_is_described_as_a_signal_not_an_exit_code(self) -> None:
+        """-9 is not an exit code, and calling it one sends people nowhere.
+
+        A user searching "exit code -9" finds little; "SIGKILL" finds the
+        answer immediately.
+        """
+        e = _augment_with_oom_hint(cmd=self.cmd, returncode=-9)
+        assert "SIGKILL" in str(e)
+        assert "exit code -9" not in str(e)
 
     def test_sigkill_shell_form_gets_hint(self) -> None:
         """``137`` is the shell-style ``128 + 9`` SLURM reports."""
         e = _augment_with_oom_hint(cmd=self.cmd, returncode=137)
-        assert "OOM" in e.stderr.upper()
-        assert "137" in e.stderr  # the actual code is interpolated
+        assert "OOM" in str(e).upper()
+        assert "137" in str(e)
+        assert "SIGKILL" in str(e)  # translated, not left as a bare number
+
+    def test_hint_mentions_actionable_fixes(self) -> None:
+        e = _augment_with_oom_hint(cmd=self.cmd, returncode=-9)
+        msg = str(e)
+        assert "--mem" in msg  # request more memory
+        assert "GB" in msg  # and says how much
 
     def test_non_oom_exit_code_does_not_get_hint(self) -> None:
         """Plain failures (malformed input, missing file, etc.) shouldn't
         be misattributed to memory issues."""
         e = _augment_with_oom_hint(cmd=self.cmd, returncode=1, stderr="parse error at line 3")
-        assert "OOM" not in e.stderr.upper()
-        assert "KaryoScope hint" not in e.stderr
+        assert "OOM" not in str(e).upper()
+        assert "KaryoScope hint" not in str(e)
         assert e.stderr == "parse error at line 3"
 
     def test_sigterm_does_not_get_oom_hint(self) -> None:
         """SIGTERM (-15) is normally a user / scheduler ``timeout`` kill,
         not OOM. Pointing at memory would be misleading."""
         e = _augment_with_oom_hint(cmd=self.cmd, returncode=-15)
-        assert "KaryoScope hint" not in e.stderr
+        assert "KaryoScope hint" not in str(e)
+        # ... but it is still reported as a signal rather than an exit code.
+        assert "SIGTERM" in str(e)
 
     def test_returncode_zero_does_not_get_hint(self) -> None:
         """Defensive: even success-code construction (shouldn't happen
         normally) doesn't get a hint."""
         e = _augment_with_oom_hint(cmd=self.cmd, returncode=0)
         assert e.stderr == ""
-
-    def test_hint_mentions_actionable_fixes(self) -> None:
-        """The hint should mention the concrete next steps users care
-        about: --mem on SLURM, --threads, moving off a login node."""
-        e = _augment_with_oom_hint(cmd=self.cmd, returncode=-9)
-        lower = e.stderr.lower()
-        assert "--mem" in lower
-        assert "--threads" in lower or "threads" in lower
-        assert "login node" in lower or "compute node" in lower
-
-    def test_stdout_passthrough(self) -> None:
-        e = _augment_with_oom_hint(
-            cmd=self.cmd, returncode=-9, stdout="some output", stderr="some err"
-        )
-        assert e.stdout == "some output"
-        assert "some err" in e.stderr
+        assert "KaryoScope hint" not in str(e)
 
 
 # --- _infer_prefix -------------------------------------------------

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,182 @@
+"""Tests for :mod:`karyoscope.memory`.
+
+The check exists because an under-allocated HKS run is killed by the kernel
+mid-query with no explanation. Its whole value is being right about when to
+block — so most of what is pinned here is when it must *not*.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from karyoscope import memory
+from karyoscope.exceptions import InsufficientMemoryError
+
+GB = memory.GB
+
+
+def _no_resolvers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SLURM_MEM_PER_NODE", raising=False)
+    monkeypatch.delenv("SLURM_MEM_PER_CPU", raising=False)
+    monkeypatch.setattr(memory, "_cgroup_limit_bytes", lambda: None)
+    monkeypatch.setattr(memory, "_meminfo_available_bytes", lambda: None)
+
+
+# --- resolution order -------------------------------------------------
+
+
+def test_slurm_allocation_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The scheduler's grant outranks the cgroup and the machine.
+
+    A site can schedule by memory without cgroup enforcement, in which case
+    the allocation is real but invisible to everything else — and exceeding
+    it still gets the job killed.
+    """
+    monkeypatch.setenv("SLURM_MEM_PER_NODE", "16384")  # MB
+    monkeypatch.setattr(memory, "_cgroup_limit_bytes", lambda: 999 * GB)
+    monkeypatch.setattr(memory, "_meminfo_available_bytes", lambda: 999 * GB)
+    have, source = memory.available_bytes()
+    assert have == 16384 * 1024 * 1024
+    assert "SLURM" in source
+
+
+def test_slurm_per_cpu_is_multiplied_by_the_cpu_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SLURM_MEM_PER_NODE", raising=False)
+    monkeypatch.setenv("SLURM_MEM_PER_CPU", "2048")
+    monkeypatch.setenv("SLURM_CPUS_PER_TASK", "8")
+    monkeypatch.setattr(memory, "_cgroup_limit_bytes", lambda: None)
+    have, _ = memory.available_bytes()
+    assert have == 2048 * 8 * 1024 * 1024
+
+
+def test_cgroup_is_used_when_slurm_is_silent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SLURM_MEM_PER_NODE", raising=False)
+    monkeypatch.delenv("SLURM_MEM_PER_CPU", raising=False)
+    monkeypatch.setattr(memory, "_cgroup_limit_bytes", lambda: 12 * GB)
+    monkeypatch.setattr(memory, "_meminfo_available_bytes", lambda: 999 * GB)
+    have, source = memory.available_bytes()
+    assert have == 12 * GB
+    assert "cgroup" in source
+
+
+def test_unlimited_cgroup_values_are_ignored(tmp_path: Path) -> None:
+    """cgroup v2 writes 'max'; v1 writes a number near 2**63.
+
+    Treating either as a real limit would report absurd availability, and
+    (worse) would stop the resolver falling through to MemAvailable.
+    """
+    v2 = tmp_path / "memory.max"
+    v2.write_text("max\n")
+    assert memory._read_int(v2) is None
+    v1 = tmp_path / "limit_in_bytes"
+    v1.write_text(str(2**63 - 1))
+    assert memory._read_int(v1) is None
+    real = tmp_path / "real"
+    real.write_text(str(8 * GB))
+    assert memory._read_int(real) == 8 * GB
+
+
+# --- fail-open --------------------------------------------------------
+
+
+def test_undeterminable_memory_never_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """macOS has no /proc, a bare machine has no cgroup, users run outside SLURM.
+
+    Refusing to run because we could not measure something would break
+    working setups; letting it through costs at worst the tool's own OOM
+    message, which is now legible.
+    """
+    _no_resolvers(monkeypatch)
+    assert memory.available_bytes() is None
+    memory.require_memory(500 * GB, what="testing")  # must not raise
+
+
+def test_skip_bypasses_the_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(memory, "available_bytes", lambda: (1 * GB, "test"))
+    memory.require_memory(500 * GB, what="testing", skip=True)
+
+
+def test_enough_memory_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(memory, "available_bytes", lambda: (64 * GB, "test"))
+    memory.require_memory(10 * GB, what="testing")
+
+
+# --- the failure it exists to produce ---------------------------------
+
+
+def test_too_little_memory_raises_with_the_numbers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(memory, "available_bytes", lambda: (4 * GB, "$SLURM_MEM_PER_NODE"))
+    with pytest.raises(InsufficientMemoryError) as excinfo:
+        memory.require_memory(
+            10 * GB, what="annotating HG002 against HKS_human_CHM13_v2", hint="  - use --mem=16G"
+        )
+    msg = str(excinfo.value)
+    assert "annotating HG002 against HKS_human_CHM13_v2" in msg
+    assert "4.0 GB" in msg  # what we have
+    assert "$SLURM_MEM_PER_NODE" in msg  # and where that came from
+    assert "short by" in msg
+    assert "--mem=16G" in msg  # actionable
+
+
+def test_the_margin_is_applied(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A run driven to exactly its limit is killed, not slowed.
+
+    The index is not the whole footprint -- query buffers, allocator slack
+    and the Python parent sit on top.
+    """
+    monkeypatch.setattr(memory, "available_bytes", lambda: (10 * GB, "test"))
+    memory.require_memory(10 * GB, what="testing", margin=0.0)
+    with pytest.raises(InsufficientMemoryError):
+        memory.require_memory(10 * GB, what="testing", margin=0.15)
+
+
+# --- the HKS requirement is measured, not extrapolated ----------------
+
+
+def test_hks_requirement_is_base_plus_largest_labeling(tmp_path: Path) -> None:
+    """hks loads the base plus ONE labeling at a time, so the peak is that sum.
+
+    This is what makes the figure independent of input size and thread count.
+    """
+    from karyoscope.core.io.hks import estimate_hks_memory_bytes
+
+    (tmp_path / "features.hksb").write_bytes(b"x" * 1000)
+    (tmp_path / "features.chromosome.hksf").write_bytes(b"x" * 500)
+    (tmp_path / "features.repeat.hksf").write_bytes(b"x" * 300)
+    got = estimate_hks_memory_bytes(
+        db_dir=tmp_path, basename="features", feature_sets=["chromosome", "repeat"]
+    )
+    assert got == 1000 + 500  # base + LARGEST labeling, not the sum of both
+
+    # Requesting only the smaller set lowers it.
+    assert (
+        estimate_hks_memory_bytes(
+            db_dir=tmp_path, basename="features", feature_sets=["repeat"]
+        )
+        == 1000 + 300
+    )
+
+
+def test_hks_requirement_is_none_when_the_index_cannot_be_sized(tmp_path: Path) -> None:
+    """Fail open: a database we cannot inspect must not block the run."""
+    from karyoscope.core.io.hks import estimate_hks_memory_bytes
+
+    assert (
+        estimate_hks_memory_bytes(
+            db_dir=tmp_path, basename="features", feature_sets=["chromosome"]
+        )
+        is None
+    )
+    (tmp_path / "features.hksb").write_bytes(b"x" * 10)
+    assert (
+        estimate_hks_memory_bytes(
+            db_dir=tmp_path, basename="features", feature_sets=["missing"]
+        )
+        is None
+    )

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -156,9 +156,7 @@ def test_hks_requirement_is_base_plus_largest_labeling(tmp_path: Path) -> None:
 
     # Requesting only the smaller set lowers it.
     assert (
-        estimate_hks_memory_bytes(
-            db_dir=tmp_path, basename="features", feature_sets=["repeat"]
-        )
+        estimate_hks_memory_bytes(db_dir=tmp_path, basename="features", feature_sets=["repeat"])
         == 1000 + 300
     )
 
@@ -168,15 +166,11 @@ def test_hks_requirement_is_none_when_the_index_cannot_be_sized(tmp_path: Path) 
     from karyoscope.core.io.hks import estimate_hks_memory_bytes
 
     assert (
-        estimate_hks_memory_bytes(
-            db_dir=tmp_path, basename="features", feature_sets=["chromosome"]
-        )
+        estimate_hks_memory_bytes(db_dir=tmp_path, basename="features", feature_sets=["chromosome"])
         is None
     )
     (tmp_path / "features.hksb").write_bytes(b"x" * 10)
     assert (
-        estimate_hks_memory_bytes(
-            db_dir=tmp_path, basename="features", feature_sets=["missing"]
-        )
+        estimate_hks_memory_bytes(db_dir=tmp_path, basename="features", feature_sets=["missing"])
         is None
     )


### PR DESCRIPTION
Stacked on #20 — this PR's diff is the 2 commits on top.

Two halves of the same failure, reported from a real run: a `karyotype` against a human HKS database in an under-allocated job died with

```
Error: command failed with exit code -9: .../hks lookup ...
[2026-07-28T22:36:35Z INFO  hks] Loading the index ...
```

## Half 1: say what actually happened

`-9` is not an exit code. `subprocess` reports `-N` when a child is killed by signal N, so this is **SIGKILL** — and on a step whose job is to hold a ~10 GB index resident, that is the OOM killer essentially every time. The message named neither fact, and "exit code -9" is unsearchable.

**We already had this diagnosis.** `kmc.py` grew `_augment_with_oom_hint` in `050173f` after two early colleagues hit exactly this, and it's thorough — it knows both `-9` and the shell-style `137` that SLURM and Docker report. But it was written when KMC was the only backend and never moved. The HKS backend calls `run_tool` directly and got the bare message. **The regression is architectural: the hint sat one layer too low.**

Detection moves to `core/external.py`, where every tool funnels through. `describe_returncode` now renders a signal as a signal (`killed by SIGKILL (signal 9)`) for *any* tool, hint or not. Only the memory figures stay backend-specific, and they must — KMC says 20–30 GB, HKS ~10 GB, and telling an HKS user to request 100 GB is as unhelpful as saying nothing.

**One behaviour change worth reviewing:** the hint now lands in the exception *message*. The old version spliced it into captured `stderr`, so a caller inspecting stderr programmatically saw KaryoScope's prose mixed into the tool's own output. `stderr` is now left exactly as the tool wrote it.

## Half 2: don't reach that point

KaryoScope checked free disk before starting but never memory — though for HKS the requirement is the *more* knowable of the two. `hks` loads the shared base index plus **one** feature set's labeling at a time, so the peak is the sum of two file sizes read off disk. No calibration constants, none of the fragility the output-size estimate carries.

Measured against the human database: **9.73 GB predicted vs 10.04 GB observed** — the difference is query buffering, covered by the margin. It's also why the figure barely moves with `--threads` or input size, and why a single haplotype costs the same as a diploid.

`karyoscope.memory` resolves the limit in order of authority, mirroring `karyoscope.cpus`:

1. `$SLURM_MEM_PER_NODE` / `$SLURM_MEM_PER_CPU` — what the scheduler granted, correct even at sites that don't enforce via cgroups
2. the cgroup limit — what actually kills the process
3. `MemAvailable` — deliberately not `MemFree`, which reads near zero on a busy node because the page cache is doing its job, and would reject every run

**It fails open twice**: an index that can't be sized, and a limit that can't be determined, both proceed. Between them it can only stop a run we're confident would be killed anyway. macOS has no `/proc`, so it simply doesn't fire there.

## Verified against the reported command

Under a simulated 8 GB allocation it now stops before any work:

```
Error: not enough memory for annotating hg002v1.1.fasta.gz against HKS_human_CHM13_v2:
needs ~11.2 GB but only 8.6 GB is available (per $SLURM_MEM_PER_NODE/...); short by 2.6 GB.
hks holds the shared base index plus one feature set's labeling at a time, so this figure
is set by the database and does not shrink with fewer --threads, fewer --feature-set, or a
smaller input.
Options:
  - request more memory (on SLURM, e.g. --mem=16G)
  - move from a login node to a compute node
  - pass --no-space-check to attempt the run anyway
```

807 tests pass (18 new), 11/11 pre-commit hooks.

## Where to look hardest

- **The fail-open paths.** A check that wrongly blocks is worse than no check; most of `test_memory.py` pins when it must *not* fire.
- **The resolution order.** SLURM before cgroup is deliberate (a site can schedule by memory without enforcing it), but if that's wrong for your cluster it's the thing to say so about.
- **The margin (15%).** Chosen so a run isn't driven to exactly its limit, where it's killed rather than slowed. Measured overhead above index size was ~0.3–1.0 GB on human data.
- **`--no-space-check` now also skips the memory check.** Reusing the existing escape rather than adding a second flag — reasonable, but it does make one flag mean two things.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
