### PR TITLE
perf(cli): import subcommands on demand, and check dependencies explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Arabidopsis) with notes on what each shows, for comparing your own output
   against.
 
+### Changed
+- **CLI subcommands are imported on demand, cutting startup from ~290 ms to
+  ~70 ms.** Registering the eleven subcommands meant importing all eleven
+  command modules, and one of them (`download`) pulls in `requests` — about
+  190 ms of that 290 ms, paid by every invocation, for an HTTP library most
+  commands never touch. `karyoscope --help` still imports everything, because
+  Click asks each command for its short help to build the listing; every other
+  path now imports only the command being run.
+
+  The broken-install check that `_entry` performs used to be a side-effect of
+  those eager imports, so it is now explicit: the declared dependencies are
+  verified with `importlib.util.find_spec`, which locates a module without
+  executing it (~8 ms for the full set). The check is consequently *stricter*
+  than before — it covers every declared dependency, where the old form caught
+  only what the eager imports happened to touch — and the list is read from
+  installed metadata so it cannot drift from `pyproject.toml`. Since
+  `find_spec` proves presence but not importability, the CLI run is also
+  wrapped, so a dependency that is installed yet unimportable (a truncated
+  install, or `cairosvg` built against the wrong ABI) still reports readably
+  instead of as a traceback.
+
+
 ### Fixed
 - **Karyotype outlines now follow the theme, and the legend lists only what is
   visible.** The sequence-outline guard read `if background_color == "white"`,

--- a/src/karyoscope/_entry.py
+++ b/src/karyoscope/_entry.py
@@ -1,40 +1,113 @@
 """Console-script entry point, deliberately free of heavy imports.
 
-``karyoscope.cli`` eagerly imports every command module so it can register
-the subcommands, and those pull in the package's hard dependencies
-(``drawsvg``, ``cairosvg``, ``requests``, ...). When one of them is
-missing — a partial install, or a shell using a different interpreter than
-the one KaryoScope was installed into — the failure happens *during*
-``from karyoscope.cli import main``. That import lives in the console
-script pip generates:
+When one of KaryoScope's dependencies is missing — a partial install, or a
+shell using a different interpreter than the one KaryoScope was installed
+into — the failure would otherwise surface as a raw ``ModuleNotFoundError``
+traceback from the console script pip generates:
 
     from karyoscope.cli import main
     sys.exit(main())
 
-so it is outside any code KaryoScope controls. The result is a raw
-``ModuleNotFoundError`` traceback from **every** command, including
-``karyoscope --help`` and ``karyoscope version`` — precisely the two a
-user would reach for to diagnose it. The dependency preflight in
-:mod:`karyoscope.preflight` cannot help either: it runs inside a command,
-long after import has already failed.
+That import is outside any code KaryoScope controls, so the traceback comes
+back from **every** command, including ``karyoscope --help`` and
+``karyoscope version`` — precisely the two a user would reach for to diagnose
+it. The dependency preflight in :mod:`karyoscope.preflight` cannot help
+either: it runs inside a command, long after import has already failed.
 
-Routing the entry point through this module puts a ``try`` around that
-import, so a broken install reports itself in a few readable lines. The
-message names the interpreter in use, because "wrong Python" is the most
-common cause and the least obvious from the traceback alone.
+Routing the entry point through this module makes a broken install report
+itself in a few readable lines. The message names the interpreter in use,
+because "wrong Python" is the most common cause and the least obvious from
+the traceback alone.
+
+**Why the check is explicit.** It used to be inferred: ``karyoscope.cli``
+imported every command module eagerly, those pulled in the hard dependencies,
+and wrapping that one import therefore caught a missing one. Subcommands are
+now imported on demand — registering them cost ~190 ms of startup for an HTTP
+library most commands never touch — so that side-effect is gone, and a missing
+dependency would otherwise not surface until mid-dispatch, as exactly the bare
+traceback this module exists to prevent. The dependencies are now checked
+directly, which is also stricter: the old form caught only what the eager
+imports happened to touch, while the list below is exact.
 """
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 
+#: Dependencies to verify when the installed metadata cannot be read (e.g. a
+#: source checkout that was never pip-installed). Keep in step with
+#: ``pyproject.toml``; the metadata path below is preferred precisely because
+#: it cannot drift.
+_FALLBACK_REQUIREMENTS: tuple[str, ...] = (
+    "click",
+    "drawsvg",
+    "cairosvg",
+    "requests",
+    "yaml",
+    "tqdm",
+    "jsonschema",
+)
 
-def _report_broken_install(exc: ImportError) -> None:
-    """Explain an import failure that happened before any command could run."""
-    missing = getattr(exc, "name", None) or "a required package"
+#: Distribution name -> module name, for the cases where they differ.
+_MODULE_NAMES: dict[str, str] = {"pyyaml": "yaml"}
+
+
+def _required_modules() -> list[str]:
+    """Module names for our declared runtime dependencies.
+
+    Read from installed metadata so this cannot drift from ``pyproject.toml``.
+    Requirements guarded by an ``extra`` marker are skipped: a missing optional
+    extra is not a broken install, and reporting it as one would send the user
+    chasing a package they never asked for.
+    """
+    try:
+        from importlib.metadata import requires
+
+        declared = requires("karyoscope")
+    except Exception:
+        declared = None
+    if not declared:
+        return list(_FALLBACK_REQUIREMENTS)
+
+    modules: list[str] = []
+    for raw in declared:
+        if "extra ==" in raw:
+            continue
+        # "requests>=2.31" / "pyyaml (>=6.0)" / "tqdm" -> the bare name.
+        name = raw.split(";")[0].strip()
+        for sep in ("[", "(", ">", "<", "=", "!", "~", " "):
+            name = name.split(sep)[0]
+        name = name.strip().lower()
+        if name:
+            modules.append(_MODULE_NAMES.get(name, name.replace("-", "_")))
+    return modules or list(_FALLBACK_REQUIREMENTS)
+
+
+def _missing_dependencies() -> list[str]:
+    """Declared dependencies that are not installed.
+
+    Uses :func:`importlib.util.find_spec`, which locates a module without
+    executing it — the point of the exercise, since importing them is the cost
+    being avoided. Measured at ~8 ms for the full set, against ~190 ms to
+    import ``requests`` alone.
+    """
+    missing: list[str] = []
+    for module in _required_modules():
+        try:
+            if importlib.util.find_spec(module) is None:
+                missing.append(module)
+        except (ImportError, ValueError):
+            # A parent package that is itself broken -- treat as missing.
+            missing.append(module)
+    return missing
+
+
+def _report_broken_install(missing: str, detail: str) -> None:
+    """Explain a dependency failure that happened before any command could run."""
     print(
         f"Error: KaryoScope's installation is incomplete — could not import "
-        f"{missing!r}.\n"
+        f"{missing}.\n"
         f"\n"
         f"  KaryoScope itself is importable, so the package is present but at "
         f"least one\n"
@@ -49,16 +122,30 @@ def _report_broken_install(exc: ImportError) -> None:
         f"    pip install karyoscope\n"
         f"    conda activate karyoscope # if you meant to use the env\n"
         f"\n"
-        f"  Original error: {exc}",
+        f"  Original error: {detail}",
         file=sys.stderr,
     )
 
 
 def main() -> int:
-    """Import and run the CLI, reporting a broken install readably."""
+    """Run the CLI, reporting a broken install readably."""
+    missing = _missing_dependencies()
+    if missing:
+        names = ", ".join(repr(m) for m in missing)
+        _report_broken_install(names, f"missing module(s): {names}")
+        return 1
+
+    # find_spec proves a module is present, not that it imports cleanly: a
+    # truncated install, or a compiled dependency built against the wrong ABI
+    # (cairosvg's C bindings being the realistic case), is found and then
+    # fails. Both the CLI import and the run are wrapped, because subcommands
+    # are now imported during dispatch rather than up front -- so an import
+    # failure can surface after `run()` has already been entered.
     try:
         from karyoscope.cli import main as run
+
+        return run()
     except ImportError as exc:
-        _report_broken_install(exc)
+        name = getattr(exc, "name", None)
+        _report_broken_install(repr(name) if name else "a required package", str(exc))
         return 1
-    return run()

--- a/src/karyoscope/cli.py
+++ b/src/karyoscope/cli.py
@@ -26,6 +26,7 @@ like ``--quiet`` on ``download``.
 
 from __future__ import annotations
 
+import importlib
 import logging
 import sys
 
@@ -33,19 +34,32 @@ import click
 
 from karyoscope import diskspace
 from karyoscope._version import __version__
-from karyoscope.commands import (
-    annotate,
-    bin_cmd,
-    build,
-    centromeres,
-    download,
-    info,
-    karyotype,
-    register,
-    remap_bed,
-    scaffold,
-    version,
-)
+
+#: Subcommand name -> ``module:attribute`` holding its ``click.Command``.
+#:
+#: Imported on demand rather than up front. Registering the subcommands used to
+#: mean importing all eleven command modules, and one of them (``download``)
+#: pulls in ``requests`` -- ~190 ms of the ~290 ms it took to import this
+#: module, paid by every invocation including ``karyoscope --version`` and
+#: every ``annotate`` run, for an HTTP library they never touch.
+#:
+#: ``--help`` still imports everything, because Click asks each command for its
+#: short help to build the listing. That is the one path where the old cost
+#: remains; it is not a regression, and avoiding it would mean duplicating each
+#: command's summary here, where it could drift from the docstring it mirrors.
+_LAZY_COMMANDS: dict[str, str] = {
+    "download": "karyoscope.commands.download:cmd",
+    "register": "karyoscope.commands.register:cmd",
+    "build": "karyoscope.commands.build:cmd",
+    "annotate": "karyoscope.commands.annotate:cmd",
+    "scaffold": "karyoscope.commands.scaffold:cmd",
+    "remap-bed": "karyoscope.commands.remap_bed:cmd",
+    "bin": "karyoscope.commands.bin_cmd:cmd",
+    "centromeres": "karyoscope.commands.centromeres:cmd",
+    "karyotype": "karyoscope.commands.karyotype:cmd",
+    "info": "karyoscope.commands.info:cmd",
+    "version": "karyoscope.commands.version:cmd",
+}
 
 CONTEXT_SETTINGS = {
     "help_option_names": ["-h", "--help"],
@@ -67,6 +81,22 @@ class _KaryoscopeGroup(click.Group):
     Catching it here covers every subcommand, including ones that don't
     (yet) run their own space check.
     """
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        """Every subcommand, without importing any of them."""
+        return sorted({*super().list_commands(ctx), *_LAZY_COMMANDS})
+
+    def get_command(self, ctx: click.Context, name: str) -> click.Command | None:
+        """Resolve one subcommand, importing only its module."""
+        cmd = super().get_command(ctx, name)
+        if cmd is not None:
+            return cmd
+        target = _LAZY_COMMANDS.get(name)
+        if target is None:
+            return None
+        module_name, _, attribute = target.partition(":")
+        module = importlib.import_module(module_name)
+        return getattr(module, attribute)
 
     def invoke(self, ctx: click.Context) -> object:
         try:
@@ -165,17 +195,6 @@ def main(ctx: click.Context, verbose: int, quiet: bool) -> None:
 
 
 # Register subcommands. The order here determines the order in `--help`.
-main.add_command(download.cmd, name="download")
-main.add_command(register.cmd, name="register")
-main.add_command(build.cmd, name="build")
-main.add_command(annotate.cmd, name="annotate")
-main.add_command(scaffold.cmd, name="scaffold")
-main.add_command(remap_bed.cmd, name="remap-bed")
-main.add_command(bin_cmd.cmd, name="bin")
-main.add_command(centromeres.cmd, name="centromeres")
-main.add_command(karyotype.cmd, name="karyotype")
-main.add_command(info.cmd, name="info")
-main.add_command(version.cmd, name="version")
 
 
 if __name__ == "__main__":

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -4,12 +4,19 @@ Its whole job is the failure path: a dependency missing at *import* time
 cannot be caught by anything inside ``karyoscope.cli``, because the
 generated console script imports that module directly. Routing through
 ``_entry`` is what makes the failure reportable at all.
+
+The check used to be inferred from a side-effect -- ``karyoscope.cli``
+imported every command module, so a missing dependency blew up during that
+import. Subcommands are now lazy, so the dependencies are checked directly
+instead, and these tests exercise that: both the up-front check and the
+backstop for a dependency that is present but does not import.
 """
 
 from __future__ import annotations
 
-import builtins
+import importlib.util
 import sys
+import types
 
 import pytest
 
@@ -17,82 +24,130 @@ from karyoscope import _entry
 
 
 @pytest.fixture
-def block_import(monkeypatch: pytest.MonkeyPatch):
-    """Make a named module unimportable on the next ``karyoscope.cli`` import.
+def hide_module(monkeypatch: pytest.MonkeyPatch):
+    """Make one module invisible to ``find_spec``, as an uninstalled one is."""
 
-    Every ``karyoscope.*`` module has to leave ``sys.modules``, not just
-    ``karyoscope.cli``. ``drawsvg`` is imported by
-    ``karyoscope.core.karyotype``, several levels down the chain; if that
-    module is still cached -- which it is as soon as any other test in the
-    suite has touched it -- re-importing ``karyoscope.cli`` is served from
-    cache and never re-executes the ``import drawsvg`` line at all. An
-    earlier version of this fixture purged only ``karyoscope.cli`` and so
-    passed in isolation but silently tested nothing in a full run.
-    """
-
-    def _block(name: str) -> None:
-        real = builtins.__import__
+    def _hide(name: str) -> None:
+        real = importlib.util.find_spec
 
         def fake(mod: str, *args: object, **kwargs: object):
-            if mod == name or mod.startswith(name + "."):
-                raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+            if mod == name:
+                return None
             return real(mod, *args, **kwargs)
 
-        doomed = [
-            m for m in sys.modules if m == "karyoscope" or m.startswith(("karyoscope.", name))
-        ]
-        for mod in doomed:
-            monkeypatch.delitem(sys.modules, mod, raising=False)
-        monkeypatch.setattr(builtins, "__import__", fake)
+        monkeypatch.setattr(importlib.util, "find_spec", fake)
 
-    return _block
+    return _hide
 
 
-def test_missing_dependency_reports_cleanly_and_exits_nonzero(
-    block_import, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """A broken install must not surface as a traceback.
+class TestMissingDependency:
+    def test_reports_cleanly_and_exits_nonzero(
+        self, hide_module, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A broken install must not surface as a traceback.
 
-    Before this, every command -- including --help and version, the two a
-    user would reach for to diagnose it -- raised a bare
-    ModuleNotFoundError out of the console script.
-    """
-    block_import("drawsvg")
-    assert _entry.main() == 1
-    err = capsys.readouterr().err
-    assert "installation is incomplete" in err
-    assert "drawsvg" in err
-    assert "Traceback" not in err
+        Before this, every command -- including --help and version, the two a
+        user would reach for to diagnose it -- raised a bare
+        ModuleNotFoundError out of the console script.
+        """
+        hide_module("drawsvg")
+        assert _entry.main() == 1
+        err = capsys.readouterr().err
+        assert "installation is incomplete" in err
+        assert "drawsvg" in err
+        assert "Traceback" not in err
+
+    def test_message_names_the_interpreter(
+        self, hide_module, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """ "Wrong Python" is the most common cause and the least obvious one."""
+        hide_module("drawsvg")
+        _entry.main()
+        assert sys.executable in capsys.readouterr().err
+
+    def test_message_suggests_a_fix(self, hide_module, capsys: pytest.CaptureFixture[str]) -> None:
+        hide_module("drawsvg")
+        _entry.main()
+        assert "pip install" in capsys.readouterr().err
+
+    def test_does_not_reach_the_cli(self, hide_module, monkeypatch) -> None:
+        """The point of checking up front is to fail before dispatch."""
+        called: list[bool] = []
+        stub = types.ModuleType("karyoscope.cli")
+        stub.main = lambda: called.append(True) or 0  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "karyoscope.cli", stub)
+        hide_module("cairosvg")
+        assert _entry.main() == 1
+        assert called == []
 
 
-def test_message_names_the_interpreter(block_import, capsys: pytest.CaptureFixture[str]) -> None:
-    """ "Wrong Python" is the most common cause and the least obvious one."""
-    block_import("drawsvg")
-    _entry.main()
-    assert sys.executable in capsys.readouterr().err
+class TestRequiredModules:
+    """The dependency list is read from metadata so it cannot drift."""
+
+    def test_covers_every_declared_dependency(self) -> None:
+        mods = set(_entry._required_modules())
+        # Every hard dependency in pyproject.toml, by module name.
+        assert {"click", "drawsvg", "cairosvg", "requests", "yaml", "tqdm"} <= mods
+
+    def test_maps_distribution_names_to_module_names(self) -> None:
+        # Installed as "pyyaml", imported as "yaml" -- checking the wrong one
+        # would report a healthy install as broken.
+        mods = _entry._required_modules()
+        assert "yaml" in mods
+        assert "pyyaml" not in mods
+
+    def test_falls_back_when_metadata_is_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A source checkout that was never pip-installed still gets checked."""
+        import importlib.metadata
+
+        def boom(_name: str) -> None:
+            raise importlib.metadata.PackageNotFoundError("karyoscope")
+
+        monkeypatch.setattr(importlib.metadata, "requires", boom)
+        assert set(_entry._required_modules()) == set(_entry._FALLBACK_REQUIREMENTS)
+
+    def test_skips_optional_extras(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A missing dev extra is not a broken install."""
+        import importlib.metadata
+
+        monkeypatch.setattr(
+            importlib.metadata,
+            "requires",
+            lambda _n: ["click>=8.1", 'pytest>=8; extra == "dev"'],
+        )
+        assert _entry._required_modules() == ["click"]
 
 
-def test_message_suggests_a_fix(block_import, capsys: pytest.CaptureFixture[str]) -> None:
-    block_import("drawsvg")
-    _entry.main()
-    assert "pip install" in capsys.readouterr().err
+class TestImportBackstop:
+    """find_spec proves a module is present, not that it imports."""
 
+    def test_installed_but_unimportable_still_reports(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The realistic case: a compiled dependency built against the wrong
+        # ABI. find_spec finds it; importing raises.
+        stub = types.ModuleType("karyoscope.cli")
 
-def test_report_uses_the_exception_name_when_present(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    _entry._report_broken_install(ModuleNotFoundError("boom", name="cairosvg"))
-    assert "'cairosvg'" in capsys.readouterr().err
+        def explode() -> int:
+            raise ImportError("libcairo.so.2: cannot open shared object file", name="cairosvg")
 
+        stub.main = explode  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "karyoscope.cli", stub)
 
-def test_report_degrades_gracefully_without_a_name(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """A bare ImportError carries no .name; still say something useful."""
-    _entry._report_broken_install(ImportError("something went wrong"))
-    err = capsys.readouterr().err
-    assert "a required package" in err
-    assert "something went wrong" in err
+        assert _entry.main() == 1
+        err = capsys.readouterr().err
+        assert "installation is incomplete" in err
+        assert "cairosvg" in err
+        assert "Traceback" not in err
+
+    def test_report_degrades_gracefully_without_a_name(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A bare ImportError carries no .name; still say something useful."""
+        _entry._report_broken_install("a required package", "something went wrong")
+        err = capsys.readouterr().err
+        assert "a required package" in err
+        assert "something went wrong" in err
 
 
 def test_healthy_install_delegates_to_the_cli(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -103,8 +158,6 @@ def test_healthy_install_delegates_to_the_cli(monkeypatch: pytest.MonkeyPatch) -
     call time, so stubbing there is what actually intercepts it regardless
     of what else in the suite has imported.
     """
-    import types
-
     called: list[bool] = []
     stub = types.ModuleType("karyoscope.cli")
     stub.main = lambda: called.append(True) or 0  # type: ignore[attr-defined]


### PR DESCRIPTION
Cuts CLI startup from **~290 ms to ~70 ms**, without weakening the
broken-install check — which a naive version of this change would have
silently defeated.

## The cost

`cli.py` imported all eleven command modules to register them. One
(`download`) pulls in `requests`:

```
karyoscope.cli                    275.9 ms
  karyoscope.commands.download    121.6 ms
    karyoscope.download           120.9 ms
      karyoscope._fetch           116.6 ms
        requests                  116.3 ms
```

So `karyoscope --version`, `karyoscope info`, and every `annotate` run paid
~190 ms for an HTTP library they never touch.

Subcommands now resolve through a name → `"module:attribute"` map, importing
only the command being run.

`--help` still imports everything, because Click asks each command for its
short help to build the listing. That is the one path where the old cost
remains — not a regression, and avoiding it would mean duplicating every
command's summary in the map where it could drift from the docstring it
mirrors.

## The part that needed care

`_entry`'s broken-install check was **inferred** from those eager imports: it
wrapped `from karyoscope.cli import main`, and the heavy dependencies came
along for the ride. Note the `try` covered only the import, not the run:

```python
try:
    from karyoscope.cli import main as run
except ImportError as exc:
    _report_broken_install(exc)
    return 1
return run()        # <-- outside the try
```

With lazy subcommands nothing heavy is imported there, so a missing dependency
would surface mid-dispatch inside `run()`, uncaught — exactly the bare
`ModuleNotFoundError` that module exists to prevent.

The check is therefore now explicit, and stronger:

- verified with `importlib.util.find_spec`, which **locates a module without
  executing it** — ~8 ms for the full set, against ~190 ms to import
  `requests` alone;
- the list is read from **installed metadata**, so it cannot drift from
  `pyproject.toml` (with a fallback for a checkout never pip-installed);
  requirements behind an `extra` marker are skipped, since a missing dev extra
  is not a broken install;
- it covers **every** declared dependency, where the old form caught only what
  the eager imports happened to reach;
- **the run is wrapped too**, because `find_spec` proves presence, not
  importability — a truncated install, or `cairosvg` built against the wrong
  ABI, is found and then fails on import.

## Verified

```
import karyoscope.cli:            290 ms -> 69-98 ms
requests imported at CLI load:    False
subcommands listed:               all 11
missing dependency:               exit 1, names the module, names the
                                  interpreter, suggests a fix, no traceback
dependency list from metadata:    cairosvg, click, drawsvg, jsonschema,
                                  yaml, requests, tqdm
```

`test_entry.py` is reworked onto the new mechanism and gains coverage the old
one could not express: metadata-vs-fallback resolution, `pyyaml` → `yaml` name
mapping, extras being skipped, that the up-front check fails *before*
dispatch, and the installed-but-unimportable backstop. 798 pass, ruff clean.