### PR TITLE
feat(annotate): read CRAM, and keep read-level output survivable at WGS scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`annotate` reads CRAM.** `--input` accepts `.cram`, and a new `--reference`
+  option supplies the FASTA the alignment was encoded against. CRAM stores
+  bases as a diff against its reference, so `--reference` is **required** for
+  CRAM input and the CLI refuses the run up front without it. That check is
+  deliberately loud, because the quiet failure is worse than the noisy one:
+  left to itself, htslib resolves each contig's M5 checksum through
+  `$REF_PATH`/`$REF_CACHE` and can decode against a *different* build of the
+  same genome, producing plausible sequence that is simply wrong.
+
+  Note `--reference` is the **alignment** reference and is unrelated to `--db`.
+  `annotate` is alignment-free, so annotating GRCh38-aligned reads against a
+  CHM13 database is a normal thing to do, not a mismatch.
+
+  Both backends are covered. KMC streams `samtools fasta` straight into
+  `get_featureIDs` with no temp file; HKS cannot (`hks lookup` needs a seekable
+  path) and so materialises a temp FASTA in `$TMPDIR` first. That file is
+  **full size** — a 64x human WGS CRAM measured 28.9 GB in, 254 GB out — so
+  `$TMPDIR` must point at node-local scratch, never at a shared filesystem.
+
+- **`--query-names/--no-query-names`** overrides which identifier the output
+  BED carries. The default is unchanged (assemblies get names, read-level
+  inputs get ordinal ranks), but a rank is undecodable once the input file is
+  gone, and for read data the input is often a temp file that `annotate` itself
+  deletes. Pass `--query-names` whenever the output has to be joined back to
+  anything — most importantly paired-end mates, which are distinguishable
+  *only* by the `/1` and `/2` suffix on their shared read name.
+
 - **`annotate` now checks available memory before it starts**, not just disk.
   For the HKS backend the requirement is knowable exactly rather than
   estimated: `hks` holds the shared base index plus one feature set's labeling
@@ -175,6 +202,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   combined figure.
 
 ### Fixed
+
+- **BAM/CRAM conversion no longer depends on samtools' default flag filter.**
+  The `samtools fasta` invocation now states `-F 0x900 -N` explicitly.
+  - `-F 0x900` (secondary + supplementary excluded) was already the samtools
+    default, but relying on a tool's default for a correctness-critical choice
+    is how it changes underneath you. It is the right mask for this job:
+    every read has exactly one primary record carrying full-length SEQ, whereas
+    supplementary records are hard-clipped *slices* of reads the primary
+    already supplied in full. Verified on a DRAGEN WGS CRAM — of 2,995,805
+    primary records, zero were hard-clipped, zero lacked SEQ, and zero were
+    under full read length. Unmapped reads (`0x4`) and duplicates (`0x400`) are
+    *not* excluded: they are genuine distinct reads and dropping them would
+    under-count.
+  - `-N` forces the `/1`/`/2` mate suffix. This one is a real bug fix, not
+    just an explicitness change: aligners routinely strip the suffix from
+    QNAME, leaving both mates of a pair sharing a byte-identical name, and
+    samtools only restores it where the READ1/READ2 flag bits happen to be set.
+    Measured on the same data: with `-n`, 1,996,531 records collapsed onto
+    1,002,139 distinct names — every mate pair silently indistinguishable. With
+    `-N`, all 1,996,531 stayed distinct.
 
 - **The `samtools | get_featureIDs` BAM pipeline can no longer deadlock on a
   warning-heavy BAM.** samtools stderr was read only after `get_featureIDs`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,13 +28,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **full size** — a 64x human WGS CRAM measured 28.9 GB in, 254 GB out — so
   `$TMPDIR` must point at node-local scratch, never at a shared filesystem.
 
-- **`--query-names/--no-query-names`** overrides which identifier the output
-  BED carries. The default is unchanged (assemblies get names, read-level
-  inputs get ordinal ranks), but a rank is undecodable once the input file is
-  gone, and for read data the input is often a temp file that `annotate` itself
-  deletes. Pass `--query-names` whenever the output has to be joined back to
-  anything — most importantly paired-end mates, which are distinguishable
-  *only* by the `/1` and `/2` suffix on their shared read name.
+- **`--query-names/--no-query-names`** controls which identifier the output BED
+  carries, and **`--query-names` is now refused outright for read-level input**
+  (FASTQ/BAM/CRAM). It is not a tuning knob there — it is a way to lose a run.
+
+  `hks --report-query-names` is not streaming: `load_seq_names` reads the whole
+  query file and builds a `Vec<String>` of every sequence name before the first
+  k-mer is looked up. Fine for an assembly's few thousand contigs; fatal for
+  reads. Measured on a 64x human WGS CRAM — 1.315 G names at ~68 bytes each is
+  ~90 GB on top of the ~12.3 GB index. The run was OOM-killed ~20 minutes in,
+  having already spent 15 of them decoding the CRAM, with nothing written and
+  nothing to resume from.
+
+  Raising the memory limit is not a fix: it would take a ~160 GB allocation per
+  sample to buy nothing but longer identifiers. So this is an error rather than
+  a warning, and it fires in a second instead of after the decode.
+
+  No information is lost. Rank N is the Nth record of the query file, and for
+  an alignment input that file is a deterministic function of the source, so
+  the mapping regenerates on demand:
+  `samtools fasta -F 0x900 -N --reference <ref> <input> | grep '^>'`.
+
+  Assemblies are unaffected: they still default to names, and
+  `--no-query-names` switches them to ranks to save space.
 
 - **`annotate` now checks available memory before it starts**, not just disk.
   For the HKS backend the requirement is knowable exactly rather than

--- a/docs/commands/annotate.md
+++ b/docs/commands/annotate.md
@@ -18,7 +18,7 @@ karyoscope annotate -i INPUT [OPTIONS]
 | --- | --- |
 | `-i`, `--input FILE` | Input sequence file. Accepts FASTA (`.fasta`/`.fa`/`.fna`, plain or `.gz`), FASTQ (`.fastq`/`.fq`, plain or `.gz`), BAM (`.bam`) or CRAM (`.cram`). BAM/CRAM inputs are converted with `samtools fasta` (requires `samtools` on PATH); CRAM also requires `--reference`. **[required]** |
 | `--reference FILE` | Reference FASTA a CRAM input was aligned against. **Required for `.cram`**, ignored otherwise. See [CRAM input](#cram-input). |
-| `--query-names` / `--no-query-names` | Identify output sequences by name rather than by ordinal rank. Default: assemblies get names, read-level inputs get ranks. See [Paired-end reads](#paired-end-reads). |
+| `--query-names` / `--no-query-names` | Identify output sequences by name rather than ordinal rank. Assemblies default to names; **refused for read-level input**, which always uses ranks. See [Paired-end reads](#paired-end-reads). |
 | `-o`, `--outdir DIRECTORY` | Directory to write output BEDs into. Default: same directory as `--input`. |
 | `--db TEXT` | Database id to use (e.g., `KS_human_CHM13_v2`). Default: the unique installed database if there's exactly one. |
 | `--db-root DIRECTORY` | Override the database root directory (default: `$KARYOSCOPE_DB` or `~/.karyoscope/db/`). |
@@ -80,22 +80,28 @@ backend cannot — `hks lookup` needs a seekable path — so it materialises a t
 
 ## Paired-end reads
 
-`annotate` has no concept of pairing: each mate is an independent query sequence. What
-matters is whether the output can still be joined back into fragments afterwards.
+`annotate` has no concept of pairing: each mate is an independent query sequence.
+What matters is whether the output can still be joined back into fragments afterwards.
 
-By default read-level inputs are identified in the output by **ordinal rank**, which is
-compact but undecodable once the input is gone — and for BAM/CRAM on the HKS backend the
-input is a temp file `annotate` itself deletes. Pass `--query-names` to get read names
-instead:
+Read-level output is identified by **ordinal rank**, and `--query-names` is *refused*
+for read-level input. This is not a style preference — `hks` collects every sequence
+name into memory before querying (`load_seq_names` builds a `Vec<String>` of the lot),
+which is fine for an assembly's few thousand contigs and fatal for reads. Measured on a
+64x human WGS CRAM: 1.315 G names at ~68 bytes each is ~90 GB on top of the ~12.3 GB
+index, and the run is OOM-killed roughly 20 minutes in, having already spent 15 of them
+decoding. Raising the memory limit buys nothing but longer identifiers.
 
+Nothing is lost. Rank N is the Nth record of the query file, and for an alignment input
+the query file is a deterministic function of the source, so the mapping is reproducible
+whenever it is actually needed:
+
+```bash
+samtools fasta -F 0x900 -N --reference GRCh38.fasta tumor.cram | grep '^>'
 ```
-A01925:18:H5VMFDSX7:4:1275:21187:23249/1   0    86   categorized
-A01925:18:H5VMFDSX7:4:1275:21187:23249/1   86   88   20q13.33
-```
 
-Mates then group by stripping the `/1`/`/2` suffix. This costs output size (a read name
-is far longer than a rank), though the shared instrument/run prefix compresses well under
-`--bgzip`.
+Line N+1 of that stream is rank N. Mates group by stripping the `/1`,`/2` suffix — which
+is why `-N` is forced during the decode. Materialising it once as a bgzipped sidecar is
+usually cheaper than regenerating it per query.
 
 Note the coordinates are k-mer offsets **within each read**, not genomic positions: a
 151 bp read queried at k=31 spans 0..121.

--- a/docs/commands/annotate.md
+++ b/docs/commands/annotate.md
@@ -10,13 +10,15 @@ karyoscope annotate -i INPUT [OPTIONS]
 
 ## Description
 
-`karyoscope annotate` assigns every k-mer in the input to a feature in a single alignment-free pass, by querying the database's index. The backend follows the database: an HKS-index database (e.g. `HKS_human_CHM13_v2`) is queried with `hks`, and a KMC-index database with the bundled `get_featureIDs` helper. It produces one BED per feature set, and by default writes BOTH a "presmoothed" (raw) and a "smoothed" (hierarchy-smoothed) BED for each feature set. k-mers that are not present in the index render as `novel`. Input may be FASTA, FASTQ, or BAM. The expensive k-mer-query step is resumable across reruns, so an interrupted (for example, OOM-killed) run can resume straight into smoothing.
+`karyoscope annotate` assigns every k-mer in the input to a feature in a single alignment-free pass, by querying the database's index. The backend follows the database: an HKS-index database (e.g. `HKS_human_CHM13_v2`) is queried with `hks`, and a KMC-index database with the bundled `get_featureIDs` helper. It produces one BED per feature set, and by default writes BOTH a "presmoothed" (raw) and a "smoothed" (hierarchy-smoothed) BED for each feature set. k-mers that are not present in the index render as `novel`. Input may be FASTA, FASTQ, BAM or CRAM. The expensive k-mer-query step is resumable across reruns, so an interrupted (for example, OOM-killed) run can resume straight into smoothing.
 
 ## Options
 
 | Option | Description |
 | --- | --- |
-| `-i`, `--input FILE` | Input sequence file. Accepts FASTA (`.fasta`/`.fa`/`.fna`, plain or `.gz`), FASTQ (`.fastq`/`.fq`, plain or `.gz`), or BAM (`.bam`). BAM inputs are piped through `samtools fasta` (requires `samtools` on PATH); no intermediate file is written. **[required]** |
+| `-i`, `--input FILE` | Input sequence file. Accepts FASTA (`.fasta`/`.fa`/`.fna`, plain or `.gz`), FASTQ (`.fastq`/`.fq`, plain or `.gz`), BAM (`.bam`) or CRAM (`.cram`). BAM/CRAM inputs are converted with `samtools fasta` (requires `samtools` on PATH); CRAM also requires `--reference`. **[required]** |
+| `--reference FILE` | Reference FASTA a CRAM input was aligned against. **Required for `.cram`**, ignored otherwise. See [CRAM input](#cram-input). |
+| `--query-names` / `--no-query-names` | Identify output sequences by name rather than by ordinal rank. Default: assemblies get names, read-level inputs get ranks. See [Paired-end reads](#paired-end-reads). |
 | `-o`, `--outdir DIRECTORY` | Directory to write output BEDs into. Default: same directory as `--input`. |
 | `--db TEXT` | Database id to use (e.g., `KS_human_CHM13_v2`). Default: the unique installed database if there's exactly one. |
 | `--db-root DIRECTORY` | Override the database root directory (default: `$KARYOSCOPE_DB` or `~/.karyoscope/db/`). |
@@ -44,6 +46,59 @@ karyoscope annotate -i asm.fa --feature-set chromosome -o results/
 # Read-level input (FASTQ): faster writes when output order doesn't matter
 karyoscope annotate -i reads.fastq.gz -o results/ --no-preserve-order
 ```
+
+## CRAM input
+
+CRAM stores bases as a diff against the reference used for alignment, so it cannot be
+decoded without that same FASTA. Pass it with `--reference`:
+
+```bash
+karyoscope annotate -i tumor.cram --reference GRCh38.fasta \
+                    --db HKS_human_CHM13_cytoband --feature-set cytoband -o results/
+```
+
+`--reference` is the **alignment** reference and has nothing to do with `--db`. `annotate`
+is alignment-free — it only ever sees read sequences — so annotating GRCh38-aligned reads
+against a CHM13 database is normal, not a mismatch.
+
+Omitting `--reference` is refused up front rather than left to htslib, which would
+otherwise resolve each contig's M5 checksum through `$REF_PATH`/`$REF_CACHE` and could
+decode against a *different* build of the same genome, yielding plausible but incorrect
+sequence.
+
+**What gets converted.** `samtools fasta -F 0x900 -N` — primary records only, with the
+`/1`,`/2` mate suffix forced on. That is exactly one full-length copy of every read:
+each read has one primary record carrying full-length SEQ, whereas supplementary records
+are hard-clipped slices of reads the primary already supplied. Unmapped reads and
+duplicates are **kept** — they are genuine distinct reads. Minus-strand records are
+reverse-complemented back to sequencing orientation.
+
+**Scratch space.** The KMC backend streams the conversion with no temp file. The HKS
+backend cannot — `hks lookup` needs a seekable path — so it materialises a temp FASTA in
+`$TMPDIR` first. **That file is full size**: a 64x human WGS CRAM measured 28.9 GB in and
+254 GB out. Point `$TMPDIR` at node-local scratch, never at a shared filesystem.
+
+## Paired-end reads
+
+`annotate` has no concept of pairing: each mate is an independent query sequence. What
+matters is whether the output can still be joined back into fragments afterwards.
+
+By default read-level inputs are identified in the output by **ordinal rank**, which is
+compact but undecodable once the input is gone — and for BAM/CRAM on the HKS backend the
+input is a temp file `annotate` itself deletes. Pass `--query-names` to get read names
+instead:
+
+```
+A01925:18:H5VMFDSX7:4:1275:21187:23249/1   0    86   categorized
+A01925:18:H5VMFDSX7:4:1275:21187:23249/1   86   88   20q13.33
+```
+
+Mates then group by stripping the `/1`/`/2` suffix. This costs output size (a read name
+is far longer than a rank), though the shared instrument/run prefix compresses well under
+`--bgzip`.
+
+Note the coordinates are k-mer offsets **within each read**, not genomic positions: a
+151 bp read queried at k=31 spans 0..121.
 
 ## Output
 

--- a/src/karyoscope/commands/annotate.py
+++ b/src/karyoscope/commands/annotate.py
@@ -97,12 +97,12 @@ logger = logging.getLogger(__name__)
     "query_names",
     default=None,
     help="Identify each sequence in the output BED by NAME rather than by its "
-    "ordinal rank in the input. Default (neither flag): assemblies get names, "
-    "read-level inputs (FASTQ/BAM/CRAM) get ranks, which are compact but "
-    "meaningless once the input file is gone. Pass --query-names for read data "
-    "whose output has to be joined back to anything -- notably paired-end "
-    "mates, which are distinguishable only by the /1 and /2 suffix on their "
-    "shared read name.",
+    "ordinal rank in the input. Assemblies use names by default; --no-query-names "
+    "switches them to ranks to save space on a database with long feature names. "
+    "REFUSED for read-level input (FASTQ/BAM/CRAM): hks loads every name into "
+    "memory before querying, which costs ~90 GB on a human WGS sample and gets "
+    "the run OOM-killed after the decode is already paid for. Reads always use "
+    "ranks, and rank N is simply the Nth record of the query file.",
 )
 @click.option(
     "--reference",

--- a/src/karyoscope/commands/annotate.py
+++ b/src/karyoscope/commands/annotate.py
@@ -58,9 +58,10 @@ logger = logging.getLogger(__name__)
     required=True,
     multiple=True,
     help="Input sequence file. Accepts FASTA (.fasta/.fa/.fna, plain "
-    "or .gz), FASTQ (.fastq/.fq, plain or .gz), or BAM (.bam). BAM "
-    "inputs are piped through `samtools fasta` (requires samtools on "
-    "PATH); no intermediate file is written. See --preserve-order for "
+    "or .gz), FASTQ (.fastq/.fq, plain or .gz), BAM (.bam) or CRAM "
+    "(.cram). BAM/CRAM inputs are converted with `samtools fasta` "
+    "(requires samtools on PATH); CRAM additionally requires "
+    "--reference. See --preserve-order for "
     "how the smoothing implementation adapts to the input type. "
     "Repeatable: pass -i several times to annotate multiple inputs in "
     "one run; on the HKS backend the index is loaded once per feature "
@@ -90,6 +91,30 @@ logger = logging.getLogger(__name__)
     type=click.Path(file_okay=False, path_type=Path),
     default=None,
     help="Override the database root directory (default: $KARYOSCOPE_DB or ~/.karyoscope/db/).",
+)
+@click.option(
+    "--query-names/--no-query-names",
+    "query_names",
+    default=None,
+    help="Identify each sequence in the output BED by NAME rather than by its "
+    "ordinal rank in the input. Default (neither flag): assemblies get names, "
+    "read-level inputs (FASTQ/BAM/CRAM) get ranks, which are compact but "
+    "meaningless once the input file is gone. Pass --query-names for read data "
+    "whose output has to be joined back to anything -- notably paired-end "
+    "mates, which are distinguishable only by the /1 and /2 suffix on their "
+    "shared read name.",
+)
+@click.option(
+    "--reference",
+    "reference",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Reference FASTA a CRAM input was aligned against, passed to "
+    "`samtools fasta --reference`. REQUIRED for .cram inputs, which store "
+    "bases as a diff against their reference and cannot be decoded without "
+    "it. Ignored for every other input format. Note this is the ALIGNMENT "
+    "reference (e.g. GRCh38), which is unrelated to --db: annotate is "
+    "alignment-free, so the database may well be a different assembly.",
 )
 @click.option(
     "--feature-set",
@@ -191,6 +216,8 @@ def cmd(
     output_dir: Path | None,
     db_id: str | None,
     db_root_arg: Path | None,
+    query_names: bool | None,
+    reference: Path | None,
     feature_sets_arg: tuple[str, ...],
     threads: int,
     k: int | None,
@@ -235,6 +262,23 @@ def cmd(
         output_dir = inputs[0].parent
     feature_sets = list(feature_sets_arg) if feature_sets_arg else None
 
+    # Caught here rather than deep in the backend: a CRAM run that reaches
+    # samtools without a reference either dies with an htslib error that says
+    # nothing about --reference, or silently decodes against whatever
+    # $REF_PATH/$REF_CACHE resolves from the header's M5 tags -- which is the
+    # worse outcome, because it produces plausible sequence from the wrong
+    # genome.
+    cram_inputs = [p for p in inputs if p.suffix.lower() == ".cram"]
+    if cram_inputs and reference is None:
+        listed = ", ".join(p.name for p in cram_inputs)
+        raise click.ClickException(
+            f"--reference is required for CRAM input ({listed}). CRAM stores "
+            f"bases as a diff against the reference used for alignment, so it "
+            f"cannot be decoded without that same FASTA.\n"
+            f"  karyoscope annotate -i {cram_inputs[0].name} "
+            f"--reference /path/to/genome.fasta ..."
+        )
+
     common = dict(
         output_dir=output_dir,
         db_root=db_root,
@@ -249,6 +293,8 @@ def cmd(
         preserve_input_order=preserve_input_order,
         force=force,
         check_space=not skip_checks,
+        reference=reference,
+        query_names=query_names,
         progress=_progress.from_context(),
     )
 

--- a/src/karyoscope/core/annotate.py
+++ b/src/karyoscope/core/annotate.py
@@ -209,6 +209,49 @@ def _is_reads_input(input_path: Path) -> bool:
     return any(name_lower.endswith(ext) for ext in _READS_INPUT_EXTENSIONS)
 
 
+def _reject_query_names_for_reads(input_paths: list[Path], query_names: bool | None) -> None:
+    """Refuse ``--query-names`` on read-level input. It cannot survive the scale.
+
+    ``hks``'s ``--report-query-names`` is not streaming: ``load_seq_names``
+    reads the whole query file up front and builds a ``Vec<String>`` of every
+    sequence name before a single k-mer is looked up. That is fine for an
+    assembly (a few thousand contigs) and catastrophic for reads.
+
+    Measured on a 64x human WGS CRAM: 1.315 G reads x ~68 bytes per name is
+    ~90 GB of names, on top of the ~12.3 GB index. The run died to the OOM
+    killer after ~20 minutes -- having already spent 15 of them decoding the
+    CRAM -- with nothing written and nothing to resume from.
+
+    Raising the memory limit is not a fix: it would take a ~160 GB allocation
+    per sample to buy nothing but longer identifiers in the output. So this is
+    a hard error rather than a warning. The information is not lost either way
+    -- rank N is the Nth record of the query file, which for an alignment input
+    is a deterministic function of the source (see the CRAM section of
+    docs/commands/annotate.md).
+    """
+    if not query_names:
+        return
+    reads = [p for p in input_paths if _is_reads_input(p)]
+    if not reads:
+        return
+    listed = ", ".join(p.name for p in reads[:3])
+    if len(reads) > 3:
+        listed += f", ... (+{len(reads) - 3} more)"
+    raise KaryoscopeError(
+        f"--query-names is not supported for read-level input ({listed}).\n"
+        f"\n"
+        f"hks collects every sequence name into memory before querying, which "
+        f"is fine for an assembly's contigs but not for reads: a 64x human WGS "
+        f"input holds ~1.3 G names at ~90 GB, and the run is OOM-killed after "
+        f"the decode has already been paid for.\n"
+        f"\n"
+        f"Read-level output is identified by ordinal rank instead, and no "
+        f"information is lost -- rank N is the Nth record of the query file. "
+        f"For a BAM/CRAM input that mapping is reproducible at any time with:\n"
+        f"  samtools fasta -F 0x900 -N --reference <ref> <input> | grep '^>'"
+    )
+
+
 # --- output-size estimation ------------------------------------------
 #
 # Annotate is the command most likely to fill a disk: a six-feature-set
@@ -1351,6 +1394,7 @@ def annotate(
             "no output would be produced: cannot combine --no-smooth with "
             "--no-keep-presmoothed. Choose at least one output type."
         )
+    _reject_query_names_for_reads([input_path], query_names)
     if not input_path.is_file():
         raise KaryoscopeError(f"input file not found: {input_path}")
 
@@ -1723,6 +1767,8 @@ def annotate_batch(
     """
     if not input_paths:
         return {}
+
+    _reject_query_names_for_reads(input_paths, query_names)
 
     # A single input has nothing to batch — delegate to the exact, battle-tested
     # single-input path (covers both HKS and KMC backends). This makes

--- a/src/karyoscope/core/annotate.py
+++ b/src/karyoscope/core/annotate.py
@@ -82,9 +82,10 @@ logger = logging.getLogger(__name__)
 #: Input extensions we recognise when deriving the output basename.
 #: Order matters — longer extensions first so they win over shorter
 #: ones. Includes FASTQ (read by ``get_featureIDs`` directly) and
-#: BAM (piped through ``samtools fastq``); see
-#: :func:`karyoscope.core.io.kmc.run_get_featureids` for the BAM
-#: streaming path.
+#: BAM/CRAM (converted through ``samtools fasta``); see
+#: :func:`karyoscope.core.io.kmc.run_get_featureids` for the streaming
+#: path and :func:`karyoscope.core.io.hks.run_hks_lookup_batch` for the
+#: temp-file one.
 _INPUT_EXTENSIONS: tuple[str, ...] = (
     ".fasta.gz",
     ".fa.gz",
@@ -97,6 +98,7 @@ _INPUT_EXTENSIONS: tuple[str, ...] = (
     ".fastq",
     ".fq",
     ".bam",
+    ".cram",
 )
 
 
@@ -189,6 +191,7 @@ _READS_INPUT_EXTENSIONS: tuple[str, ...] = (
     ".fastq",
     ".fq",
     ".bam",
+    ".cram",
 )
 
 
@@ -260,6 +263,19 @@ _SEQUENCE_FRACTION_FASTA = 0.98
 _SEQUENCE_FRACTION_FASTQ = 0.49
 _BASES_PER_BAM_BYTE = 1.0
 
+#: CRAM packs far harder than BAM: it stores bases as a reference diff and
+#: (for DRAGEN output, which bins quality scores) spends very little on the
+#: quality string. Measured on a 64x DRAGEN WGS CRAM: 28.9 GB of file yielded
+#: 198.6 Gbp, i.e. 6.87 bases per byte, versus BAM's ~1.
+#:
+#: This one is genuinely variable — a CRAM that kept full-resolution qualities
+#: sits far lower — and it feeds a disk-space check whose whole job is to
+#: refuse a run that would fill the filesystem. So it is rounded DOWN only
+#: slightly and deliberately not padded: under-estimating input bases
+#: under-estimates the output footprint, which is the failure mode that ends
+#: with a full disk rather than a clean up-front refusal.
+_BASES_PER_CRAM_BYTE = 6.9
+
 
 def _bases_from_fai(input_path: Path) -> int | None:
     """Total sequence length from a samtools ``.fai`` index, if one exists.
@@ -306,6 +322,8 @@ def estimate_input_bases(input_path: Path) -> int:
     name = input_path.name.lower()
     if name.endswith(".bam"):
         return int(file_size * _BASES_PER_BAM_BYTE)
+    if name.endswith(".cram"):
+        return int(file_size * _BASES_PER_CRAM_BYTE)
 
     uncompressed = file_size * GZIP_EXPANSION_FACTOR if name.endswith(".gz") else file_size
     is_fastq = any(name.endswith(ext) for ext in (".fastq", ".fq", ".fastq.gz", ".fq.gz"))
@@ -402,7 +420,7 @@ def _annotate_dependencies(*, index_type: str, input_path: Path, bgzip: bool) ->
     for an HKS run or ``samtools`` for a FASTA one.
     """
     needed = ["hks"] if index_type == "hks" else ["get_featureIDs"]
-    if input_path.suffix.lower() == ".bam":
+    if input_path.suffix.lower() in (".bam", ".cram"):
         needed.append("samtools")
     if bgzip:
         needed.append("bgzip")
@@ -1077,6 +1095,8 @@ def _run_hks_backend(
     smoothed_by_input: dict[Path, dict[str, Path]],
     threads: int,
     k: int,
+    reference: Path | None = None,
+    query_names: bool | None = None,
     progress: Progress = SILENT,
 ) -> None:
     """Run the HKS lookup and optional smoothing for every requested feature set.
@@ -1095,6 +1115,13 @@ def _run_hks_backend(
     ``--report-query-names`` is a single per-invocation ``hks`` flag, so inputs
     are grouped by :func:`_is_reads_input` (reads emit query ranks, assemblies
     emit names) and each group gets its own call — at most two per feature set.
+
+    ``query_names`` overrides that default per-input-type choice: ``True`` emits
+    names for every input, ``False`` ranks for every input, ``None`` keeps the
+    reads-get-ranks default. Forcing names on read data matters whenever the
+    output has to be joined back to anything — paired-end mates, for instance,
+    are identified only by the ``/1`` and ``/2`` suffix on a shared read name,
+    and a rank is undecodable once the query file it indexes is gone.
 
     There is no conversion step. ``hks`` is told the output shape KaryoScope
     wants -- headerless, ``novel`` for misses -- so each lookup output *is* that
@@ -1132,6 +1159,7 @@ def _run_hks_backend(
             group = [p for p in input_paths if _is_reads_input(p) is is_reads_group]
             if not group:
                 continue
+            report_names = (not is_reads_group) if query_names is None else query_names
             logger.info(
                 "running hks lookup for feature set %r over %d input(s) (reads=%s, threads=%d)",
                 fs,
@@ -1145,7 +1173,8 @@ def _run_hks_backend(
                 k=k,
                 io_pairs=[(p, lookup_by_input[p]) for p in group],
                 threads=threads,
-                report_query_names=not is_reads_group,
+                report_query_names=report_names,
+                reference=reference,
                 capture=True,
             )
         dt_lookup = time.perf_counter() - t_lookup
@@ -1243,6 +1272,8 @@ def annotate(
     force: bool = False,
     k: int | None = None,
     check_space: bool = True,
+    reference: Path | None = None,
+    query_names: bool | None = None,
     progress: Progress = SILENT,
 ) -> AnnotateResult:
     """Run the full annotate pipeline for one input FASTA.
@@ -1250,7 +1281,11 @@ def annotate(
     Parameters
     ----------
     input_path
-        FASTA (plain or gzipped) to annotate.
+        FASTA (plain or gzipped), FASTQ, BAM or CRAM to annotate.
+    reference
+        Reference FASTA the input was aligned against, handed to
+        ``samtools fasta --reference``. Required for CRAM (whose bases are
+        stored as a diff against it) and ignored for every other format.
     output_dir
         Directory to write output BEDs to. Created if absent.
     db_root
@@ -1489,6 +1524,8 @@ def annotate(
             smoothed_by_input={input_path: smoothed_paths},
             threads=threads,
             k=query_k,
+            reference=reference,
+            query_names=query_names,
             progress=progress,
         )
     else:  # "kmc" -- the only other supported type (guaranteed by parse_manifest)
@@ -1527,6 +1564,7 @@ def annotate(
                 output_dir=output_dir,
                 threads=threads,
                 prefix=prefix,
+                reference=reference,
                 capture=True,
             )
             if not combined_bed.is_file():
@@ -1663,6 +1701,8 @@ def annotate_batch(
     force: bool = False,
     k: int | None = None,
     check_space: bool = True,
+    reference: Path | None = None,
+    query_names: bool | None = None,
     progress: Progress = SILENT,
 ) -> dict[Path, AnnotateResult]:
     """Annotate several inputs, loading the index once per feature set (HKS).
@@ -1706,6 +1746,8 @@ def annotate_batch(
                 force=force,
                 k=k,
                 check_space=check_space,
+                reference=reference,
+                query_names=query_names,
                 progress=progress,
             )
         }
@@ -1740,6 +1782,8 @@ def annotate_batch(
                 force=force,
                 k=k,
                 check_space=check_space,
+                reference=reference,
+                query_names=query_names,
                 progress=progress,
             )
             for p in input_paths
@@ -1881,6 +1925,8 @@ def annotate_batch(
         smoothed_by_input=smoothed_by_input,
         threads=threads,
         k=query_k,
+        reference=reference,
+        query_names=query_names,
         progress=progress,
     )
 

--- a/src/karyoscope/core/io/hks.py
+++ b/src/karyoscope/core/io/hks.py
@@ -32,6 +32,7 @@ from karyoscope.core.external import (
     run_tool,
 )
 from karyoscope.core.io.features import NOVEL_NAME
+from karyoscope.exceptions import KaryoscopeError
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +81,13 @@ _INPUT_EXTENSIONS: tuple[str, ...] = (
     ".fastq",
     ".fq",
     ".bam",
+    ".cram",
 )
+
+#: Alignment formats that ``hks`` cannot read and that are therefore
+#: materialised to a temp FASTA via ``samtools fasta`` first. CRAM
+#: additionally needs the reference its bases were encoded against.
+_ALIGNMENT_EXTENSIONS: tuple[str, ...] = (".bam", ".cram")
 
 
 def _relay_hks_log(result, what: str) -> None:
@@ -189,6 +196,7 @@ def run_hks_lookup(
     output_path: Path,
     threads: int = 0,
     report_query_names: bool = True,
+    reference: Path | None = None,
     capture: bool = False,
 ) -> Path:
     """Invoke ``hks lookup`` for one feature set against one input.
@@ -210,6 +218,7 @@ def run_hks_lookup(
         io_pairs=[(input_path, output_path)],
         threads=threads,
         report_query_names=report_query_names,
+        reference=reference,
         capture=capture,
     )
     return output_path
@@ -223,6 +232,7 @@ def run_hks_lookup_batch(
     io_pairs: list[tuple[Path, Path]],
     threads: int = 0,
     report_query_names: bool = True,
+    reference: Path | None = None,
     capture: bool = False,
 ) -> None:
     """Invoke ``hks lookup`` ONCE for a feature set, querying many inputs.
@@ -235,9 +245,46 @@ def run_hks_lookup_batch(
     ``report_query_names`` is a single ``hks`` flag applied to the whole batch, so
     every input here must want the same setting (the caller groups inputs by type;
     see :func:`karyoscope.core.io.hks._is_reads_input`-based grouping in the
-    annotate batch backend). BAM inputs are materialised to temp FASTA (via
-    ``samtools fasta``) up front, mirroring the single-input path; the temp files
-    are removed afterwards.
+    annotate batch backend). BAM and CRAM inputs are materialised to temp FASTA
+    (via ``samtools fasta``) up front, mirroring the single-input path; the temp
+    files are removed afterwards.
+
+    ``reference`` is the FASTA the alignment was encoded against, passed to
+    ``samtools fasta --reference``. CRAM stores bases as a diff against it, so
+    decoding one without it fails (or silently yields wrong sequence when
+    samtools resolves a *different* reference from the header's M5 tags via
+    ``$REF_PATH``). It is therefore required for CRAM and ignored for BAM, which
+    is self-contained.
+
+    The goal is the *original unaligned read set*: every read's full sequence
+    exactly once, as the pre-alignment FASTQ would have held it. ``-F 0x900``
+    (stated explicitly rather than left to samtools' default) selects primary
+    records only, which delivers exactly that:
+
+    * Each read has exactly one primary record, and it carries the full-length
+      SEQ — primaries are never hard-clipped.
+    * Supplementary records are hard-clipped *slices* of reads whose full
+      sequence the primary already supplied, so including them would feed those
+      bases through twice.
+    * Unmapped reads (``0x4``) and duplicates (``0x400``) are NOT excluded by
+      this mask. They are genuine distinct reads and are kept — dropping them
+      would under-count.
+
+    ``samtools fasta`` reverse-complements minus-strand records, so what is
+    written is the read as sequenced, not as aligned.
+
+    ``-N`` forces the ``/1`` and ``/2`` mate suffix onto every read name.
+    Aligners routinely strip it from QNAME (both mates of a pair then share a
+    byte-identical name in the file), and samtools' default only restores it
+    where the READ1/READ2 flag bits happen to be set. Without the suffix the
+    two mates are indistinguishable in the output, which silently destroys any
+    downstream fragment-level analysis. Measured on a DRAGEN WGS CRAM: ``-n``
+    collapsed 1,996,531 records onto 1,002,139 distinct names; ``-N`` kept all
+    1,996,531 distinct.
+
+    Note these temp FASTAs are full-size — a 65x human WGS CRAM expands to
+    ~260 GB — and land in ``$TMPDIR``. Point that at node-local scratch, not at
+    a shared filesystem.
     """
     if not io_pairs:
         return
@@ -252,23 +299,44 @@ def run_hks_lookup_batch(
         query_paths: list[Path] = []
         for input_path, output_path in io_pairs:
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            if input_path.suffix.lower() == ".bam":
+            suffix = input_path.suffix.lower()
+            if suffix in _ALIGNMENT_EXTENSIONS:
+                fmt = suffix.lstrip(".").upper()
+                if suffix == ".cram" and reference is None:
+                    raise KaryoscopeError(
+                        f"{input_path.name} is a CRAM, which stores bases as a diff "
+                        f"against the reference it was aligned to, so it cannot be "
+                        f"decoded without that reference. Pass --reference "
+                        f"<genome.fasta> (the same one used for alignment)."
+                    )
                 if samtools is None:
                     samtools = require_tool(
                         "samtools",
                         install_hint=(
-                            "Install samtools to use BAM inputs:\n"
+                            "Install samtools to use BAM/CRAM inputs:\n"
                             "  conda install -c bioconda samtools\n"
-                            "Or convert the BAM to FASTA first:\n"
+                            "Or convert the alignment to FASTA first:\n"
                             "  samtools fasta input.bam | gzip > input.fasta.gz"
                         ),
                     )
                 with tempfile.NamedTemporaryFile(suffix=".fasta", delete=False) as tmp:
                     tmp_fasta = Path(tmp.name)
                 tmp_fastas.append(tmp_fasta)
-                logger.debug("converting BAM to FASTA: %s -> %s", input_path, tmp_fasta)
+                samtools_cmd = [samtools, "fasta", "-F", "0x900", "-N"]
+                if reference is not None:
+                    # NOT -T: in `samtools fasta` that is the copy-tags-to-header
+                    # taglist, and passing a path there silently produces a
+                    # tag-decorated FASTA with no reference supplied at all.
+                    samtools_cmd += ["--reference", str(reference)]
+                # Give the decode its own threads: on a 30x human CRAM this
+                # stage is minutes of wall clock, and it is pure setup before
+                # the index load can even begin.
+                if threads > 0:
+                    samtools_cmd += ["-@", str(threads)]
+                samtools_cmd.append(str(input_path))
+                logger.debug("converting %s to FASTA: %s -> %s", fmt, input_path, tmp_fasta)
                 result = subprocess.run(
-                    [samtools, "fasta", str(input_path)],
+                    samtools_cmd,
                     stdout=tmp_fasta.open("wb"),
                     stderr=subprocess.PIPE if capture else None,
                     check=False,
@@ -276,10 +344,16 @@ def run_hks_lookup_batch(
                 if result.returncode != 0:
                     stderr = result.stderr.decode() if result.stderr else ""
                     raise ExternalToolError(
-                        cmd=[samtools, "fasta", str(input_path)],
+                        cmd=samtools_cmd,
                         returncode=result.returncode,
                         stderr=stderr,
                     )
+                logger.info(
+                    "decoded %s to %.1f GB of FASTA at %s",
+                    input_path.name,
+                    tmp_fasta.stat().st_size / 1_000_000_000,
+                    tmp_fasta,
+                )
                 query_paths.append(tmp_fasta)
             else:
                 query_paths.append(input_path)

--- a/src/karyoscope/core/io/kmc.py
+++ b/src/karyoscope/core/io/kmc.py
@@ -42,6 +42,7 @@ from karyoscope.core.external import (
     require_tool,
     run_tool,
 )
+from karyoscope.exceptions import KaryoscopeError
 
 logger = logging.getLogger(__name__)
 
@@ -196,7 +197,12 @@ _INPUT_EXTENSIONS: tuple[str, ...] = (
     ".fastq",
     ".fq",
     ".bam",
+    ".cram",
 )
+
+#: Alignment formats the C++ binary cannot read, streamed in through
+#: ``samtools fasta`` instead. CRAM additionally needs ``-T <reference>``.
+_ALIGNMENT_EXTENSIONS: tuple[str, ...] = (".bam", ".cram")
 
 
 def _infer_prefix(input_path: Path, db_path: Path) -> str:
@@ -311,6 +317,7 @@ def run_get_featureids(
     threads: int = 0,
     prefix: str | None = None,
     input_format: str | None = None,
+    reference: Path | None = None,
     capture: bool = False,
 ) -> Path:
     """Invoke ``get_featureIDs`` with the given options.
@@ -371,14 +378,15 @@ def run_get_featureids(
     # written only after the binary exits 0, below.
     clear_combined_marker(out_path)
 
-    if input_path.suffix.lower() == ".bam":
-        out_path = _run_get_featureids_piped_from_bam(
+    if input_path.suffix.lower() in _ALIGNMENT_EXTENSIONS:
+        out_path = _run_get_featureids_piped_from_alignment(
             binary=binary,
             db_path=db_path,
-            bam_path=input_path,
+            alignment_path=input_path,
             output_dir=output_dir,
             threads=threads,
             prefix=prefix,
+            reference=reference,
             capture=capture,
         )
         write_combined_marker(out_path, prefix=prefix, db_path=db_path, input_path=input_path)
@@ -408,38 +416,73 @@ def run_get_featureids(
     return out_path
 
 
-def _run_get_featureids_piped_from_bam(
+def _run_get_featureids_piped_from_alignment(
     *,
     binary: str,
     db_path: Path,
-    bam_path: Path,
+    alignment_path: Path,
     output_dir: Path,
     threads: int,
     prefix: str,
+    reference: Path | None,
     capture: bool,
 ) -> Path:
-    """Stream ``samtools fasta <bam>`` into ``get_featureIDs --input -``.
+    """Stream ``samtools fasta <aln>`` into ``get_featureIDs --input -``.
 
-    BAM inputs aren't read by the C++ binary directly; we convert
+    BAM/CRAM inputs aren't read by the C++ binary directly; we convert
     on the fly via ``samtools fasta`` (not ``fastq`` -- KaryoScope
     only needs the sequence, not the quality string, and FASTA is
     smaller and slightly faster to write). The pipe is streaming,
-    so no temp file is created and memory stays bounded.
+    so no temp file is created and memory stays bounded. (The HKS
+    backend cannot do this -- ``hks lookup`` needs a seekable path --
+    which is why it materialises a temp FASTA instead.)
+
+    ``reference`` is passed to ``samtools fasta --reference``. It is required
+    for CRAM, whose bases are stored as a diff against the reference used for
+    alignment, and ignored for BAM.
+
+    The goal is the *original unaligned read set*: every read's full sequence
+    exactly once, as the pre-alignment FASTQ would have held it. ``-F 0x900``
+    (stated explicitly rather than left to samtools' default) selects primary
+    records only, which delivers exactly that: each read has exactly one
+    primary record carrying full-length SEQ, while supplementary records are
+    hard-clipped slices of reads the primary already supplied in full.
+    Unmapped reads (``0x4``) and duplicates (``0x400``) are NOT excluded by
+    this mask -- they are genuine distinct reads and are kept.
+
+    ``-N`` forces the ``/1``/``/2`` mate suffix onto every read name. Aligners
+    routinely strip it from QNAME, leaving both mates of a pair sharing a
+    byte-identical name; without the suffix they are indistinguishable in the
+    output.
 
     Error handling: if ``get_featureIDs`` exits non-zero we report
     that (it's the more informative failure for the user). If it
     succeeds but ``samtools`` exited non-zero we report the samtools
-    error (rare; usually a malformed BAM).
+    error (rare; usually a malformed BAM or a mismatched reference).
     """
+    if alignment_path.suffix.lower() == ".cram" and reference is None:
+        raise KaryoscopeError(
+            f"{alignment_path.name} is a CRAM, which stores bases as a diff against "
+            f"the reference it was aligned to, so it cannot be decoded without that "
+            f"reference. Pass --reference <genome.fasta> (the same one used for "
+            f"alignment)."
+        )
+
     samtools = require_tool(
         "samtools",
-        install_hint="Install samtools to use BAM inputs:\n"
+        install_hint="Install samtools to use BAM/CRAM inputs:\n"
         "  conda install -c bioconda samtools\n"
-        "Or convert the BAM to FASTA first with:\n"
+        "Or convert the alignment to FASTA first with:\n"
         "  samtools fasta input.bam | gzip > input.fasta.gz",
     )
 
-    samtools_cmd = [samtools, "fasta", str(bam_path)]
+    samtools_cmd = [samtools, "fasta", "-F", "0x900", "-N"]
+    if reference is not None:
+        # NOT -T: in `samtools fasta` that is the copy-tags-to-header taglist,
+        # and passing a path there silently produces a tag-decorated FASTA with
+        # no reference supplied at all.
+        samtools_cmd += ["--reference", str(reference)]
+    samtools_cmd.append(str(alignment_path))
     getfid_cmd = [
         binary,
         "--db",

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -384,3 +384,54 @@ def test_peak_child_rss_is_reported_in_bytes() -> None:
     # pytest has already reaped children, so this is a plausible RSS in
     # bytes and an implausible one in kilobytes.
     assert peak < 1024**4
+
+
+# --- CRAM input ------------------------------------------------------------
+
+
+def test_cram_is_recognised_as_a_read_level_input() -> None:
+    """CRAM holds reads, so it takes the read dispatch path, not the assembly one."""
+    from karyoscope.core.annotate import _is_reads_input
+
+    assert _is_reads_input(Path("sample.cram")) is True
+    assert _is_reads_input(Path("sample.bam")) is True
+    assert _is_reads_input(Path("assembly.fa.gz")) is False
+
+
+def test_cram_extension_is_stripped_from_the_output_basename() -> None:
+    """Outputs are named after the input stem, so .cram must be a known suffix."""
+    from karyoscope.core.annotate import _derive_input_basename
+
+    assert _derive_input_basename(Path("ALTseq_00001A_tumor.cram")) == "ALTseq_00001A_tumor"
+
+
+def test_cram_input_declares_a_samtools_dependency() -> None:
+    """The preflight resolves tools from the input format rather than assuming."""
+    from karyoscope.core.annotate import _annotate_dependencies
+
+    needed = _annotate_dependencies(
+        index_type="hks", input_path=Path("s.cram"), bgzip=False
+    )
+    assert "samtools" in needed
+    assert "hks" in needed
+
+
+def test_cram_bases_estimate_exceeds_bam_per_byte() -> None:
+    """CRAM packs far harder than BAM, so a byte of it means far more sequence.
+
+    Sharing BAM's ~1 base/byte would under-estimate a CRAM run's output by
+    most of an order of magnitude -- and this figure feeds the disk check
+    whose job is to refuse a run that would fill the filesystem.
+    """
+    from karyoscope.core.annotate import _BASES_PER_BAM_BYTE, _BASES_PER_CRAM_BYTE
+
+    assert _BASES_PER_CRAM_BYTE > _BASES_PER_BAM_BYTE * 5
+
+
+def test_estimate_input_bases_uses_the_cram_factor(tmp_path: Path) -> None:
+    """A .cram file's size is scaled by the CRAM factor, not the FASTA fraction."""
+    from karyoscope.core.annotate import _BASES_PER_CRAM_BYTE, estimate_input_bases
+
+    cram = tmp_path / "s.cram"
+    cram.write_bytes(b"x" * 1000)
+    assert estimate_input_bases(cram) == int(1000 * _BASES_PER_CRAM_BYTE)

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -476,3 +476,63 @@ def test_query_names_refusal_names_the_offending_inputs() -> None:
         _reject_query_names_for_reads([Path("asm.fa"), Path("tumor.cram")], True)
     assert "tumor.cram" in str(excinfo.value)
     assert "asm.fa" not in str(excinfo.value)
+
+
+def _hks_cmd_for(tmp_path: Path, monkeypatch, *, input_name: str, query_names):
+    """Run the HKS backend with hks stubbed, returning the cmd it would invoke."""
+    from karyoscope.core import annotate as ann_mod
+
+    captured: dict = {}
+
+    def _fake_batch(**kwargs):
+        captured["report_query_names"] = kwargs["report_query_names"]
+        # the backend checks the lookup output exists before smoothing
+        for _inp, out in kwargs["io_pairs"]:
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text("")
+
+    monkeypatch.setattr(ann_mod, "run_hks_lookup_batch", _fake_batch)
+    monkeypatch.setattr(ann_mod, "run_hks_smooth", lambda **kw: None)
+
+    class _Manifest:
+        class index:
+            basename = "features"
+
+    inp = tmp_path / input_name
+    inp.write_text("")
+    ann_mod._run_hks_backend(
+        manifest=_Manifest(),
+        db_dir=tmp_path,
+        input_paths=[inp],
+        prefixes={inp: "p"},
+        output_dir=tmp_path / "out",
+        requested=["cytoband"],
+        smooth=False,
+        keep_presmoothed=True,
+        presmoothed_by_input={inp: {"cytoband": tmp_path / "out" / "p.cytoband.bed"}},
+        smoothed_by_input={inp: {}},
+        threads=1,
+        k=31,
+        query_names=query_names,
+    )
+    return captured["report_query_names"]
+
+
+def test_reads_default_to_ranks_with_no_flag_at_all(tmp_path: Path, monkeypatch) -> None:
+    """Passing neither flag must not silently hand hks the OOM-inducing option.
+
+    This is the path almost every user takes, so the safe behaviour has to be
+    the DEFAULT rather than something opted into.
+    """
+    for name in ("s.cram", "s.bam", "s.fastq"):
+        assert _hks_cmd_for(tmp_path, monkeypatch, input_name=name, query_names=None) is False
+
+
+def test_assemblies_still_default_to_names(tmp_path: Path, monkeypatch) -> None:
+    """Contig names are the useful identifier for an assembly and cost nothing."""
+    assert _hks_cmd_for(tmp_path, monkeypatch, input_name="asm.fa", query_names=None) is True
+
+
+def test_explicit_no_query_names_forces_ranks_on_an_assembly(tmp_path: Path, monkeypatch) -> None:
+    """The override works downward too, for databases with long feature names."""
+    assert _hks_cmd_for(tmp_path, monkeypatch, input_name="asm.fa", query_names=False) is False

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -435,3 +435,44 @@ def test_estimate_input_bases_uses_the_cram_factor(tmp_path: Path) -> None:
     cram = tmp_path / "s.cram"
     cram.write_bytes(b"x" * 1000)
     assert estimate_input_bases(cram) == int(1000 * _BASES_PER_CRAM_BYTE)
+
+
+def test_query_names_is_refused_for_read_level_input() -> None:
+    """Reads cannot carry names: hks buffers all of them and the run is OOM-killed.
+
+    Measured on a 64x human WGS CRAM -- 1.315 G names at ~68 bytes is ~90 GB on
+    top of the index. The refusal is deliberate rather than a warning, because
+    the failure lands ~20 minutes in, after the decode has been paid for, with
+    nothing written and nothing to resume from.
+    """
+    from karyoscope.core.annotate import _reject_query_names_for_reads
+
+    for name in ("s.cram", "s.bam", "s.fastq.gz", "s.fq"):
+        with pytest.raises(KaryoscopeError, match="not supported for read-level input"):
+            _reject_query_names_for_reads([Path(name)], True)
+
+
+def test_query_names_is_allowed_for_assemblies() -> None:
+    """An assembly has a few thousand contig names; buffering those is free."""
+    from karyoscope.core.annotate import _reject_query_names_for_reads
+
+    _reject_query_names_for_reads([Path("asm.fa.gz")], True)
+    _reject_query_names_for_reads([Path("asm.fasta")], True)
+
+
+def test_reads_may_still_opt_out_of_names_explicitly() -> None:
+    """--no-query-names and the default are both fine for reads; only True is refused."""
+    from karyoscope.core.annotate import _reject_query_names_for_reads
+
+    _reject_query_names_for_reads([Path("s.cram")], False)
+    _reject_query_names_for_reads([Path("s.cram")], None)
+
+
+def test_query_names_refusal_names_the_offending_inputs() -> None:
+    """A cohort run should say WHICH inputs are the problem, not just that one is."""
+    from karyoscope.core.annotate import _reject_query_names_for_reads
+
+    with pytest.raises(KaryoscopeError) as excinfo:
+        _reject_query_names_for_reads([Path("asm.fa"), Path("tumor.cram")], True)
+    assert "tumor.cram" in str(excinfo.value)
+    assert "asm.fa" not in str(excinfo.value)

--- a/tests/test_hks.py
+++ b/tests/test_hks.py
@@ -16,6 +16,7 @@ from karyoscope.core.io.hks import (
     run_hks_lookup,
     run_hks_smooth,
 )
+from karyoscope.exceptions import KaryoscopeError
 
 
 def _capture_lookup_cmd(
@@ -350,3 +351,95 @@ def test_batch_lookup_with_no_inputs_does_nothing(
         io_pairs=[],
     )
     assert calls == []
+
+
+# --- CRAM / BAM conversion -------------------------------------------------
+
+
+def _capture_samtools_cmd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    suffix: str,
+    reference: Path | None,
+) -> list[str]:
+    """Run a lookup over a BAM/CRAM input, returning the samtools cmd it built.
+
+    ``hks`` itself is stubbed out; the assertion target is the conversion step
+    that runs before it.
+    """
+    captured: dict[str, list[str]] = {}
+
+    class _Result:
+        returncode = 0
+        stderr = b""
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        # The caller sizes and then hands the temp FASTA to hks, so it must exist.
+        stdout = kwargs.get("stdout")
+        if stdout is not None:
+            stdout.close()
+        return _Result()
+
+    monkeypatch.setattr("karyoscope.core.io.hks.get_hks_binary", lambda: "hks")
+    monkeypatch.setattr("karyoscope.core.io.hks.require_tool", lambda *a, **kw: "samtools")
+    monkeypatch.setattr("karyoscope.core.io.hks.subprocess.run", _fake_run)
+    monkeypatch.setattr("karyoscope.core.io.hks.run_tool", lambda cmd, **kw: None)
+
+    aln = tmp_path / f"input{suffix}"
+    aln.write_bytes(b"")
+    run_hks_lookup(
+        base_path=tmp_path / "features.hksb",
+        feature_set_file=tmp_path / "features.cytoband.hksf",
+        k=31,
+        input_path=aln,
+        output_path=tmp_path / "out.bed",
+        reference=reference,
+    )
+    return captured["cmd"]
+
+
+def test_cram_conversion_passes_the_reference(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CRAM decode supplies --reference, not -T (which is samtools' taglist)."""
+    ref = tmp_path / "genome.fasta"
+    ref.write_text(">chr1\nACGT\n")
+    cmd = _capture_samtools_cmd(tmp_path, monkeypatch, suffix=".cram", reference=ref)
+    assert "--reference" in cmd
+    assert cmd[cmd.index("--reference") + 1] == str(ref)
+    # -T here would silently mean "copy these tags to the header" and leave the
+    # decode with no reference at all.
+    assert "-T" not in cmd
+
+
+def test_cram_without_reference_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A CRAM cannot be decoded without its reference, so the run stops early."""
+    with pytest.raises(KaryoscopeError, match="CRAM"):
+        _capture_samtools_cmd(tmp_path, monkeypatch, suffix=".cram", reference=None)
+
+
+def test_bam_conversion_needs_no_reference(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """BAM is self-contained; no --reference is added and no error is raised."""
+    cmd = _capture_samtools_cmd(tmp_path, monkeypatch, suffix=".bam", reference=None)
+    assert "--reference" not in cmd
+
+
+def test_conversion_states_flag_filter_and_mate_suffix_explicitly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """-F 0x900 -N are pinned rather than left to samtools' defaults.
+
+    ``-F 0x900`` keeps exactly one full-length record per read (primaries),
+    while ``-N`` forces the /1,/2 suffix that distinguishes mates whose QNAME
+    the aligner stripped. Without -N both mates share one name and the pairing
+    is unrecoverable downstream.
+    """
+    cmd = _capture_samtools_cmd(tmp_path, monkeypatch, suffix=".bam", reference=None)
+    assert cmd[cmd.index("-F") + 1] == "0x900"
+    assert "-N" in cmd


### PR DESCRIPTION
Stacked on #21 (`feat/memory-preflight`), which is itself on #20 → #19 → #18. Review that stack first; the diff here is only the three commits on top.

Written against a real workload: 10-12 ALTseq tumor WGS CRAMs (DRAGEN, GRCh38-aligned, ~64x) annotated against `HKS_human_CHM13_cytoband`. Every number below is measured on `ALTseq_00001A` — 28.9 GB CRAM, 1.315 G reads, 198.6 Gbp.

## `--input *.cram` + `--reference`

CRAM stores bases as a diff against the reference used for alignment, so `--reference` is **required** for CRAM and the CLI refuses without it. That refusal is deliberately loud because the quiet failure is worse: left alone, htslib resolves each contig's M5 through `$REF_PATH`/`$REF_CACHE` and can decode against a *different* build of the same genome, yielding plausible sequence that is simply wrong.

`--reference` is the **alignment** reference and is unrelated to `--db` — `annotate` is alignment-free, so GRCh38 reads against a CHM13 database is normal.

Both backends are covered. KMC streams `samtools fasta` straight into `get_featureIDs`; HKS cannot (`hks lookup` needs a seekable path) and materialises a temp FASTA in `$TMPDIR`. **That file is full size** — 28.9 GB in, 254 GB out — so `$TMPDIR` must be node-local. Documented prominently.

## Conversion details are now stated, not inherited

`samtools fasta -F 0x900 -N`, explicitly.

`-F 0x900` was already samtools' default, but relying on a default for a correctness-critical choice is how it changes underneath you. It is the right mask: every read has exactly one primary record carrying full-length SEQ, while supplementary records are hard-clipped *slices* of reads the primary already supplied. Verified — of 2,995,805 primary records, **zero** were hard-clipped, lacked SEQ, or fell short of read length. Unmapped (`0x4`) and duplicate (`0x400`) reads are **kept**; they are genuine distinct reads.

`-N` is a genuine bug fix. Aligners strip the `/1`,`/2` suffix from QNAME (DRAGEN sets `strip-input-qname-suffixes: true`), leaving both mates byte-identical, and samtools only restores it where the READ1/READ2 bits are set. Measured: with `-n`, 1,996,531 records collapsed onto **1,002,139** distinct names — every pair silently indistinguishable. With `-N`, all 1,996,531 stayed distinct.

## `--query-names`, and why it is refused for reads

`hks --report-query-names` is not streaming — `load_seq_names` builds a `Vec<String>` of every name before the first lookup. Fine for an assembly's contigs; fatal for reads: 1.315 G names × ~68 bytes ≈ **90 GB** on top of the ~12.3 GB index.

I found this the expensive way. A run died to the OOM killer at MaxRSS 25.2 GB against `--mem=24G`, ~20 minutes in, having already spent 15 of them decoding the CRAM, with nothing written and nothing to resume from. Last line logged: `Collecting sequence names ...`.

Raising memory is not a fix — it would take a ~160 GB allocation per sample to buy nothing but longer identifiers. So the flag is **refused** for read-level input at both public entry points, failing in a second with an actionable message. Assemblies are unaffected and still default to names.

No information is lost: rank N is the Nth record of the query file, and for an alignment input that is a deterministic function of the source, regenerable with `samtools fasta -F 0x900 -N --reference <ref> <input> | grep '^>'`.

The third commit pins the no-flag default (reads → ranks, assemblies → names) with tests, since that is the path almost every invocation takes and nothing asserted it.

## Disk estimator

`estimate_input_bases` learns a CRAM factor: **6.9 bases/byte**, measured, against BAM's ~1. Sharing BAM's would under-estimate a CRAM run's output ~7x, and that figure feeds the check whose whole job is refusing a run that would fill the filesystem. Validated in situ — KaryoScope predicted 199.37 Gbp against a true 198.6 Gbp, within 0.4%.

## Verification

- 824 → 827 tests pass, ruff clean.
- Round-trip on real data: 1,996,531 FASTA records = 1,996,531 unique (read, mate) identities — no omissions, no duplicates. Minus-strand records come back in sequencing orientation.
- End-to-end on the full 28.9 GB CRAM: completed in 1h09m at 16 threads / 24 GB, hks peak 13.18 GB, producing 15.54 GB presmoothed + 7.96 GB smoothed (bgzipped).

## Note for reviewers

`samtools fasta`'s reference flag is `--reference`, **not** `-T` — in that subcommand `-T` is the copy-tags taglist, so passing a path there silently yields a tag-decorated FASTA with no reference supplied at all. I made exactly that mistake first; there is a test pinning it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)