### PR TITLE
docs(build): put the features.tsv bullet back in Defaults

### DIFF
--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -63,6 +63,7 @@ Bases that no feature annotates are, by default, filled with a **background** le
 
 - No hierarchy for a set → a flat star: every leaf is a child of the root, `categorized`.
 - No colours → an auto-generated distinct palette per leaf; grouping/root nodes are `#B0C4DE`, background is `#808080`. Provide your own with `--colors NAME=file` (`feature<tab>color`, or the full `feature_set<tab>feature<tab>color`).
+- `features.tsv` is **not** produced: the HKS backend reads label names from the index and never uses it.
 
 ### Grouping the legend
 
@@ -92,7 +93,6 @@ must share a colour** — otherwise there is no well-defined swatch and the figu
 would silently misrepresent the rest. `build` checks this and fails if a group
 spans two colours. The reverse is fine: two groups may share a colour (two
 labels, one swatch — legible, just redundant).
-- `features.tsv` is **not** produced: the HKS backend reads label names from the index and never uses it.
 
 ## Options
 


### PR DESCRIPTION
Follow-up to #25. The `Grouping the legend` subsection I added there was inserted between the second and third bullets of the **Defaults** list, orphaning the third — it renders as a stray list item dangling off the end of the legend prose, several paragraphs from the list it belongs to.

Docs only; moves one line back where it was.

```
### Defaults
- No hierarchy for a set → ...
- No colours → ...
- `features.tsv` is **not** produced: ...   <- was stranded below

### Grouping the legend
...
```