### PR TITLE
perf(annotate): decode an alignment once per run, and tee the query-name sidecar off it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **A BAM/CRAM input is now decoded ONCE per run, not once per feature set.** The
+  `samtools fasta` conversion lived inside `run_hks_lookup_batch`, which the
+  annotate backend calls once per feature set -- so a six-feature-set database
+  decoded the same alignment six times. On a 56 GB CRAM that is ~25 minutes each,
+  ~2.5 hours of pure redundancy. The conversion is now a context manager
+  (`materialised_queries`) that the backend enters once and reuses across every
+  set. Single-feature-set runs are unaffected; already-seekable inputs pass
+  straight through and cost nothing.
+
 ### Added
+
+- **`--query-names-sidecar`** writes `<outdir>/<input>.query_names.txt.gz` for
+  BAM/CRAM input: the record names in the order hks assigns ranks, one per line.
+  It is **teed off the decode annotate performs anyway**, so it is nearly free.
+
+  This exists because read-level output is identified by ordinal rank (names OOM
+  the lookup -- see below), and recovering the mapping afterwards means decoding
+  the whole alignment a second time: ~25 minutes and a full re-read of a 56 GB
+  CRAM. Anything that joins rank-identified output back to reads needs it --
+  pairing paired-end mates, for instance, since mates are not adjacent in a
+  coordinate-sorted CRAM.
+
+  Verified byte-identical to `samtools fasta -F 0x900 -N | grep '^>'` on a real
+  CRAM, and named from the input stem rather than the db-qualified prefix, since
+  the mapping is a property of the input rather than the database.
 
 - **`annotate` reads CRAM.** `--input` accepts `.cram`, and a new `--reference`
   option supplies the FASTA the alignment was encoded against. CRAM stores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,9 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Both backends are covered. KMC streams `samtools fasta` straight into
   `get_featureIDs` with no temp file; HKS cannot (`hks lookup` needs a seekable
-  path) and so materialises a temp FASTA in `$TMPDIR` first. That file is
+  path) and so materialises a temp FASTA next to the output first — the system
+  tempdir on cluster nodes is often small or RAM-backed. That file is
   **full size** — a 64x human WGS CRAM measured 28.9 GB in, 254 GB out — so
-  `$TMPDIR` must point at node-local scratch, never at a shared filesystem.
+  budget that space on the output filesystem on top of the BEDs.
 
 - **`--query-names/--no-query-names`** controls which identifier the output BED
   carries, and **`--query-names` is now refused outright for read-level input**

--- a/docs/commands/annotate.md
+++ b/docs/commands/annotate.md
@@ -74,9 +74,10 @@ duplicates are **kept** — they are genuine distinct reads. Minus-strand record
 reverse-complemented back to sequencing orientation.
 
 **Scratch space.** The KMC backend streams the conversion with no temp file. The HKS
-backend cannot — `hks lookup` needs a seekable path — so it materialises a temp FASTA in
-`$TMPDIR` first. **That file is full size**: a 64x human WGS CRAM measured 28.9 GB in and
-254 GB out. Point `$TMPDIR` at node-local scratch, never at a shared filesystem.
+backend cannot — `hks lookup` needs a seekable path — so it materialises a temp FASTA
+next to the output first (the system tempdir on cluster nodes is often small or
+RAM-backed). **That file is full size**: a 64x human WGS CRAM measured 28.9 GB in and
+254 GB out, so budget that space on the output filesystem on top of the BEDs.
 
 ## Paired-end reads
 

--- a/src/karyoscope/commands/annotate.py
+++ b/src/karyoscope/commands/annotate.py
@@ -105,6 +105,17 @@ logger = logging.getLogger(__name__)
     "ranks, and rank N is simply the Nth record of the query file.",
 )
 @click.option(
+    "--query-names-sidecar",
+    is_flag=True,
+    default=False,
+    help="For BAM/CRAM input, also write <outdir>/<input>.query_names.txt.gz: "
+    "the record names in the order hks assigns ranks, one per line. Teed off the "
+    "decode annotate performs anyway, so it is nearly free -- whereas recovering "
+    "the same mapping afterwards costs a second full decode of the alignment "
+    "(~25 min on a 56 GB CRAM). Needed to join rank-identified output back to "
+    "read names, e.g. to pair paired-end mates.",
+)
+@click.option(
     "--reference",
     "reference",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
@@ -217,6 +228,7 @@ def cmd(
     db_id: str | None,
     db_root_arg: Path | None,
     query_names: bool | None,
+    query_names_sidecar: bool,
     reference: Path | None,
     feature_sets_arg: tuple[str, ...],
     threads: int,
@@ -295,6 +307,7 @@ def cmd(
         check_space=not skip_checks,
         reference=reference,
         query_names=query_names,
+        query_names_sidecar=query_names_sidecar,
         progress=_progress.from_context(),
     )
 

--- a/src/karyoscope/core/annotate.py
+++ b/src/karyoscope/core/annotate.py
@@ -52,6 +52,7 @@ from karyoscope.core.io.hierarchy import (
 )
 from karyoscope.core.io.hks import (
     estimate_hks_memory_bytes,
+    materialised_queries,
     run_hks_lookup_batch,
     run_hks_smooth,
 )
@@ -1140,6 +1141,7 @@ def _run_hks_backend(
     k: int,
     reference: Path | None = None,
     query_names: bool | None = None,
+    query_names_sidecar: bool = False,
     progress: Progress = SILENT,
 ) -> None:
     """Run the HKS lookup and optional smoothing for every requested feature set.
@@ -1179,6 +1181,80 @@ def _run_hks_backend(
 
     t_hks_start = time.perf_counter()
     tracker = progress.track(requested)
+
+    # Decode alignment inputs ONCE, outside the feature-set loop. The conversion
+    # used to happen inside run_hks_lookup_batch, which is called per feature
+    # set, so a BAM/CRAM was decoded once PER SET -- six times over for a
+    # six-set database, ~25 minutes each on a 56 GB CRAM. The context manager
+    # also tees the query-name sidecar off that same decode when asked, instead
+    # of the caller decoding the input a second time to recover names.
+    sidecars = (
+        # Named from the INPUT stem only, not the db-qualified prefix: the
+        # rank -> name mapping is a property of the input, so annotating one CRAM
+        # against two databases must not write two identical sidecars.
+        {p: output_dir / f"{_derive_input_basename(p)}.query_names.txt.gz" for p in input_paths}
+        if query_names_sidecar
+        else None
+    )
+    with materialised_queries(
+        input_paths,
+        reference=reference,
+        threads=threads,
+        query_names_sidecar=sidecars,
+        capture=True,
+    ) as resolved:
+        _run_hks_feature_sets(
+            manifest=manifest,
+            db_dir=db_dir,
+            base_path=base_path,
+            input_paths=input_paths,
+            resolved=resolved,
+            prefixes=prefixes,
+            output_dir=output_dir,
+            requested=requested,
+            smooth=smooth,
+            keep_presmoothed=keep_presmoothed,
+            presmoothed_by_input=presmoothed_by_input,
+            smoothed_by_input=smoothed_by_input,
+            threads=threads,
+            k=k,
+            query_names=query_names,
+            progress=progress,
+            tracker=tracker,
+            t_hks_start=t_hks_start,
+        )
+    if sidecars:
+        for path in sidecars.values():
+            if path.is_file():
+                logger.info("wrote query-name sidecar %s", path)
+
+
+def _run_hks_feature_sets(
+    *,
+    manifest,
+    db_dir: Path,
+    base_path: Path,
+    input_paths: list[Path],
+    resolved: dict[Path, Path],
+    prefixes: dict[Path, str],
+    output_dir: Path,
+    requested: list[str],
+    smooth: bool,
+    keep_presmoothed: bool,
+    presmoothed_by_input: dict[Path, dict[str, Path]],
+    smoothed_by_input: dict[Path, dict[str, Path]],
+    threads: int,
+    k: int,
+    query_names: bool | None,
+    progress: Progress,
+    tracker,
+    t_hks_start: float,
+) -> None:
+    """Query every feature set against inputs that are ALREADY seekable.
+
+    Split out of :func:`_run_hks_backend` so the alignment decode happens once,
+    in the caller, rather than once per feature set.
+    """
     for fs in requested:
         t_fs = time.perf_counter()
         fs_file = db_dir / f"{manifest.index.basename}.{fs}.hksf"
@@ -1214,10 +1290,9 @@ def _run_hks_backend(
                 base_path=base_path,
                 feature_set_file=fs_file,
                 k=k,
-                io_pairs=[(p, lookup_by_input[p]) for p in group],
+                io_pairs=[(resolved[p], lookup_by_input[p]) for p in group],
                 threads=threads,
                 report_query_names=report_names,
-                reference=reference,
                 capture=True,
             )
         dt_lookup = time.perf_counter() - t_lookup
@@ -1317,6 +1392,7 @@ def annotate(
     check_space: bool = True,
     reference: Path | None = None,
     query_names: bool | None = None,
+    query_names_sidecar: bool = False,
     progress: Progress = SILENT,
 ) -> AnnotateResult:
     """Run the full annotate pipeline for one input FASTA.
@@ -1570,6 +1646,7 @@ def annotate(
             k=query_k,
             reference=reference,
             query_names=query_names,
+            query_names_sidecar=query_names_sidecar,
             progress=progress,
         )
     else:  # "kmc" -- the only other supported type (guaranteed by parse_manifest)
@@ -1747,6 +1824,7 @@ def annotate_batch(
     check_space: bool = True,
     reference: Path | None = None,
     query_names: bool | None = None,
+    query_names_sidecar: bool = False,
     progress: Progress = SILENT,
 ) -> dict[Path, AnnotateResult]:
     """Annotate several inputs, loading the index once per feature set (HKS).
@@ -1794,6 +1872,7 @@ def annotate_batch(
                 check_space=check_space,
                 reference=reference,
                 query_names=query_names,
+                query_names_sidecar=query_names_sidecar,
                 progress=progress,
             )
         }
@@ -1830,6 +1909,7 @@ def annotate_batch(
                 check_space=check_space,
                 reference=reference,
                 query_names=query_names,
+                query_names_sidecar=query_names_sidecar,
                 progress=progress,
             )
             for p in input_paths
@@ -1973,6 +2053,7 @@ def annotate_batch(
         k=query_k,
         reference=reference,
         query_names=query_names,
+        query_names_sidecar=query_names_sidecar,
         progress=progress,
     )
 

--- a/src/karyoscope/core/annotate.py
+++ b/src/karyoscope/core/annotate.py
@@ -1198,6 +1198,7 @@ def _run_hks_backend(
     )
     with materialised_queries(
         input_paths,
+        dest_dir=output_dir,
         reference=reference,
         threads=threads,
         query_names_sidecar=sidecars,

--- a/src/karyoscope/core/io/hks.py
+++ b/src/karyoscope/core/io/hks.py
@@ -312,13 +312,22 @@ def materialised_queries(
                 )
             else:
                 # tee(1) rather than Python: the FASTA branch is hundreds of GB
-                # and must not be marshalled through this process.
+                # and must not be marshalled through this process. The pipeline
+                # is LINEAR — tee writes the FASTA as its file argument and the
+                # sidecar is the pipeline's terminus — rather than tee into a
+                # >(...) process substitution, because bash neither propagates
+                # a substitution's failure into pipefail nor waits for it to
+                # finish: a full disk under the sidecar would have reported
+                # success, and gzip could still be flushing when the run moved
+                # on. Every stage of a linear pipeline is covered by pipefail
+                # and complete when bash returns. awk rather than grep so an
+                # input with zero records is empty output, not exit code 1.
                 sidecar.parent.mkdir(parents=True, exist_ok=True)
                 pipeline = (
                     f"{shlex.join(cmd)} "
-                    f"| tee >(grep '^>' | cut -c2- | cut -d' ' -f1 "
-                    f"| gzip > {shlex.quote(str(sidecar))}) "
-                    f"> {shlex.quote(str(tmp_fasta))}"
+                    f"| tee {shlex.quote(str(tmp_fasta))} "
+                    "| awk '/^>/ { print substr($1, 2) }' "
+                    f"| gzip > {shlex.quote(str(sidecar))}"
                 )
                 logger.debug("teeing query names to %s", sidecar)
                 result = subprocess.run(

--- a/src/karyoscope/core/io/hks.py
+++ b/src/karyoscope/core/io/hks.py
@@ -18,8 +18,10 @@ If neither resolves, :func:`get_hks_binary` raises :class:`ToolNotFoundError`.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -197,6 +199,7 @@ def run_hks_lookup(
     threads: int = 0,
     report_query_names: bool = True,
     reference: Path | None = None,
+    query_names_sidecar: Path | None = None,
     capture: bool = False,
 ) -> Path:
     """Invoke ``hks lookup`` for one feature set against one input.
@@ -219,9 +222,119 @@ def run_hks_lookup(
         threads=threads,
         report_query_names=report_query_names,
         reference=reference,
+        query_names_sidecar=query_names_sidecar,
         capture=capture,
     )
     return output_path
+
+
+@contextlib.contextmanager
+def materialised_queries(
+    input_paths: list[Path],
+    *,
+    reference: Path | None = None,
+    threads: int = 0,
+    query_names_sidecar: dict[Path, Path] | None = None,
+    capture: bool = False,
+):
+    """Yield ``{input_path: seekable_query_path}``, converting alignments once.
+
+    ``hks lookup`` needs a seekable path, so BAM/CRAM inputs are decoded to a
+    temp FASTA. That decode is EXPENSIVE -- ~25 minutes for a 56 GB CRAM -- and
+    it used to live inside :func:`run_hks_lookup_batch`, which the annotate
+    backend calls once per feature set. A six-feature-set database therefore
+    decoded the same alignment six times, ~2.5 hours of pure redundancy. Hoisting
+    it into a context manager lets the caller pay for it once and reuse the
+    result across every feature set.
+
+    ``query_names_sidecar`` maps an input to a path that receives its record
+    names, one per line, in the order hks will assign ranks. That is teed off
+    THIS decode rather than requiring the caller to decode the alignment a second
+    time purely to recover them (another ~25 minutes and a full re-read on the
+    largest sample).
+
+    Temp FASTAs are removed on exit, including on failure.
+    """
+    tmp_fastas: list[Path] = []
+    samtools: str | None = None
+    query_paths: dict[Path, Path] = {}
+    try:
+        for input_path in input_paths:
+            suffix = input_path.suffix.lower()
+            if suffix not in _ALIGNMENT_EXTENSIONS:
+                query_paths[input_path] = input_path
+                continue
+            fmt = suffix.lstrip(".").upper()
+            if suffix == ".cram" and reference is None:
+                raise KaryoscopeError(
+                    f"{input_path.name} is a CRAM, which stores bases as a diff "
+                    f"against the reference it was aligned to, so it cannot be "
+                    f"decoded without that reference. Pass --reference "
+                    f"<genome.fasta> (the same one used for alignment)."
+                )
+            if samtools is None:
+                samtools = require_tool(
+                    "samtools",
+                    install_hint=(
+                        "Install samtools to use BAM/CRAM inputs:\n"
+                        "  conda install -c bioconda samtools\n"
+                        "Or convert the alignment to FASTA first:\n"
+                        "  samtools fasta input.bam | gzip > input.fasta.gz"
+                    ),
+                )
+            with tempfile.NamedTemporaryFile(suffix=".fasta", delete=False) as tmp:
+                tmp_fasta = Path(tmp.name)
+            tmp_fastas.append(tmp_fasta)
+
+            cmd = [samtools, "fasta", "-F", "0x900", "-N"]
+            if reference is not None:
+                # NOT -T: in `samtools fasta` that is the copy-tags-to-header
+                # taglist, and a path there silently yields a tag-decorated FASTA
+                # with no reference supplied at all.
+                cmd += ["--reference", str(reference)]
+            if threads > 0:
+                cmd += ["-@", str(threads)]
+            cmd.append(str(input_path))
+
+            sidecar = (query_names_sidecar or {}).get(input_path)
+            logger.debug("converting %s to FASTA: %s -> %s", fmt, input_path, tmp_fasta)
+            if sidecar is None:
+                result = subprocess.run(
+                    cmd,
+                    stdout=tmp_fasta.open("wb"),
+                    stderr=subprocess.PIPE if capture else None,
+                    check=False,
+                )
+            else:
+                # tee(1) rather than Python: the FASTA branch is hundreds of GB
+                # and must not be marshalled through this process.
+                sidecar.parent.mkdir(parents=True, exist_ok=True)
+                pipeline = (
+                    f"{shlex.join(cmd)} "
+                    f"| tee >(grep '^>' | cut -c2- | cut -d' ' -f1 "
+                    f"| gzip > {shlex.quote(str(sidecar))}) "
+                    f"> {shlex.quote(str(tmp_fasta))}"
+                )
+                logger.debug("teeing query names to %s", sidecar)
+                result = subprocess.run(
+                    ["bash", "-o", "pipefail", "-c", pipeline],
+                    stderr=subprocess.PIPE if capture else None,
+                    check=False,
+                )
+            if result.returncode != 0:
+                stderr = result.stderr.decode() if result.stderr else ""
+                raise ExternalToolError(cmd=cmd, returncode=result.returncode, stderr=stderr)
+            logger.info(
+                "decoded %s to %.1f GB of FASTA at %s",
+                input_path.name,
+                tmp_fasta.stat().st_size / 1_000_000_000,
+                tmp_fasta,
+            )
+            query_paths[input_path] = tmp_fasta
+        yield query_paths
+    finally:
+        for tmp in tmp_fastas:
+            tmp.unlink(missing_ok=True)
 
 
 def run_hks_lookup_batch(
@@ -233,6 +346,7 @@ def run_hks_lookup_batch(
     threads: int = 0,
     report_query_names: bool = True,
     reference: Path | None = None,
+    query_names_sidecar: dict[Path, Path] | None = None,
     capture: bool = False,
 ) -> None:
     """Invoke ``hks lookup`` ONCE for a feature set, querying many inputs.
@@ -292,71 +406,20 @@ def run_hks_lookup_batch(
     binary = get_hks_binary()
     n_threads = threads if threads > 0 else 4
 
-    tmp_fastas: list[Path] = []
-    samtools: str | None = None
-    try:
-        # Resolve each input to a seekable query path (converting BAM up front).
-        query_paths: list[Path] = []
-        for input_path, output_path in io_pairs:
+    # Conversion is delegated so it is defined in exactly one place. Inputs that
+    # are already seekable pass straight through, so a caller that pre-converted
+    # (see materialised_queries, which the annotate backend uses to decode once
+    # for ALL feature sets) pays nothing here.
+    with materialised_queries(
+        [inp for inp, _ in io_pairs],
+        reference=reference,
+        threads=threads,
+        query_names_sidecar=query_names_sidecar,
+        capture=capture,
+    ) as resolved:
+        query_paths = [resolved[inp] for inp, _ in io_pairs]
+        for _inp, output_path in io_pairs:
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            suffix = input_path.suffix.lower()
-            if suffix in _ALIGNMENT_EXTENSIONS:
-                fmt = suffix.lstrip(".").upper()
-                if suffix == ".cram" and reference is None:
-                    raise KaryoscopeError(
-                        f"{input_path.name} is a CRAM, which stores bases as a diff "
-                        f"against the reference it was aligned to, so it cannot be "
-                        f"decoded without that reference. Pass --reference "
-                        f"<genome.fasta> (the same one used for alignment)."
-                    )
-                if samtools is None:
-                    samtools = require_tool(
-                        "samtools",
-                        install_hint=(
-                            "Install samtools to use BAM/CRAM inputs:\n"
-                            "  conda install -c bioconda samtools\n"
-                            "Or convert the alignment to FASTA first:\n"
-                            "  samtools fasta input.bam | gzip > input.fasta.gz"
-                        ),
-                    )
-                with tempfile.NamedTemporaryFile(suffix=".fasta", delete=False) as tmp:
-                    tmp_fasta = Path(tmp.name)
-                tmp_fastas.append(tmp_fasta)
-                samtools_cmd = [samtools, "fasta", "-F", "0x900", "-N"]
-                if reference is not None:
-                    # NOT -T: in `samtools fasta` that is the copy-tags-to-header
-                    # taglist, and passing a path there silently produces a
-                    # tag-decorated FASTA with no reference supplied at all.
-                    samtools_cmd += ["--reference", str(reference)]
-                # Give the decode its own threads: on a 30x human CRAM this
-                # stage is minutes of wall clock, and it is pure setup before
-                # the index load can even begin.
-                if threads > 0:
-                    samtools_cmd += ["-@", str(threads)]
-                samtools_cmd.append(str(input_path))
-                logger.debug("converting %s to FASTA: %s -> %s", fmt, input_path, tmp_fasta)
-                result = subprocess.run(
-                    samtools_cmd,
-                    stdout=tmp_fasta.open("wb"),
-                    stderr=subprocess.PIPE if capture else None,
-                    check=False,
-                )
-                if result.returncode != 0:
-                    stderr = result.stderr.decode() if result.stderr else ""
-                    raise ExternalToolError(
-                        cmd=samtools_cmd,
-                        returncode=result.returncode,
-                        stderr=stderr,
-                    )
-                logger.info(
-                    "decoded %s to %.1f GB of FASTA at %s",
-                    input_path.name,
-                    tmp_fasta.stat().st_size / 1_000_000_000,
-                    tmp_fasta,
-                )
-                query_paths.append(tmp_fasta)
-            else:
-                query_paths.append(input_path)
 
         cmd: list[str] = [
             binary,
@@ -386,10 +449,6 @@ def run_hks_lookup_batch(
 
         logger.debug("running (batch, %d queries): %s", len(io_pairs), " ".join(cmd))
         _relay_hks_log(run_tool(cmd, capture=capture, oom_hint=HKS_OOM_HINT), "lookup-batch")
-    finally:
-        for p in tmp_fastas:
-            if p.exists():
-                p.unlink()
 
 
 def run_hks_smooth(

--- a/src/karyoscope/core/io/hks.py
+++ b/src/karyoscope/core/io/hks.py
@@ -232,6 +232,7 @@ def run_hks_lookup(
 def materialised_queries(
     input_paths: list[Path],
     *,
+    dest_dir: Path | None = None,
     reference: Path | None = None,
     threads: int = 0,
     query_names_sidecar: dict[Path, Path] | None = None,
@@ -253,7 +254,11 @@ def materialised_queries(
     time purely to recover them (another ~25 minutes and a full re-read on the
     largest sample).
 
-    Temp FASTAs are removed on exit, including on failure.
+    Temp FASTAs are created in ``dest_dir`` (pass the run's output
+    directory: the FASTA is input-sized, and the output's filesystem is the
+    one provisioned for data that scale — the system tempdir on cluster
+    nodes is often small or RAM-backed) and removed on exit, including on
+    failure. ``dest_dir=None`` falls back to the system tempdir.
     """
     tmp_fastas: list[Path] = []
     samtools: str | None = None
@@ -282,7 +287,7 @@ def materialised_queries(
                         "  samtools fasta input.bam | gzip > input.fasta.gz"
                     ),
                 )
-            with tempfile.NamedTemporaryFile(suffix=".fasta", delete=False) as tmp:
+            with tempfile.NamedTemporaryFile(suffix=".fasta", delete=False, dir=dest_dir) as tmp:
                 tmp_fasta = Path(tmp.name)
             tmp_fastas.append(tmp_fasta)
 
@@ -397,8 +402,8 @@ def run_hks_lookup_batch(
     1,996,531 distinct.
 
     Note these temp FASTAs are full-size — a 65x human WGS CRAM expands to
-    ~260 GB — and land in ``$TMPDIR``. Point that at node-local scratch, not at
-    a shared filesystem.
+    ~260 GB. The annotate backend materialises them next to the output via
+    ``materialised_queries``, so budget that space on the output filesystem.
     """
     if not io_pairs:
         return

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -410,9 +410,7 @@ def test_cram_input_declares_a_samtools_dependency() -> None:
     """The preflight resolves tools from the input format rather than assuming."""
     from karyoscope.core.annotate import _annotate_dependencies
 
-    needed = _annotate_dependencies(
-        index_type="hks", input_path=Path("s.cram"), bgzip=False
-    )
+    needed = _annotate_dependencies(index_type="hks", input_path=Path("s.cram"), bgzip=False)
     assert "samtools" in needed
     assert "hks" in needed
 

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -7,6 +7,7 @@ runs on the default unit-test pass.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import threading
@@ -493,6 +494,14 @@ def _hks_cmd_for(tmp_path: Path, monkeypatch, *, input_name: str, query_names):
 
     monkeypatch.setattr(ann_mod, "run_hks_lookup_batch", _fake_batch)
     monkeypatch.setattr(ann_mod, "run_hks_smooth", lambda **kw: None)
+
+    # The decode now happens in the caller (once for all feature sets), so it has
+    # to be stubbed too -- otherwise a .cram input tries to reach samtools.
+    @contextlib.contextmanager
+    def _identity(paths, **kwargs):
+        yield {p: p for p in paths}
+
+    monkeypatch.setattr(ann_mod, "materialised_queries", _identity)
 
     class _Manifest:
         class index:

--- a/tests/test_hks.py
+++ b/tests/test_hks.py
@@ -443,3 +443,75 @@ def test_conversion_states_flag_filter_and_mate_suffix_explicitly(
     cmd = _capture_samtools_cmd(tmp_path, monkeypatch, suffix=".bam", reference=None)
     assert cmd[cmd.index("-F") + 1] == "0x900"
     assert "-N" in cmd
+
+
+def test_materialised_queries_decodes_once_and_passes_through(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Already-seekable inputs cost nothing; alignments are decoded exactly once.
+
+    The decode used to live inside run_hks_lookup_batch, which the annotate
+    backend calls once per feature set -- so a six-set database decoded the same
+    CRAM six times, ~25 minutes each on a 56 GB input.
+    """
+    from karyoscope.core.io.hks import materialised_queries
+
+    calls: list[list[str]] = []
+
+    class _Result:
+        returncode = 0
+        stderr = b""
+
+    def _fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        stdout = kwargs.get("stdout")
+        if stdout is not None:
+            stdout.close()
+        return _Result()
+
+    monkeypatch.setattr("karyoscope.core.io.hks.require_tool", lambda *a, **kw: "samtools")
+    monkeypatch.setattr("karyoscope.core.io.hks.subprocess.run", _fake_run)
+
+    plain = tmp_path / "reads.fastq"
+    plain.write_text("")
+    bam = tmp_path / "aln.bam"
+    bam.write_bytes(b"")
+    with materialised_queries([plain, bam], threads=4) as resolved:
+        # a seekable input is handed straight back, unconverted
+        assert resolved[plain] == plain
+        # the alignment became a temp FASTA
+        assert resolved[bam] != bam
+        tmp_fasta = resolved[bam]
+    assert len(calls) == 1, "exactly one decode for one alignment"
+    assert not tmp_fasta.exists(), "temp FASTA removed on exit"
+
+
+def test_materialised_queries_tees_the_name_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The sidecar comes off the SAME decode, not a second pass over the input."""
+    from karyoscope.core.io.hks import materialised_queries
+
+    captured: dict[str, object] = {}
+
+    class _Result:
+        returncode = 0
+        stderr = b""
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _Result()
+
+    monkeypatch.setattr("karyoscope.core.io.hks.require_tool", lambda *a, **kw: "samtools")
+    monkeypatch.setattr("karyoscope.core.io.hks.subprocess.run", _fake_run)
+
+    bam = tmp_path / "aln.bam"
+    bam.write_bytes(b"")
+    sidecar = tmp_path / "names.txt.gz"
+    with materialised_queries([bam], threads=2, query_names_sidecar={bam: sidecar}):
+        pass
+    joined = " ".join(captured["cmd"])
+    # one process: samtools teed into the sidecar writer AND the FASTA
+    assert "tee" in joined
+    assert str(sidecar) in joined
+    assert "samtools fasta" in joined

--- a/tests/test_hks.py
+++ b/tests/test_hks.py
@@ -414,17 +414,13 @@ def test_cram_conversion_passes_the_reference(
     assert "-T" not in cmd
 
 
-def test_cram_without_reference_is_refused(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_cram_without_reference_is_refused(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A CRAM cannot be decoded without its reference, so the run stops early."""
     with pytest.raises(KaryoscopeError, match="CRAM"):
         _capture_samtools_cmd(tmp_path, monkeypatch, suffix=".cram", reference=None)
 
 
-def test_bam_conversion_needs_no_reference(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_bam_conversion_needs_no_reference(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """BAM is self-contained; no --reference is added and no error is raised."""
     cmd = _capture_samtools_cmd(tmp_path, monkeypatch, suffix=".bam", reference=None)
     assert "--reference" not in cmd


### PR DESCRIPTION
Stacked on #22 (`tcl/cram-input`), which is on #21 → #20 → #19 → #18. The diff here is one commit.

Two changes with one root cause: **the pipeline was re-decoding its input.**

## Decode once per run, not once per feature set

`samtools fasta` conversion lived inside `run_hks_lookup_batch`, which the annotate backend calls **once per feature set**. So a six-feature-set database decoded the same alignment six times. At ~25 min per decode on a 56 GB CRAM that is **~2.5 hours of pure redundancy**.

Extracted into a `materialised_queries` context manager the backend enters once and reuses across every set. Already-seekable inputs pass straight through, so FASTA/FASTQ behaviour is unchanged, and single-feature-set runs (which is what surfaced this) are unaffected in wall clock.

## `--query-names-sidecar`

Read-level output is identified by ordinal rank, because names OOM the lookup (#22). Recovering the rank → name mapping afterwards meant decoding the whole alignment a **second** time — another ~25 min and a full re-read of the input.

The sidecar is now teed off the decode `annotate` already performs, via `tee(1)` so the hundreds-of-GB FASTA branch never passes through Python. It costs essentially nothing.

Anything that joins rank-identified output back to reads needs this. Pairing paired-end mates is the motivating case: mates are not adjacent in a coordinate-sorted CRAM, so the names are the only way to group a fragment.

## Verification

- 829 tests pass, ruff clean.
- End to end on a real CRAM: the sidecar is **byte-identical** to `samtools fasta -F 0x900 -N | grep '^>'` — 199,746 records, same order.
- New tests assert exactly one decode for one alignment, pass-through for seekable inputs, temp cleanup on exit, and that the sidecar is teed off the same process rather than a second pass.

## Notes for review

- The sidecar is named from the **input stem**, not the db-qualified prefix, because the mapping is a property of the input rather than the database — otherwise annotating one CRAM against two databases writes two identical files.
- I did **not** touch hks. The larger win here would be streaming the FASTA into `hks lookup` instead of materialising it — that round trip is ~960 GB of I/O per sample on our data, and `open_fastx` only needs `BufRead`, not `Seek` (seekability is required solely by `load_seq_names`, the names pass we deliberately skip). But `hks` is a compiled binary that both conda envs symlink to a single shared build tree, so rebuilding it in place would swap the binary out from under running jobs. That needs its own worktree, a private `target/`, and `$KARYOSCOPE_HKS` to point at it — and HKS's `origin` is upstream `jnalanko/HKS` with the lab's work on a `fork` remote, so it wouldn't follow this PR flow. Flagging rather than doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)