### PR TITLE
feat(prep-bed): convert source annotations into feature-set BEDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rows rather than joined blocks) and would silently build a different feature
   set — the real source is UCSC's `chm13v2.0_rmsk.bb` — and the Col-CEN gene
   annotation is published in two attribute syntaxes that were not interchangeable
-  until this release. The Arabidopsis recipe has been run end to end from its own
-  URLs: all four BEDs match their published checksums and all five index files
-  come out bit-identical to the database in use.
+  until this release.
+
+  Both recipes reproduce their databases exactly. The Arabidopsis one has been
+  run end to end from its own URLs: all four BEDs match their published
+  checksums and all five index files come out bit-identical to the database in
+  use. For CHM13 all four BEDs are byte-identical to the files the shipped
+  database was built from, and applying the published repeat priority order via
+  `flatten: true` reproduces its flattened `repeat` set to the row —
+  4,423,197 rows, identical. The priority order recorded in the original build
+  script is *not* the one that was used and does not reproduce it; the correct
+  order ships as `docs/recipes/files/chm13v2_repeat.priority.txt`.
 
 - **`karyoscope prep-bed`, converting source annotations into feature-set BEDs.**
   `build` starts from a final labelled BED, and producing that BED was the last

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   against.
 
 ### Changed
+- **`build` documentation restructured, and the variable-k description
+  corrected.** The "mode A / mode B" naming is gone: BED plus a genome is
+  described as the input, and the per-feature-FASTA form now sits in the
+  build-spec section where it is actually usable. Hierarchy, priorities and
+  colours each have a reference section that the options table links to, and
+  overlap resolution is shown worked through — a hierarchy, a BED, and the label
+  a shared k-mer ends up with, with and without priorities.
+
+  Two claims were wrong. Priorities are applied when the index is built, not at
+  query time. And `kmer.max_size` read as a range one may query within: on a
+  fixed-k index it equals `kmer.size`, and that single length is the only one
+  `annotate` accepts. Since HKS rejects priorities together with variable-k, a
+  priority-resolved database is necessarily fixed-k — now stated in `build`,
+  `annotate` and `info`.
+
 - **CLI subcommands are imported on demand, cutting startup from ~290 ms to
   ~70 ms.** Registering the eleven subcommands meant importing all eleven
   command modules, and one of them (`download`) pulls in `requests` — about

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`karyoscope prep-bed`, converting source annotations into feature-set BEDs.**
+  `build` starts from a final labelled BED, and producing that BED was the last
+  step with no command behind it — every dataset needed its own script. There is
+  now one subcommand per *source format*: `repeatmasker` (native `.out` or the
+  UCSC BED repackaging), `edta`, `gff-gene` (GFF3 or GTF), `cytoband` (UCSC
+  golden-path or `cytoBandMapped`), `fai`, and `satellite`. Keying on the format
+  rather than on the output name is what keeps the options honest — RepeatMasker
+  output and an EDTA GFF3 both yield a `repeat` set but share no parsing, so a
+  single command would have to carry flags that are valid for only some inputs.
+
+  Each writes its BED and hierarchy and prints the matching `feature_sets:`
+  stanza on **stdout**, with progress and warnings on stderr, so the stanza can
+  be appended straight to a build spec. Optional `--colors` reproduces the
+  reference palettes and fills in `legend_group`, so a cytoband set arrives with
+  its legend already collapsed to nine stain rows rather than needing the
+  database edited by hand afterwards.
+
+  `prep-bed` deliberately does not gap-fill, flatten overlaps, or drop
+  sequences: `build` already owns `background:`, `flatten:` and `exclude:`, and
+  duplicating them would mean two places to get them wrong. Sequences a set does
+  not cover are reported for the spec's `exclude:` rather than given a
+  placeholder `exclude` *label*, which older hand-written sets used — a label
+  claims the sequence for the feature set instead of leaving it uncovered.
+  The one converter that tiles is `satellite`, because telling `p_arm` from
+  `q_arm` needs the centromere position and a gap-fill has only one label.
+
+  Verified by re-deriving the reference feature sets from their original inputs:
+  the `edta`, `fai`, `satellite`, `cytoband` and `gff-gene` outputs are
+  byte-identical to the files the bespoke scripts produced, including the CHM13
+  human gene set (612,908 records) and the whole CHM13 RepeatMasker set
+  (4,636,653 records).
+
+### Fixed
+- **`prep-bed gff-gene` derives introns per transcript, not per chromosome.**
+  The *A. thaliana* Col-CEN `gene.bed` used to build that database labels 8,325
+  spans `intron` that lie inside no gene at all — gaps between neighbouring
+  genes, which are intergenic. The effect is not marginal: it reports 42.0% of
+  the genome as intron against 20.6% actual, and 21.6% intergenic against 43.0%.
+  Introns are now derived from each transcript's own consecutive exons, and
+  where transcripts disagree the more specific label wins (`exon` > `intron` >
+  `intergenic`) so alternative splicing never double-labels a base. The human
+  CHM13 gene set is unaffected and reproduces byte-identically; the Arabidopsis
+  database needs regenerating.
 - **`colors.tsv` gains an optional 4th column, `legend_group`, and `build`
   carries it through.** A feature set with hundreds of leaves in a handful of
   colours produced a legend that dwarfed the figure — and worse, silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (4,636,653 records).
 
 ### Fixed
+- **`prep-bed repeatmasker` no longer folds unmappable classes into `Unknown`.**
+  `Unknown` is a real RepeatMasker class — 22,523 records in CHM13 v2 — meaning
+  "RepeatMasker could not classify this element". Using it as the fallback for a
+  class *we* have no leaf for conflated two different claims: one where the
+  annotation is uncertain, one where the annotation is confident and we are the
+  ones unable to place it. Such rows now get their own `other_repeat` leaf, which
+  joins the hierarchy and palette only when something actually lands on it — so a
+  file whose classes are all recognised, including the CHM13 v2 input, produces
+  byte-identical output to before. They are still not dropped: that would leave
+  their bases to the `nonrepeat` gap-fill and assert the opposite of what the
+  annotation says.
+
 - **`prep-bed gff-gene` derives introns per transcript, not per chromosome.**
   The *A. thaliana* Col-CEN `gene.bed` used to build that database labels 8,325
   spans `intron` that lie inside no gene at all — gaps between neighbouring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`docs/recipes/` — reproducible recipes for the shipped databases.** One page
+  each for `HKS_human_CHM13_v2` (`chromosome`, `region`, `repeat`, `gene`) and
+  `HKS_arabidopsis_ColCEN` (all four sets), giving the exact download URL for
+  every input, a SHA-256 for the file and for its decompressed content, the
+  `prep-bed` command that converts it, a checksum for the resulting BED, and the
+  build spec that assembles them.
+
+  Every URL was verified by downloading it and comparing checksums, which turned
+  up two traps worth the exercise: the RepeatMasker URL recorded in the original
+  build script serves a *different representation* of the same run (per-fragment
+  rows rather than joined blocks) and would silently build a different feature
+  set — the real source is UCSC's `chm13v2.0_rmsk.bb` — and the Col-CEN gene
+  annotation is published in two attribute syntaxes that were not interchangeable
+  until this release. The Arabidopsis recipe has been run end to end from its own
+  URLs: all four BEDs match their published checksums and all five index files
+  come out bit-identical to the database in use.
+
 - **`karyoscope prep-bed`, converting source annotations into feature-set BEDs.**
   `build` starts from a final labelled BED, and producing that BED was the last
   step with no command behind it — every dataset needed its own script. There is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,86 +15,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `prep-bed` command that converts it, a checksum for the resulting BED, and the
   build spec that assembles them.
 
-  Every URL was verified by downloading it and comparing checksums, which turned
-  up two traps worth the exercise: the RepeatMasker URL recorded in the original
-  build script serves a *different representation* of the same run (per-fragment
-  rows rather than joined blocks) and would silently build a different feature
-  set — the real source is UCSC's `chm13v2.0_rmsk.bb` — and the Col-CEN gene
-  annotation is published in two attribute syntaxes that were not interchangeable
-  until this release.
+  Inputs that cannot be derived ship alongside in `docs/recipes/files/`: the
+  curated chromosome groupings, the repeat priority order, and the RefSeq
+  accession map.
 
-  Both recipes reproduce their databases exactly. The Arabidopsis one has been
-  run end to end from its own URLs: all four BEDs match their published
-  checksums and all five index files come out bit-identical to the database in
-  use. For CHM13 all four BEDs are byte-identical to the files the shipped
-  database was built from, and applying the published repeat priority order via
-  `flatten: true` reproduces its flattened `repeat` set to the row —
-  4,423,197 rows, identical. The priority order recorded in the original build
-  script is *not* the one that was used and does not reproduce it; the correct
-  order ships as `docs/recipes/files/chm13v2_repeat.priority.txt`.
+  Both recipes reproduce their databases. The Arabidopsis one has been run end
+  to end from its published URLs and produces bit-identical index files; the
+  CHM13 feature-set BEDs are byte-identical to those the shipped database was
+  built from.
 
 - **`karyoscope prep-bed`, converting source annotations into feature-set BEDs.**
-  `build` starts from a final labelled BED, and producing that BED was the last
-  step with no command behind it — every dataset needed its own script. There is
-  now one subcommand per *source format*: `repeatmasker` (native `.out` or the
-  UCSC BED repackaging), `edta`, `gff-gene` (GFF3 or GTF), `cytoband` (UCSC
-  golden-path or `cytoBandMapped`), `fai`, and `satellite`. Keying on the format
-  rather than on the output name is what keeps the options honest — RepeatMasker
-  output and an EDTA GFF3 both yield a `repeat` set but share no parsing, so a
-  single command would have to carry flags that are valid for only some inputs.
+  `build` starts from a final labelled BED; producing that BED previously needed
+  a script per dataset. There is now one subcommand per *source format*:
+  `repeatmasker` (native `.out` or the UCSC BED repackaging), `edta`,
+  `gff-gene` (GFF3 or GTF), `cytoband` (UCSC golden-path or `cytoBandMapped`),
+  `censat`, `fai`, and `satellite`. Formats are the unit rather than feature-set
+  names because unrelated formats yield the same kind of set: RepeatMasker
+  output and an EDTA GFF3 both produce a `repeat` set but share no parsing.
 
   Each writes its BED and hierarchy and prints the matching `feature_sets:`
   stanza on **stdout**, with progress and warnings on stderr, so the stanza can
-  be appended straight to a build spec. Optional `--colors` reproduces the
-  reference palettes and fills in `legend_group`, so a cytoband set arrives with
-  its legend already collapsed to nine stain rows rather than needing the
-  database edited by hand afterwards.
+  be appended straight to a build spec. Optional `--colors` writes the reference
+  palette with `legend_group` filled in, so a cytoband set arrives with its
+  legend already collapsed to nine stain rows.
 
-  `prep-bed` deliberately does not gap-fill, flatten overlaps, or drop
-  sequences: `build` already owns `background:`, `flatten:` and `exclude:`, and
-  duplicating them would mean two places to get them wrong. Sequences a set does
-  not cover are reported for the spec's `exclude:` rather than given a
-  placeholder `exclude` *label*, which older hand-written sets used — a label
-  claims the sequence for the feature set instead of leaving it uncovered.
-  The one converter that tiles is `satellite`, because telling `p_arm` from
-  `q_arm` needs the centromere position and a gap-fill has only one label.
+  `prep-bed` does not gap-fill, flatten overlaps, or drop sequences: `build`
+  owns `background:`, `flatten:` and `exclude:`. Sequences a set does not cover
+  are reported for the spec's `exclude:` rather than given a placeholder
+  `exclude` *label*. `censat` and `satellite` tile, because separating `p_arm`
+  from `q_arm` needs the centromere position. A RepeatMasker class the converter
+  has no leaf for is labelled `other_repeat`, keeping it distinct from
+  RepeatMasker's own `Unknown` class.
 
-  Verified by re-deriving the reference feature sets from their original inputs:
-  the `edta`, `fai`, `satellite`, `cytoband` and `gff-gene` outputs are
-  byte-identical to the files the bespoke scripts produced, including the CHM13
-  human gene set (612,908 records) and the whole CHM13 RepeatMasker set
-  (4,636,653 records).
+  See [prep-bed](docs/commands/prep-bed.md).
 
 ### Fixed
-- **`prep-bed repeatmasker` no longer folds unmappable classes into `Unknown`.**
-  `Unknown` is a real RepeatMasker class — 22,523 records in CHM13 v2 — meaning
-  "RepeatMasker could not classify this element". Using it as the fallback for a
-  class *we* have no leaf for conflated two different claims: one where the
-  annotation is uncertain, one where the annotation is confident and we are the
-  ones unable to place it. Such rows now get their own `other_repeat` leaf, which
-  joins the hierarchy and palette only when something actually lands on it — so a
-  file whose classes are all recognised, including the CHM13 v2 input, produces
-  byte-identical output to before. They are still not dropped: that would leave
-  their bases to the `nonrepeat` gap-fill and assert the opposite of what the
-  annotation says.
+- **`HKS_arabidopsis_ColCEN` regenerated — its `gene` set labelled intergenic
+  regions as intron.** The set had been built by deriving introns from a
+  chromosome-wide exon list, which treats every gap between neighbouring genes
+  as an intron: 8,325 such spans, reporting 42.0% of the genome as intron
+  against 20.6%, and 21.6% intergenic against 43.0%. The database is rebuilt and
+  now at 1.2.0. `HKS_human_CHM13_v2` was unaffected.
 
-- **`prep-bed gff-gene` derives introns per transcript, not per chromosome.**
-  The *A. thaliana* Col-CEN `gene.bed` used to build that database labels 8,325
-  spans `intron` that lie inside no gene at all — gaps between neighbouring
-  genes, which are intergenic. The effect is not marginal: it reports 42.0% of
-  the genome as intron against 20.6% actual, and 21.6% intergenic against 43.0%.
-  Introns are now derived from each transcript's own consecutive exons, and
-  where transcripts disagree the more specific label wins (`exon` > `intron` >
-  `intergenic`) so alternative splicing never double-labels a base. The human
-  CHM13 gene set is unaffected and reproduces byte-identically; the Arabidopsis
-  database needs regenerating.
+  `prep-bed gff-gene` derives introns from each transcript's own consecutive
+  exons, and where transcripts disagree the more specific label wins
+  (`exon` > `intron` > `intergenic`).
+
 - **`colors.tsv` gains an optional 4th column, `legend_group`, and `build`
   carries it through.** A feature set with hundreds of leaves in a handful of
-  colours produced a legend that dwarfed the figure — and worse, silently
-  truncated to whatever fit the canvas. The CHM13 cytoband database has 833
-  features and the legend drew 51 of them, showing 6% of what was present with
-  no indication the rest were dropped. Features sharing a `legend_group` now
-  collapse to one legend row: 833 entries become 9, labelled by Giemsa stain.
+  colours produced a legend that dwarfed the figure and was truncated to
+  whatever fit the canvas, with no indication that rows had been dropped. The
+  CHM13 cytoband database has 833 features and the legend drew 51 of them.
+  Features sharing a `legend_group` now collapse to one legend row: 833 entries
+  become 9, labelled by Giemsa stain.
 
   The column is optional and the header must be exactly 3 or exactly 4 columns,
   so every existing database parses unchanged and keeps its per-feature legend
@@ -103,8 +76,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   supply and the file the database ships have the same shape; it is emitted only
   when at least one feature declares a group, leaving ungrouped builds
   byte-identical. Because a legend row is one swatch and one label, `build`
-  fails if a group spans two colours — there would be no well-defined swatch,
-  and the figure would silently misrepresent the rest of the group. See
+  fails if a group spans two colours, since there is no well-defined swatch for
+  such a group. See
   [build → Grouping the legend](docs/commands/build.md#grouping-the-legend).
 
 - **`examples/karyotypes/`** — reference karyotype plots for six assemblies
@@ -116,8 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLI subcommands are imported on demand, cutting startup from ~290 ms to
   ~70 ms.** Registering the eleven subcommands meant importing all eleven
   command modules, and one of them (`download`) pulls in `requests` — about
-  190 ms of that 290 ms, paid by every invocation, for an HTTP library most
-  commands never touch. `karyoscope --help` still imports everything, because
+  190 ms of that 290 ms, paid by every invocation regardless of whether the
+  command used it. `karyoscope --help` still imports everything, because
   Click asks each command for its short help to build the listing; every other
   path now imports only the command being run.
 
@@ -146,9 +119,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   there are zero hardcoded `stroke="black"` left.
 
   Separately, the legend now omits features whose entire drawn extent is under
-  half a pixel. Such a feature cannot be found in the figure, so a legend row
-  for it only sends the reader hunting for a colour that was never visibly
-  rendered.
+  half a pixel, since a legend row for such a feature names a colour that is not
+  visibly present in the figure.
 
 - **`bin` no longer emits a runt trailing bin.** A trailing partial bin cast a
   label vote of equal standing to a full one, so a handful of bases could

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Pass `--format pdf` or `--format png` (repeatable) to additionally produce those
 |---|---|
 | [`karyoscope download`](docs/commands/download.md) | Acquire pre-built databases |
 | [`karyoscope register`](docs/commands/register.md) | Register a locally-placed database so commands can use it |
+| [`karyoscope prep-bed`](docs/commands/prep-bed.md) | Convert a source annotation into a feature-set BED |
 | [`karyoscope build`](docs/commands/build.md) | Build an HKS database from a genome and per-feature-set BEDs |
 | [`karyoscope annotate`](docs/commands/annotate.md) | Annotate sequences with *k*-mer features |
 | [`karyoscope scaffold`](docs/commands/scaffold.md) | Order, orient, and rename assembly contigs |
@@ -306,7 +307,7 @@ karyoscope download --list           # download and on-disk size for each
 karyoscope download --info <ID>      # ...plus the free space needed to install
 ```
 
-You can also build your own database from a genome and per-feature-set BED annotations with [`karyoscope build`](docs/commands/build.md). `build` starts from a final labelled BED; producing that BED from raw annotation sources (GFF3/GTF, RepeatMasker/EDTA, satellite catalogs) is currently a manual, source-specific step, and a dedicated `karyoscope prep-bed` helper to automate it is [planned](docs/commands/build.md#preparing-a-feature-set-bed).
+You can also build your own database from a genome and per-feature-set BED annotations with [`karyoscope build`](docs/commands/build.md). `build` starts from a final labelled BED; [`karyoscope prep-bed`](docs/commands/prep-bed.md) produces one from the formats annotation usually arrives in — RepeatMasker and EDTA tables, GFF3/GTF gene models, UCSC cytoband tables, satellite catalogs, and a plain `.fai` — and prints the build-spec stanza to go with it.
 
 ## Pre-computed annotations
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 > ℹ️ **KaryoScope follows [semantic versioning](https://semver.org); v1.0.0 is the first stable release.** The command-line interface is stable: deprecations ship with warnings and a back-compatible transition, and any breaking change will come with a major-version bump. The project is being prepared for journal submission, and new features continue to land between releases — see the [CHANGELOG](CHANGELOG.md) and [releases](https://github.com/barthel-lab/KaryoScope/releases).
 
-> 🚀 **New in v2.2.0.** [`karyoscope prep-bed`](docs/commands/prep-bed.md) converts source annotations — RepeatMasker, EDTA, GFF3/GTF gene models, UCSC cytobands, CenSat, satellite catalogs, a plain `.fai` — into the feature-set BEDs [`karyoscope build`](docs/commands/build.md) consumes, so building a database no longer needs a script per dataset. [`docs/recipes/`](docs/recipes/) rebuilds the shipped human and *Arabidopsis* databases end to end, from download URL to built index. [`examples/karyotypes/`](examples/karyotypes/) collects reference karyotype plots for six assemblies to compare your own output against. Legends can now be collapsed with a `legend_group` column, turning the cytoband database's 833 entries into 9. See the [CHANGELOG](CHANGELOG.md).
+> 🚀 **New in v2.2.0.** [`karyoscope prep-bed`](docs/commands/prep-bed.md) converts source annotations — RepeatMasker, EDTA, GFF3/GTF gene models, CenSat, satellite catalogs, a plain `.fai` — into the feature-set BEDs [`karyoscope build`](docs/commands/build.md) consumes, so building a database no longer needs a script per dataset. [`docs/recipes/`](docs/recipes/) rebuilds the shipped human and *Arabidopsis* databases end to end, from download URL to built index. [`examples/karyotypes/`](examples/karyotypes/) collects reference karyotype plots for six assemblies to compare your own output against. Legends can now be collapsed with a `legend_group` column. See the [CHANGELOG](CHANGELOG.md).
 
 ---
 
@@ -73,7 +73,9 @@ A pre-built database for the human genome is distributed alongside the tool, der
 **Hardware.** No non-standard hardware is required — KaryoScope runs on a standard CPU and has no GPU dependency. Resource needs scale with the input:
 
 - **Demo and small inputs:** run on any laptop in seconds (see [Demo](#demo)).
-- **Human whole-genome inputs (HKS backend, recommended):** `annotate` holds the index (~10 GB, fixed) plus per-query buffering that grows with how much sequence one lookup processes at once, so the memory to request depends on the input shape. A **single haplotype** peaks at **~10 GB** (request ≥ 16 GB) and finishes in **~7–9 minutes** at 16 threads. A **combined diploid assembly** — both haplotypes in one file, e.g. HG002 v1.1 — peaks at **~17 GB** (request ≥ 24 GB); annotating each haplotype separately keeps the peak at ~10 GB. Measured at 16 threads on T2T-CHM13v2.0, HG008N, HG008T, and HG002 v1.1. See [Disk space](#disk-space) for storage.
+- **Human whole-genome inputs (HKS backend, recommended):** `annotate`'s peak is set by the index, not by the input. It holds the shared base index (6.0 GiB) plus one feature set's labeling at a time (the largest is 3.0 GiB), so the peak is **~10 GB whatever you annotate** — a single haplotype and a combined diploid assembly measure the same. **Request ≥ 16 GB.** A single haplotype's six-feature-set run takes **~7–9 minutes** at 16 threads; a combined diploid is roughly twice that. Measured on T2T-CHM13v2.0, HG008N, HG008T and HG002 v1.1. See [Disk space](#disk-space) for storage.
+
+  Memory barely moves with `--threads`, so there is no reason to hold threads back to save RAM. What *does* vary by machine is the index load: 9 GB is read per feature set, and if there is enough free RAM for the page cache to hold it, the second and later feature sets load in ~2 s instead of ~25 s. On a memory-tight machine expect every load to be cold.
 - **Human whole-genome inputs (KMC backend):** loading the KMC index during `annotate` needs roughly 30 GB of RAM (we measured ~30–35 GB peak at 16 threads), so we recommend ≥ 50 GB RAM and ≥ 16 CPU cores. A single haplotype's six-feature-set run takes ~17–22 minutes at 16 threads.
 
 ### Disk space
@@ -218,11 +220,12 @@ This walkthrough uses the [HG002 v1.1 T2T diploid assembly](https://s3-us-west-2
 
 <!-- TODO(hks-default): this Quick start uses the default `karyoscope download`,
      which currently installs the KMC KS_human_CHM13_v2 database (hence the KMC
-     name in the output filenames below and the ~17 GB / KMC RAM figures). When
+     name in the output filenames below and the KMC RAM figures). When
      the registry default flips to HKS_human_CHM13_v2 (after KMC removal + the
      conda recipe guarantees `hks` on every install), switch this walkthrough to
      HKS: the output names become HKS_human_CHM13_v2 and the RAM guidance drops
-     to the HKS figures (~16-24 GB). Keep it on KMC until then. -->
+     to the HKS figure (~16 GB, since the peak is the index and not the
+     input). Keep it on KMC until then. -->
 
 ```bash
 # 1. Download the recommended human reference database (one-time).
@@ -236,10 +239,10 @@ karyoscope download
 curl -O https://s3-us-west-2.amazonaws.com/human-pangenomics/T2T/HG002/assemblies/hg002v1.1.fasta.gz
 
 # 3. Annotate the assembly. Recommended: at least 16 threads and, for the
-#    HKS backend, ≥ 24 GB of RAM — HG002 v1.1 is a combined diploid
-#    assembly and its annotate peaks at ~17 GB (a single haplotype peaks
-#    at ~10 GB and fits 16 GB). The KMC backend needs ≥ 50 GB. HG002 runs
-#    in ~20-30 min at -t 16.
+#    HKS backend, ≥ 16 GB of RAM — annotate's peak is set by the index it
+#    holds (~10 GB) rather than by the input, so a combined diploid and a
+#    single haplotype need the same. The KMC backend needs ≥ 50 GB. HG002
+#    runs in ~20-30 min at -t 16.
 #    Needs ~34 GB free in results/ -- six feature sets over a 6 Gbp
 #    diploid assembly. --no-bgzip keeps the per-feature-set BEDs as plain
 #    text for easy inspection; drop it to get the default bgzipped

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 > ℹ️ **KaryoScope follows [semantic versioning](https://semver.org); v1.0.0 is the first stable release.** The command-line interface is stable: deprecations ship with warnings and a back-compatible transition, and any breaking change will come with a major-version bump. The project is being prepared for journal submission, and new features continue to land between releases — see the [CHANGELOG](CHANGELOG.md) and [releases](https://github.com/barthel-lab/KaryoScope/releases).
 
-> 🚀 **New in v2.0.0.** An [HKS](https://github.com/jnalanko/HKS) *k*-mer indexing backend now runs alongside KMC — annotating a human haplotype **~2.5–3× faster at about a third of the memory** — and a new [`karyoscope build`](docs/commands/build.md) command constructs a ready-to-use database from any genome and per-feature-set BEDs. Both are additive: existing KMC databases and workflows are unchanged. See the [CHANGELOG](CHANGELOG.md).
+> 🚀 **New in v2.2.0.** [`karyoscope prep-bed`](docs/commands/prep-bed.md) converts source annotations — RepeatMasker, EDTA, GFF3/GTF gene models, UCSC cytobands, CenSat, satellite catalogs, a plain `.fai` — into the feature-set BEDs [`karyoscope build`](docs/commands/build.md) consumes, so building a database no longer needs a script per dataset. [`docs/recipes/`](docs/recipes/) rebuilds the shipped human and *Arabidopsis* databases end to end, from download URL to built index. [`examples/karyotypes/`](examples/karyotypes/) collects reference karyotype plots for six assemblies to compare your own output against. Legends can now be collapsed with a `legend_group` column, turning the cytoband database's 833 entries into 9. See the [CHANGELOG](CHANGELOG.md).
 
 ---
 
@@ -28,14 +28,14 @@
 
 KaryoScope is an alignment-free annotation tool that assigns each *k*-mer in a query assembly or sequencing read to a feature drawn from one or more user-defined hierarchical feature sets, producing a base-pair resolution annotation in a single pass. Because a feature set is simply any tiling of a reference with labelled regions, KaryoScope is extensible to arbitrary annotation sources, from satellite catalogs and repeat libraries to cytobands, FISH-probe coordinates, and structural-variant breakpoints.
 
-A pre-built database for the human genome is distributed alongside the tool, derived from T2T-CHM13v2.0 with six feature sets covering chromosome of origin, satellite composition, interspersed repeats, subtelomeric structure, gene boundaries, and acrocentric-specific features. From these annotations, KaryoScope produces karyotype visualizations and cytogenetic reports without ever performing read alignment. Additional databases can be built for any reference genome or community-curated annotation source, and pre-built databases are shared through the [KaryoScope registry](https://github.com/barthel-lab/KaryoScope-registry).
+A pre-built database for the human genome is distributed alongside the tool, derived from T2T-CHM13v2.0 with six feature sets covering chromosome of origin, satellite composition, interspersed repeats, subtelomeric structure, gene boundaries, and acrocentric-specific features. From these annotations, KaryoScope produces karyotype visualizations and cytogenetic reports without ever performing read alignment. Additional databases can be built for any reference genome or community-curated annotation source. [`karyoscope prep-bed`](docs/commands/prep-bed.md) converts the annotation into labelled feature-set BEDs and [`karyoscope build`](docs/commands/build.md) indexes them; [`docs/recipes/`](docs/recipes/) works both steps through for the human and *Arabidopsis* databases. Databases built this way can be published to, and installed from, the [KaryoScope registry](https://github.com/barthel-lab/KaryoScope-registry).
 
 <!-- TODO: hero figure of a KaryoScope output, e.g. the HG008T karyotype -->
 <!-- <p align="center"><img src="assets/hero_karyotype.png" alt="Example KaryoScope karyotype" width="800"/></p> -->
 
 ### Why alignment-free?
 
-- **Pangenome-scale throughput.** Annotates a single feature set on a complete human haplotype in ~8 minutes on a standard workstation, or the full six-feature-set pipeline for a diploid sample in ~30 minutes at 16 threads — scaling to cohorts of hundreds of phased assemblies. The [HKS](https://github.com/jnalanko/HKS) *k*-mer indexing backend, now available alongside KMC, annotates all six feature sets for a human haplotype in ~7–9 minutes at a ~10 GB memory peak — roughly 2.5–3× faster than KMC and about a third of the RAM (measured at 16 threads on the T2T-CHM13v2.0, HG008N, and HG008T assemblies).
+- **Pangenome-scale throughput.** On the [HKS](https://github.com/jnalanko/HKS) *k*-mer indexing backend, one `annotate` run covering all six feature sets finishes a complete human haplotype in **~7–9 minutes at a ~10 GB memory peak**, at 16 threads — scaling to cohorts of hundreds of phased assemblies. The original KMC backend does the same work in ~17–22 minutes at ~30–35 GB, so HKS is roughly 2.5–3× faster on about a third of the RAM. (Measured at 16 threads on T2T-CHM13v2.0, HG008N and HG008T, as a single sequential run of the whole pipeline — assignment plus smoothing for every feature set.)
 - **Base-pair resolution across the entire genome.** Performs well in the satellite-dense centromeres, subtelomeres, and acrocentric short arms where alignment-based pipelines suffer from reference bias and ambiguous mappings.
 - **Multiple feature classes in a single pass.** The same *k*-mer can carry labels across feature sets simultaneously, so a single position can be annotated as belonging to a specific chromosome, satellite family, repeat class, and gene at once.
 - **Extensible.** Any annotation that tiles a reference of interest can serve as a feature set.
@@ -73,8 +73,8 @@ A pre-built database for the human genome is distributed alongside the tool, der
 **Hardware.** No non-standard hardware is required — KaryoScope runs on a standard CPU and has no GPU dependency. Resource needs scale with the input:
 
 - **Demo and small inputs:** run on any laptop in seconds (see [Demo](#demo)).
-- **Human whole-genome inputs (KMC backend):** loading the KMC index during `annotate` needs roughly 30 GB of RAM (we measured ~30–35 GB peak at 16 threads). We recommend ≥ 50 GB RAM and ≥ 16 CPU cores for human-scale runs. A single human haplotype's six-feature-set run takes ~17–22 minutes at 16 threads. See [Disk space](#disk-space) for storage.
-- **Human whole-genome inputs (HKS backend):** `annotate` holds the index (~10 GB, fixed) plus per-query buffering that grows with how much sequence one lookup processes at once, so the memory you should request depends on the input shape. A **single haplotype** peaks at **~10 GB** (request ≥ 16 GB) and finishes in **~7–9 minutes** at 16 threads. A **combined diploid assembly** — both haplotypes in one file, e.g. HG002 v1.1 — peaks at **~17 GB** (request ≥ 24 GB); annotating each haplotype separately keeps the peak at ~10 GB. Measured at 16 threads on T2T-CHM13v2.0, HG008N, HG008T, and HG002 v1.1.
+- **Human whole-genome inputs (HKS backend, recommended):** `annotate` holds the index (~10 GB, fixed) plus per-query buffering that grows with how much sequence one lookup processes at once, so the memory to request depends on the input shape. A **single haplotype** peaks at **~10 GB** (request ≥ 16 GB) and finishes in **~7–9 minutes** at 16 threads. A **combined diploid assembly** — both haplotypes in one file, e.g. HG002 v1.1 — peaks at **~17 GB** (request ≥ 24 GB); annotating each haplotype separately keeps the peak at ~10 GB. Measured at 16 threads on T2T-CHM13v2.0, HG008N, HG008T, and HG002 v1.1. See [Disk space](#disk-space) for storage.
+- **Human whole-genome inputs (KMC backend):** loading the KMC index during `annotate` needs roughly 30 GB of RAM (we measured ~30–35 GB peak at 16 threads), so we recommend ≥ 50 GB RAM and ≥ 16 CPU cores. A single haplotype's six-feature-set run takes ~17–22 minutes at 16 threads.
 
 ### Disk space
 
@@ -82,8 +82,8 @@ Databases are large, and the archive is **not** deleted until extraction finishe
 
 | Database | Backend | Download (`.tar.gz`) | On disk after install | **Free space to install** |
 |---|---|---|---|---|
-| `KS_human_CHM13_v2` (default) | KMC | 16.3 GB | 17.2 GB | **~34 GB** |
 | `HKS_human_CHM13_v2` | HKS | 13.3 GB | 22.7 GB | **~36 GB** |
+| `KS_human_CHM13_v2` (default) | KMC | 16.3 GB | 17.2 GB | **~34 GB** |
 
 The HKS archive compresses far better than the KMC one, so its download is the *smaller* of the two while its installed footprint is the larger. Once the install completes the archive is removed and only the "on disk" column remains occupied.
 
@@ -295,6 +295,13 @@ Run `karyoscope <command> --help` for full options on any command.
 ## Documentation
 
 Per-command reference pages live under [`docs/commands/`](docs/commands/) — one page per subcommand, linked from the [Commands](#commands) table above. The `--help` output of each command (`karyoscope <command> --help`) remains the authoritative, always-current reference.
+
+Beyond the per-command pages:
+
+| Where | What |
+|---|---|
+| [`docs/recipes/`](docs/recipes/) | Rebuild the shipped human and *Arabidopsis* databases from published sources — every download URL and checksum, the `prep-bed` command for each feature set, and the build spec. |
+| [`examples/karyotypes/`](examples/karyotypes/) | Reference karyotype plots for six assemblies (CHM13, HG002, an HG008 tumour/normal pair, an HPRC population sample, and *Arabidopsis*), with notes on what each shows and the commands that produced them. |
 
 ## Databases
 

--- a/README.md
+++ b/README.md
@@ -238,13 +238,15 @@ karyoscope download
 #    Skip if you already have your own assembly to annotate.
 curl -O https://s3-us-west-2.amazonaws.com/human-pangenomics/T2T/HG002/assemblies/hg002v1.1.fasta.gz
 
-# 3. Annotate the assembly. Recommended: at least 16 threads and, for the
-#    HKS backend, ≥ 16 GB of RAM — annotate's peak is set by the index it
-#    holds (~10 GB) rather than by the input, so a combined diploid and a
-#    single haplotype need the same. The KMC backend needs ≥ 50 GB. HG002
-#    runs in ~20-30 min at -t 16.
-#    Needs ~34 GB free in results/ -- six feature sets over a 6 Gbp
-#    diploid assembly. --no-bgzip keeps the per-feature-set BEDs as plain
+# 3. Annotate the assembly. This runs against the KMC database installed
+#    in step 1, so budget for the KMC backend: it peaks at ~30-35 GB, so
+#    request >= 50 GB of RAM, with at least 16 threads. A single haplotype
+#    takes ~17-22 min at -t 16; HG002 v1.1 is a combined diploid, so expect
+#    roughly twice that.
+#    Allow ~34 GB free in results/ for six feature sets over this 6 Gbp
+#    assembly, plus headroom for the combined-BED intermediate the KMC
+#    backend writes alongside them. See "Disk space" above.
+#    --no-bgzip keeps the per-feature-set BEDs as plain
 #    text for easy inspection; drop it to get the default bgzipped
 #    outputs (which shrink the result but not the peak, since compression
 #    runs after every BED has been written).

--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ karyoscope download --info <ID>      # ...plus the free space needed to install
 
 You can also build your own database from a genome and per-feature-set BED annotations with [`karyoscope build`](docs/commands/build.md). `build` starts from a final labelled BED; [`karyoscope prep-bed`](docs/commands/prep-bed.md) produces one from the formats annotation usually arrives in — RepeatMasker and EDTA tables, GFF3/GTF gene models, UCSC cytoband tables, satellite catalogs, and a plain `.fai` — and prints the build-spec stanza to go with it.
 
+For complete worked examples — every download URL, checksum, conversion and build spec — see [docs/recipes/](docs/recipes/), which rebuilds the human CHM13v2 and *Arabidopsis* Col-CEN databases from published sources.
+
 ## Pre-computed annotations
 
 KaryoScope outputs for the [HPRC Release 2](https://humanpangenome.org/) pangenome samples are hosted by the Human Pangenome Reference Consortium at the [`TGen_HPRCv2_KaryoScope` S3 bucket](https://s3-us-west-2.amazonaws.com/human-pangenomics/index.html?prefix=submissions/B5FC8EB1-5B2A-49FE-8421-6D938943DFC9--TGen_HPRCv2_KaryoScope/). Use these to explore HPRC karyotypes without running the pipeline yourself, or as references for downstream analysis.

--- a/docs/commands/annotate.md
+++ b/docs/commands/annotate.md
@@ -22,7 +22,7 @@ karyoscope annotate -i INPUT [OPTIONS]
 | `--db-root DIRECTORY` | Override the database root directory (default: `$KARYOSCOPE_DB` or `~/.karyoscope/db/`). |
 | `--feature-set TEXT` | Restrict output to this feature set. Repeatable. Default: all feature sets declared in the database's manifest. |
 | `-t`, `--threads INTEGER` | Threads for both k-mer querying and smoothing. `0` means auto-detect. [default: `0`] |
-| `--k INTEGER` | Query k-mer length. Defaults to the database's k. Only a variable-k HKS index (built with `karyoscope build --variable-k`) accepts a value other than its k — use it for a k-sweep. Outputs are tagged `.k<k>` so runs into one directory don't collide. |
+| `--k INTEGER` | Query k-mer length. Defaults to the database's k. Only a variable-k HKS index (built with `karyoscope build --variable-k`) accepts a value other than its k — use it for a k-sweep; on a fixed-k index any other value is an error. A database built with priorities is always fixed-k. Outputs are tagged `.k<k>` so runs into one directory don't collide. |
 | `--smooth` / `--no-smooth` | Produce the hierarchy-smoothed BED in addition to the presmoothed BED. [default: `smooth`] |
 | `--keep-presmoothed` / `--no-keep-presmoothed` | Keep the presmoothed BED. Pass `--no-keep-presmoothed` to write only the smoothed output. [default: `keep-presmoothed`] |
 | `--keep-intermediates` | Keep the combined `.featureIDs.bed` from the C++ step (useful for debugging). |

--- a/docs/commands/annotate.md
+++ b/docs/commands/annotate.md
@@ -56,7 +56,7 @@ Each BED's 4th column is the human-readable feature name. k-mers absent from the
 
 Smoothing promotes short noisy intervals (especially short `novel` runs flanked by specific features) to the lowest common ancestor of their flankers in the feature set's hierarchy.
 
-For human-scale inputs, use at least 16 threads. Memory to request depends on the backend and input shape. With the **HKS backend**, a single haplotype peaks at ~10 GB (request ≥ 16 GB) and a combined diploid assembly such as HG002 v1.1 peaks at ~17 GB (request ≥ 24 GB); annotating each haplotype separately keeps the peak at ~10 GB. The **KMC backend** peaks at ~30–35 GB (request ≥ 50 GB). HG002 runs in ~20–30 min at `-t 16`.
+For human-scale inputs, use at least 16 threads. Memory to request depends on the backend and input shape. With the **HKS backend**, the peak is set by the index rather than the input — the shared base index plus one feature set's labeling at a time — so it is ~10 GB whether you annotate a single haplotype or a combined diploid assembly such as HG002 v1.1 (request ≥ 16 GB). The **KMC backend** peaks at ~30–35 GB (request ≥ 50 GB). HG002 runs in ~20–30 min at `-t 16`.
 
 ## Progress output
 

--- a/docs/commands/annotate.md
+++ b/docs/commands/annotate.md
@@ -10,7 +10,7 @@ karyoscope annotate -i INPUT [OPTIONS]
 
 ## Description
 
-`karyoscope annotate` assigns every k-mer in the input to a feature in a single alignment-free pass, by querying the database's KMC index via the bundled `get_featureIDs` helper. It produces one BED per feature set, and by default writes BOTH a "presmoothed" (raw) and a "smoothed" (hierarchy-smoothed) BED for each feature set. k-mers that are not present in the index render as `novel`. Input may be FASTA, FASTQ, or BAM. The expensive k-mer-query step is resumable across reruns, so an interrupted (for example, OOM-killed) run can resume straight into smoothing.
+`karyoscope annotate` assigns every k-mer in the input to a feature in a single alignment-free pass, by querying the database's index. The backend follows the database: an HKS-index database (e.g. `HKS_human_CHM13_v2`) is queried with `hks`, and a KMC-index database with the bundled `get_featureIDs` helper. It produces one BED per feature set, and by default writes BOTH a "presmoothed" (raw) and a "smoothed" (hierarchy-smoothed) BED for each feature set. k-mers that are not present in the index render as `novel`. Input may be FASTA, FASTQ, or BAM. The expensive k-mer-query step is resumable across reruns, so an interrupted (for example, OOM-killed) run can resume straight into smoothing.
 
 ## Options
 

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -13,7 +13,7 @@ karyoscope build --spec build.yaml [OPTIONS]
 
 `build` produces a complete, registry-ready [HKS](https://github.com/jnalanko/HKS) database — the same layout `download`/`register` expect (`manifest.yaml`, `hierarchy.tsv`, `colors.tsv`, and an `index/` directory) — from a reference genome and one or more feature-set BED files. It runs the HKS `build-base` and `add-feature-set` construction steps for you, gap-fills unannotated regions with a named background feature, derives the label hierarchy and colours, writes the manifest, and records the result in `installed.json`.
 
-The command's contract begins at a **final per-feature-set BED** whose 4th column is the **feature label**: a leaf of that feature set's hierarchy. Turning raw annotation sources (RepeatMasker, censat, GENCODE, …) into that BED is up to you — see the worked example under [Preparing a feature-set BED](#preparing-a-feature-set-bed).
+The command's contract begins at a **final per-feature-set BED** whose 4th column is the **feature label**: a leaf of that feature set's hierarchy. Turning raw annotation sources (RepeatMasker, censat, GENCODE, …) into that BED is [`karyoscope prep-bed`](prep-bed.md)'s job — see [Preparing a feature-set BED](#preparing-a-feature-set-bed).
 
 ## Required inputs
 
@@ -21,11 +21,11 @@ Only two inputs are required — a genome and at least one annotation BED:
 
 | Input | Required | What it is |
 | --- | --- | --- |
-| **Genome FASTA** (`--sequence`) | **Yes**, for BED (mode A) feature sets | The assembly your annotations are in coordinates of; plain or bgzipped. If a `.fai` is missing, `build` creates one with `samtools faidx`. |
+| **Genome FASTA** (`--sequence`) | **Yes** | The assembly your annotations are in coordinates of; plain or bgzipped. If a `.fai` is missing, `build` creates one with `samtools faidx`. |
 | **Feature-set BED** (`--feature-set NAME=BED`) | **Yes**, at least one | A BED whose **4th column is the feature label** — a leaf of this feature set's hierarchy. With no hierarchy file, each distinct label simply becomes its own leaf. Repeat the flag for more sets. Overlaps are allowed and gaps are filled automatically. |
-| Hierarchy (`--hierarchy NAME=PATH`) | No | `child<tab>parent` edge list. Without one, every leaf becomes a child of the root `categorized` (a flat star). |
-| Priorities (`--priority NAME=PATH`) | No | Resolves which label wins a k-mer claimed by several. In its 3-column `child priority parent` form it **also supplies the hierarchy**, so one file covers both. |
-| Colours (`--colors NAME=PATH`) | No | `feature<tab>color`, or the full `feature_set<tab>feature<tab>color`, with an optional 4th `legend_group` column (see [Grouping the legend](#grouping-the-legend)). Without one, a distinct palette is generated per leaf. |
+| Hierarchy (`--hierarchy NAME=PATH`) | No | `child<tab>parent` edge list. Without one, every leaf becomes a child of the root `categorized` (a flat star). See [Hierarchy](#hierarchy). |
+| Priorities (`--priority NAME=PATH`) | No | Resolves which label wins a k-mer claimed by several. In its 3-column `child priority parent` form it **also supplies the hierarchy**, so one file covers both. See [Priorities](#priorities). |
+| Colours (`--colors NAME=PATH`) | No | `feature<tab>color`, or the full `feature_set<tab>feature<tab>color`, with an optional 4th `legend_group` column. Without one, a distinct palette is generated per leaf. See [Colours](#colours). |
 | Background label (`--background NAME=LABEL`) | No | Names the gap-fill leaf (default `background`). |
 
 Nothing else is needed. In particular there is **no** alignment step, no pre-existing index, and no per-feature FASTA files — `build` slices those out of the genome itself.
@@ -38,38 +38,103 @@ karyoscope build --id HKS_mygenome --sequence genome.fa.gz --feature-set repeat=
 
 For what this costs in time, memory, and disk, see [Resource requirements](#resource-requirements).
 
-### Input modes
+### Hierarchy
 
-Each feature set is one of:
+An edge list, `child<tab>parent`, one edge per line, rooted at `categorized`.
+Every label appearing in the BED must be a node in it. Without a hierarchy file
+each distinct BED label becomes a child of the root — a flat star, under which
+every shared k-mer resolves to `categorized`.
 
-- **BED (mode A):** `--feature-set NAME=annot.bed` together with a shared `--sequence` genome. The genome is sliced into one FASTA per feature label (each region extended by `k-1` bp so every k-mer that starts in the region is captured). Gaps are filled with a background leaf (see below).
-- **FASTAs (mode B, spec file only):** a feature set entry with `fastas:` (one file per feature) or `per_seq_file:` (one sequence per feature). No genome slicing and no gap-fill.
+The hierarchy also drives smoothing and rendering: `bin` and `karyotype` prefer
+leaf labels, so anything you want drawn must be a leaf rather than an interior
+node.
 
-### Overlaps, priorities, and variable-k
+### How labels are resolved
 
-HKS resolves a k-mer that belongs to several labels via its hierarchy, so **overlapping BED regions are allowed** — you do not need a non-overlapping partition. To control which label wins an overlap, supply a **priority file** for the set (`--priority NAME=file`); HKS then keeps the higher-priority (lower integer) label per k-mer, climbing to the common ancestor only on ties. This is the per-k-mer equivalent of pre-flattening the BED, so it usually replaces it. If you *do* want a hard flattened partition, `--flatten` collapses overlaps to one label per base before indexing.
+HKS indexes **k-mers**, not coordinates. A feature set's BED is sliced into one
+FASTA per label, and a k-mer is claimed by every label whose sequence contains
+it. Two consequences follow:
 
-The priority file accepts either the 3-column `child priority parent` form (which also supplies the hierarchy) or the 2-column `name priority` form. Within any group of siblings, priorities must be either all equal or all distinct (an HKS requirement, checked up front).
+- Overlapping BED regions are fine. You do not need a non-overlapping partition.
+- The same k-mer sequence occurring in two different regions is claimed by both
+  **whether or not those regions overlap in coordinates** — including regions on
+  different chromosomes.
 
-By default — no priority file — a set is built as a plain **fixed-k** labeling, which is exactly what `annotate` queries at (k = s). This is the recommended default for a production database.
+Where a k-mer has more than one claimant, the label is the claimants' **lowest
+common ancestor** in the hierarchy, unless priorities say otherwise.
 
-`--variable-k` (or per set, `variable_k: true` in the spec) instead builds an index that can be queried at **any k ≤ s from a single build** — useful for a k-sweep, e.g. checking that results are stable across k without rebuilding. It works from BED (mode A) input: because HKS variable-k needs a dummy node for each feature sequence's start, the base index is built from the per-feature FASTAs `build` already generates (the genome slices), not from the whole genome. `--variable-k` is mutually exclusive with `--priority`, and it produces a larger index, so use it when you actually need multi-k queries. The manifest's `kmer.type` is set to `variable` when every feature set is variable-k.
+Take this hierarchy and BED:
 
-### Background (gap-fill) feature
+```
+# repeat.hierarchy.txt          # repeat.bed
+LINE        Transposon          chr1  100  200  LINE
+SINE        Transposon          chr1  150  250  SINE
+Transposon  categorized
+```
 
-Bases that no feature annotates are, by default, filled with a **background** leaf so they render as a real feature rather than as `novel` (HKS's `none`, meaning "k-mer not in the reference at all"). The background label defaults to `background`; name it per set with `--background NAME=LABEL` (e.g. `--background repeat=nonrepeat`). It is attached under the hierarchy root and coloured grey (`#808080`). Set `background: null` in the spec file to disable gap-fill for a set. Where a BED already tiles the whole genome, no background records are produced.
+A k-mer found only in 100–150 is `LINE`; one found only in 200–250 is `SINE`.
+One found in both labels' sequence — anywhere — is `Transposon`, the lowest
+common ancestor. Under a flat hierarchy that ancestor is the root,
+`categorized`; a hierarchy is what lets a shared k-mer resolve to something more
+specific.
 
-### Defaults
+### Priorities
 
-- No hierarchy for a set → a flat star: every leaf is a child of the root, `categorized`.
-- No colours → an auto-generated distinct palette per leaf; grouping/root nodes are `#B0C4DE`, background is `#808080`. Provide your own with `--colors NAME=file` (`feature<tab>color`, or the full `feature_set<tab>feature<tab>color`).
-- `features.tsv` is **not** produced: the HKS backend reads label names from the index and never uses it.
+A priority file overrides the common-ancestor rule: the claimant with the
+**lowest priority number wins**, and the ancestor is used only when the top
+claimants tie.
 
-### Grouping the legend
+```
+# repeat.priority.txt
+LINE        1  Transposon
+SINE        2  Transposon
+Transposon  1  categorized
+```
+
+With that file, the shared k-mer above is `LINE` rather than `Transposon`.
+
+Both priorities and `--flatten` resolve competing claims when the index is
+built, but at different granularity. `--flatten` picks a winner per *base*
+before the k-mers are extracted, so the losing label is gone. Priorities keep
+every claim and resolve per *k-mer*, which is the finer of the two and does not
+depend on the regions overlapping in coordinates.
+
+The file takes either form:
+
+| Form | Columns | Also supplies the hierarchy? |
+| --- | --- | --- |
+| 3-column | `child priority parent` | Yes — one file covers both |
+| 2-column | `name priority` | No — pass `--hierarchy` separately |
+
+**Within any group of siblings, priorities must be either all equal or all
+distinct.** This is an HKS requirement (a mix makes its priority-aware ancestor
+operation non-associative) and is checked before the build starts:
+
+```
+LINE  1  Transposon      LINE  1  Transposon      LINE  1  Transposon
+SINE  1  Transposon      SINE  2  Transposon      SINE  1  Transposon
+LTR   1  Transposon      LTR   3  Transposon      LTR   2  Transposon
+      valid                    valid                    rejected
+```
+
+Interior nodes need priorities only to satisfy that rule; they are never
+assigned to a k-mer directly.
+
+### Colours
+
+`feature<tab>color`, or the full `feature_set<tab>feature<tab>color`, with an
+optional 4th `legend_group` column. Without a colours file, `build` generates a
+distinct palette per leaf; interior nodes are `#B0C4DE` and the background leaf
+is `#808080`.
+
+Rows are written to the database's `colors.tsv` in hierarchy order — each root,
+then every child in edge order.
+
+#### Grouping the legend
 
 A feature set with hundreds of leaves in a handful of colours produces a legend
-that dwarfs the figure. To collapse it, add an optional 4th column,
-`legend_group`, to the colours file you pass with `--colors`:
+that dwarfs the figure. Features sharing a `legend_group` collapse to **one
+legend row**, labelled by the group:
 
 ```
 feature_set	feature	color	legend_group
@@ -78,35 +143,75 @@ cytoband	q21.3	#000000	gpos100
 cytoband	p13.2	#ffffff	gneg
 ```
 
-Features sharing a `legend_group` collapse to **one legend row**, labelled by
-the group. A blank cell means "ungrouped" — that feature keeps its own row. For
-the CHM13 cytoband database this turns 833 legend entries into 9, labelled by
-Giemsa stain.
+A blank cell means "ungrouped" — that feature keeps its own row. For the CHM13
+cytoband database this turns 833 legend entries into 9, labelled by Giemsa
+stain. Groups appear in the legend in order of first appearance in `colors.tsv`.
 
 `build` carries the column through to the database's `colors.tsv`, so the file
 you supply and the file the database ships have the same shape. The column is
-written **only if at least one feature declares a group**, so a build that
-doesn't ask for grouping produces the same 3-column file as before.
+written only if at least one feature declares a group, so a build that doesn't
+ask for grouping produces the same 3-column file as before.
 
-Because a legend row is one swatch and one label, **every feature in a group
-must share a colour** — otherwise there is no well-defined swatch and the figure
-would silently misrepresent the rest. `build` checks this and fails if a group
-spans two colours. The reverse is fine: two groups may share a colour (two
-labels, one swatch — legible, just redundant).
+A legend row is one swatch and one label, so **every feature in a group must
+share a colour**; `build` fails if a group spans two. Two groups may share a
+colour, which is legal and merely redundant.
+
+### Background (gap-fill) feature
+
+Bases that no feature annotates are, by default, filled with a **background**
+leaf so they render as a real feature rather than as `novel` (HKS's `none`,
+meaning "k-mer not in the reference at all"). The background label defaults to
+`background`; name it per set with `--background NAME=LABEL` (e.g.
+`--background repeat=nonrepeat`). It is attached under the hierarchy root and
+coloured grey (`#808080`). Set `background: null` in the spec file to disable
+gap-fill for a set. Where a BED already tiles the genome, no background records
+are produced.
+
+### Fixed-k and variable-k
+
+By default a database is **fixed-k**: the index answers exactly one k-mer
+length, the `s` it was built with, and that is what `annotate` queries at. This
+is the recommended default for a production database.
+
+`--variable-k` (per set, `variable_k: true`) instead builds an index that
+answers **any k ≤ s from a single build**, for a k-sweep. Three things to know
+before using it:
+
+- **It cannot be combined with priorities.** HKS rejects the combination, so a
+  priority-resolved database is necessarily fixed-k. `build` checks this up
+  front.
+- **The base index is built differently.** Variable-k needs a dummy node per
+  feature sequence start, so the base is built from the per-feature FASTAs
+  rather than from the genome. With feature sets that tile the genome, its input
+  is roughly one genome copy *per set* — six tiling sets over a 3.1 Gb genome
+  means ~19 Gb of input rather than 3.1 Gb.
+- **The index is larger.**
+
+In the manifest, `kmer.type` is `variable` only when every feature set is
+variable-k. `kmer.max_size` is the largest queryable k, which on a fixed-k
+index equals `kmer.size` — it is **not** a range you may query within. On a
+fixed-k database `annotate --k` accepts only `kmer.size` and rejects anything
+else.
+
+### Defaults
+
+- No hierarchy for a set → a flat star: every leaf is a child of the root, `categorized`.
+- No colours → an auto-generated distinct palette per leaf.
+- `features.tsv` is **not** produced: the HKS backend reads label names from the index and never uses it.
 
 ## Options
 
 | Option | Description |
 | --- | --- |
 | `--id TEXT` | Database id (also the directory name). Required unless `--spec`. |
-| `--sequence FILE` | Genome FASTA (plain or bgzipped). Required for BED (mode A) feature sets. |
+| `--sequence FILE` | Genome FASTA (plain or bgzipped). Required for BED feature sets. |
 | `--feature-set NAME=BED` | A feature set as `NAME=annotation.bed` (4th column = the feature label, a leaf of its hierarchy). Repeatable. |
 | `--background NAME=LABEL` | Gap-fill label for a feature set (default `background`). Repeatable. |
-| `--hierarchy NAME=PATH` | Edge-list (`child parent`) hierarchy for a feature set. Repeatable. |
-| `--priority NAME=PATH` | Priority file for a feature set; enables priority mode. Repeatable. |
-| `--colors NAME=PATH` | Colours file for a feature set: `feature<tab>color`, or the full `feature_set<tab>feature<tab>color`, optionally with a 4th `legend_group` column ([Grouping the legend](#grouping-the-legend)). Repeatable. |
-| `--flatten` | Pre-flatten overlapping BED regions to one label per base. |
-| `--variable-k` | Build a variable-k index (queryable at any k ≤ s, e.g. a k-sweep). Not combinable with `--priority`. |
+| `--hierarchy NAME=PATH` | Edge-list (`child parent`) hierarchy for a feature set ([Hierarchy](#hierarchy)). Repeatable. |
+| `--priority NAME=PATH` | Priority file for a feature set ([Priorities](#priorities)); enables priority mode. Repeatable. |
+| `--colors NAME=PATH` | Colours file for a feature set: `feature<tab>color`, or the full `feature_set<tab>feature<tab>color`, optionally with a 4th `legend_group` column ([Colours](#colours)). Repeatable. |
+| `--flatten` | Pre-flatten overlapping BED regions to one label per base ([Priorities](#priorities)). |
+| `--variable-k` | Build a variable-k index, queryable at any k ≤ s ([Fixed-k and variable-k](#fixed-k-and-variable-k)). Not combinable with `--priority`. |
 | `--spec FILE` | Build-spec YAML (alternative to `--id`/`--sequence`/`--feature-set`). |
 | `--db-version TEXT` | Database version, semver (default `1.0.0`). |
 | `-s`, `--s INTEGER` | Maximum query length / k-mer size (default `31`). |
@@ -146,6 +251,23 @@ smoothing: { recommended_window_bp: 1000 }     # optional
 ```
 
 Relative paths in the spec are resolved against the spec file's directory.
+
+### Feature sets from FASTAs instead of a BED
+
+A feature set can name its sequences directly rather than being sliced out of a
+genome. This form is spec-only, and replaces `bed:` with one of:
+
+```yaml
+feature_sets:
+  - name: marker
+    fastas: [/path/markerA.fa, /path/markerB.fa]   # one file per feature
+  - name: probe
+    per_seq_file: /path/probes.fa                  # one sequence per feature
+```
+
+There is no coordinate system here, so `background:` and `flatten:` do not
+apply and are rejected. `--sequence` is not required unless some *other*
+feature set uses `bed:`.
 
 ## Excluding sequences
 

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -189,6 +189,8 @@ done
 
 Use [`karyoscope prep-bed`](prep-bed.md) to produce that BED from the formats annotation usually arrives in: RepeatMasker and EDTA tables, GFF3/GTF gene models, UCSC cytoband tables, satellite monomer catalogs, and a plain `.fai`. It writes the BED and hierarchy and prints the `feature_sets:` stanza to paste (or append) here.
 
+For complete worked examples, see the [database recipes](../recipes/).
+
 `prep-bed` is deliberately a **separate subcommand** rather than something `build` does for you: `build`'s contract stays "a final labelled BED", so it never has to sniff and guess at raw file formats. For the same reason `prep-bed` never gap-fills, flattens or drops sequences — `background:`, `flatten:` and `exclude:` below already do that, and doing it in both places would mean two places to get it wrong.
 
 ## Resource requirements

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -55,7 +55,7 @@ HKS indexes **k-mers**, not coordinates. A feature set's BED is sliced into one
 FASTA per label, and a k-mer is claimed by every label whose sequence contains
 it. Two consequences follow:
 
-- Overlapping BED regions are fine. You do not need a non-overlapping partition.
+- Overlapping BED regions are fine; any set of labelled regions works.
 - The same k-mer sequence occurring in two different regions is claimed by both
   **whether or not those regions overlap in coordinates** — including regions on
   different chromosomes.
@@ -197,7 +197,6 @@ else.
 
 - No hierarchy for a set → a flat star: every leaf is a child of the root, `categorized`.
 - No colours → an auto-generated distinct palette per leaf.
-- `features.tsv` is **not** produced: the HKS backend reads label names from the index and never uses it.
 
 ## Options
 
@@ -266,7 +265,7 @@ feature_sets:
 ```
 
 There is no coordinate system here, so `background:` and `flatten:` do not
-apply and are rejected. `--sequence` is not required unless some *other*
+apply and are rejected. `--sequence` is needed only if some *other*
 feature set uses `bed:`.
 
 ## Excluding sequences
@@ -313,7 +312,7 @@ Use [`karyoscope prep-bed`](prep-bed.md) to produce that BED from the formats an
 
 For complete worked examples, see the [database recipes](../recipes/).
 
-`prep-bed` is deliberately a **separate subcommand** rather than something `build` does for you: `build`'s contract stays "a final labelled BED", so it never has to sniff and guess at raw file formats. For the same reason `prep-bed` never gap-fills, flattens or drops sequences — `background:`, `flatten:` and `exclude:` below already do that, and doing it in both places would mean two places to get it wrong.
+`prep-bed` is a **separate subcommand** rather than a mode of `build`. That keeps `build`'s input contract to one thing — a final labelled BED — so it reads a single known format instead of identifying whichever the source annotation happened to use. It also keeps gap-filling, flattening and sequence exclusion in one place: `background:`, `flatten:` and `exclude:` below.
 
 ## Resource requirements
 
@@ -337,23 +336,25 @@ Measured runs, all with `-t 16` on one cluster node. Wall time is the whole comm
 > k=41, 51 and 61 is measurement noise, not a real effect of k — see below.
 > **Request ~1.5x the figure here**, e.g. 128 GB for a human build at k≤31.
 
-Three things follow, and the first two are easy to get wrong:
+Three things follow:
 
-### `--mem-gigas` is not a memory cap
+### `--mem-gigas` sets the SBWT construction budget
 
-It is the budget handed to SBWT construction, not a ceiling on the process. Every human-scale row above used `mem_gigas: 32` and still peaked far higher. **Do not size a job from `--mem-gigas`** — size it from this table, or use `--external-memory` (below).
+It is the allowance handed to the SBWT construction step, and total process memory runs well above it: every human-scale row above used `mem_gigas: 32` and peaked far higher. **Size a job from the table above**, or from `--external-memory` (below).
 
 ### Peak memory doubles above k=32, and is otherwise flat
 
-Peak RSS tracks *number of distinct k-mers × bytes per k-mer*, and has almost nothing to do with the size of the database produced — the k=11 build peaked at 72 GB while emitting a 19 MB index. The bytes-per-k-mer term is a step function: SBWT packs a k-mer into `⌈k/32⌉` 64-bit words, **padded**, so cost jumps at k=32, 64, 96, 128 and is flat between. That is why k=11/21/31 all sit near 70 GB and k=41/51/61 all sit near 148 GB — a k=41 k-mer occupies the same 16 bytes as a k=64 one.
+Peak RSS tracks *number of distinct k-mers × bytes per k-mer*; the size of the database produced is unrelated — the k=11 build peaked at 72 GB while emitting a 19 MB index. The bytes-per-k-mer term is a step function: SBWT packs a k-mer into `⌈k/32⌉` 64-bit words, **padded**, so cost jumps at k=32, 64, 96, 128 and is flat between. That is why k=11/21/31 all sit near 70 GB and k=41/51/61 all sit near 148 GB — a k=41 k-mer occupies the same 16 bytes as a k=64 one.
 
 Measured across the six builds above: roughly 70–82 GB for every k ≤ 31, and roughly 147–170 GB for every k ≥ 41 — flat within each band, with the spread inside a band being measurement noise rather than an effect of k.
 
 Practical consequence: **k ≤ 31 costs about half the RAM of k > 32**, and within a band, raising k is nearly free in memory.
 
-### Low on RAM? Use `--external-memory`, not fewer threads
+### `--external-memory` is the lever on a memory-limited machine
 
-Lowering `--threads` does **not** reduce peak memory — it only makes the build slower. `--external-memory DIR` is the lever, switching to the disk-based construction algorithm. Both measured on the CHM13 v2 six-set build at k=31:
+`--external-memory DIR` switches base-index construction to a disk-based algorithm: a **5.7× smaller memory footprint for ~1.4× the wall time**, producing the same index. It is what makes a human-scale build feasible on a workstation rather than a cluster node. Point `DIR` at a filesystem with room for the intermediates.
+
+`--threads` controls speed rather than memory. Both measured on the CHM13 v2 six-set build at k=31:
 
 | | Peak RSS | Wall |
 | --- | --- | --- |
@@ -362,10 +363,7 @@ Lowering `--threads` does **not** reduce peak memory — it only makes the build
 | `-t 1` | 74.8 GB | 1 h 40 m |
 | `-t 16 --external-memory` | **13.8 GB** | 32 m 27 s |
 
-Dropping from 16 threads to 1 costs **4.2x the wall time to save 4% of the
-memory** — so threads are not the lever, even at the extreme.
-
-`--external-memory` gives a **5.7× smaller memory footprint for ~1.4× the wall time**, and produces the same index. This is what makes a human-scale build feasible on a workstation rather than a cluster node. Point `DIR` at a filesystem with room for the intermediates.
+Dropping from 16 threads to 1 costs **4.2× the wall time and saves 4% of the memory**, so the thread count is worth setting for speed alone.
 
 ### Disk
 

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -185,9 +185,11 @@ done
 
 ## Preparing a feature-set BED
 
-`build` starts from a final BED; producing one is dataset-specific. A typical recipe is: take a reference annotation source (RepeatMasker, censat, GENCODE, EDTA, a satellite-monomer catalog, …), reduce it to a BED whose 4th column is the feature label, optionally priority-merge overlaps, and hand that BED to `build`. Overlaps and gaps are fine — `build` gap-fills automatically and HKS resolves overlaps per k-mer.
+`build` starts from a final BED whose 4th column is the feature label. Overlaps and gaps are fine — `build` gap-fills automatically and HKS resolves overlaps per k-mer.
 
-> **Planned: `karyoscope prep-bed`.** Turning those raw annotation sources into a final labelled BED — GFF3/GTF gene models into exon/intron/intergenic, RepeatMasker/EDTA tables into labelled repeat BEDs with a hierarchy, satellite monomer files into merged array bands — is the main friction in building a database today, and each source currently needs its own conversion. A dedicated `karyoscope prep-bed` helper for these common conversions is planned. It will be a **separate subcommand**, not folded into `build`: `build`'s contract stays "a final labelled BED", so it never has to sniff and guess at raw file formats.
+Use [`karyoscope prep-bed`](prep-bed.md) to produce that BED from the formats annotation usually arrives in: RepeatMasker and EDTA tables, GFF3/GTF gene models, UCSC cytoband tables, satellite monomer catalogs, and a plain `.fai`. It writes the BED and hierarchy and prints the `feature_sets:` stanza to paste (or append) here.
+
+`prep-bed` is deliberately a **separate subcommand** rather than something `build` does for you: `build`'s contract stays "a final labelled BED", so it never has to sniff and guess at raw file formats. For the same reason `prep-bed` never gap-fills, flattens or drops sequences — `background:`, `flatten:` and `exclude:` below already do that, and doing it in both places would mean two places to get it wrong.
 
 ## Resource requirements
 

--- a/docs/commands/info.md
+++ b/docs/commands/info.md
@@ -51,6 +51,12 @@ KS_dummy_test_v1
     region: 6 edges
 ```
 
+`k-mer` reports the query length, the index type, and the largest queryable
+length. On a `fixed` index — the default, and what a priority-resolved database
+is necessarily built as — `max` equals `size` and that one length is the only
+one `annotate` accepts. `max` is a range you may query within only when `type`
+is `variable`. See [build → Fixed-k and variable-k](build.md#fixed-k-and-variable-k).
+
 ## See also
 
 - [`karyoscope download`](download.md) — install databases

--- a/docs/commands/prep-bed.md
+++ b/docs/commands/prep-bed.md
@@ -114,6 +114,8 @@ The result tiles every sequence in `--lengths`, so the stanza sets `background: 
 
 Band labels keep their chromosome (`chr1` + `p36.33` → `1p36.33`) so no label is ambiguous across chromosomes, and the hierarchy nests three deep: chromosome → band group → band. A band with no sub-band (`1p33`) hangs directly off its chromosome.
 
+UCSC ships the band column bare in both shapes — the 5-column golden-path table and the 6-column `cytoBandMapped` BED, where the qualified name sits in a *separate* column that is ignored and rebuilt, so one code path serves both. A redistributed file that puts the qualified name in column 4 directly is also handled: a band already beginning with its own chromosome is left alone rather than becoming `11p36.33`. Bare cytogenetic bands always start with the arm, `p` or `q`, which is what makes the two safe to tell apart.
+
 The hierarchy is checked before anything is written — every band must be a node with a clean path to the root, and no label may be both a band and a group. That is far cheaper than discovering it part-way through a multi-hour `build`.
 
 ### `censat`

--- a/docs/commands/prep-bed.md
+++ b/docs/commands/prep-bed.md
@@ -166,3 +166,4 @@ karyoscope build --spec build.yaml
 ## See also
 
 - [`karyoscope build`](build.md) — turn these BEDs into an HKS database.
+- [Database recipes](../recipes/) — end-to-end worked examples, from download URL to built database.

--- a/docs/commands/prep-bed.md
+++ b/docs/commands/prep-bed.md
@@ -10,6 +10,7 @@ karyoscope prep-bed edta         --input FILE --output BED --hierarchy TSV [OPTI
 karyoscope prep-bed gff-gene     --input FILE --lengths FAI --output BED --hierarchy TSV [OPTIONS]
 karyoscope prep-bed cytoband     --input FILE --lengths FAI --output BED --hierarchy TSV [OPTIONS]
 karyoscope prep-bed fai          --lengths FAI --output BED [OPTIONS]
+karyoscope prep-bed censat       --input FILE --lengths FAI --output BED --hierarchy TSV [OPTIONS]
 karyoscope prep-bed satellite    --input FILE --lengths FAI --output BED --hierarchy TSV [OPTIONS]
 ```
 
@@ -26,6 +27,7 @@ There is one subcommand **per source format**, not per feature set. Unrelated fo
 | `gff-gene` | GFF3 or GTF gene models | `gene`: `exon` / `intron` / `intergenic` |
 | `cytoband` | UCSC `cytoBand.txt` or `cytoBandMapped` BED | `cytoband`: one leaf per band |
 | `fai` | samtools `.fai` | `chromosome`: one leaf per sequence |
+| `censat` | CenSat annotation BED | `region`: CenSat features plus `p_arm`/`q_arm` |
 | `satellite` | centromeric satellite monomers (GFF or BED) | `region`: satellite bands plus `p_arm`/`q_arm` |
 
 Each subcommand writes its BED (and, where the format implies one, a hierarchy) and prints the matching build-spec stanza. **The stanza goes to stdout and everything else to stderr**, so you can append it straight to a spec:
@@ -39,7 +41,7 @@ karyoscope prep-bed edta --input EDTA.TEanno.gff3.gz \
 
 It does not gap-fill, flatten overlaps, or drop sequences. `build` already owns all three — `background:`, `flatten:` and `exclude:` — and doing them twice would mean two places to get them wrong. So a converter emits only the bases its source annotates, and names the gap-fill label in the stanza rather than materialising it.
 
-The one exception is `satellite`, which does tile. That tiling is *semantic*, not a gap-fill: `p_arm` and `q_arm` have to be told apart, and only the satellite annotation knows where the centromere is. `build`'s gap-fill has exactly one label and could not make that distinction.
+The exceptions are `censat` and `satellite`, which do tile. That tiling is *semantic*, not a gap-fill: `p_arm` and `q_arm` have to be told apart, and only the annotation knows where the centromere is. `build`'s gap-fill has exactly one label and could not make that distinction.
 
 Sequences a set deliberately does not cover — `_alt`/`_random`/`_fix` scaffolds, `chrUn_*` contigs, organelles — are reported for the spec's top-level `exclude:` rather than given a placeholder label. Older hand-written sets used a literal `exclude` label for this; that predates `build`'s real `exclude:` list, and a placeholder label is worse because it claims the sequence for the feature set instead of leaving it uncovered.
 
@@ -81,6 +83,7 @@ Format-specific options of note:
 | `repeatmasker`, `edta`, `cytoband`, `satellite` | `--priority PATH` | Also write the tree as a 3-column priority file. |
 | `gff-gene` | `--feature-type TYPE` | Column-3 type read as an exon (default `exon`). |
 | `cytoband` | `--primary-pattern REGEX` | Which seqids carry banding (default `^chr([0-9]+\|X\|Y)$`). |
+| `censat` | `--priority PATH` | Priority file ranking centromeric over rDNA over arm. |
 | `satellite` | `--satellite LABEL` | Leaf label for the bands, e.g. `CEN180` or `aSat`. |
 | `satellite` | `--merge-gap N` | Merge monomers within N bases into one band (default 10). |
 | `satellite` | `--cluster-gap N` | Gap for clustering bands into the centromere core (default 500000). |
@@ -110,6 +113,16 @@ The result tiles every sequence in `--lengths`, so the stanza sets `background: 
 Band labels keep their chromosome (`chr1` + `p36.33` → `1p36.33`) so no label is ambiguous across chromosomes, and the hierarchy nests three deep: chromosome → band group → band. A band with no sub-band (`1p33`) hangs directly off its chromosome.
 
 The hierarchy is checked before anything is written — every band must be a node with a clean path to the root, and no label may be both a band and a group. That is far cheaper than discovering it part-way through a multi-hour `build`.
+
+### `censat`
+
+For assemblies with a CenSat annotation (human), which already names its features. CenSat qualifies every label with the specific arrays it contains — `gSat(TAR1)`, `hor(S1C10H1-B)` — so the part before the parenthesis is taken as the leaf, collapsing several hundred distinct values onto the 14 features the hierarchy names. Abutting rows that end up sharing a label are merged.
+
+The centromere is located from the `ct` (centromeric transition) features that bracket it: first `ct` start to last `ct` end. Where a sequence has no `ct`, the extent of all centromeric features is used instead. Everything outside the annotated features is then `p_arm` or `q_arm` by which side of that boundary it falls on — so pericentromeric remnants far out on an arm keep their own labels and only the gaps around them become arm.
+
+`--priority` writes the CenSat v2.1 ranking (centromeric 1, rDNA 2, arm 3), which is what the shipped CHM13 v2 `region` set was built with.
+
+Sequences with no CenSat annotation at all are left uncovered and reported for `exclude:`.
 
 ### `satellite`
 

--- a/docs/commands/prep-bed.md
+++ b/docs/commands/prep-bed.md
@@ -18,7 +18,7 @@ karyoscope prep-bed satellite    --input FILE --lengths FAI --output BED --hiera
 
 `build` starts from a final labelled BED. `prep-bed` produces one from the annotation formats those BEDs usually come from, so that step is a documented command rather than a bespoke script per dataset.
 
-There is one subcommand **per source format**, not per feature set. Unrelated formats produce the same kind of set — RepeatMasker output and an EDTA GFF3 both yield a `repeat` set but share no parsing at all — so keying on the format is what lets each subcommand carry exactly the options that apply to it, with no flags that are silently ignored depending on the input.
+There is one subcommand **per source format**, not per feature set. Unrelated formats produce the same kind of set — RepeatMasker output and an EDTA GFF3 both yield a `repeat` set but share no parsing at all — so keying on the format lets each subcommand carry exactly the options that apply to it, with no flags that are ignored depending on the input.
 
 | Subcommand | Input | Produces |
 | --- | --- | --- |
@@ -43,7 +43,7 @@ It does not gap-fill, flatten overlaps, or drop sequences. `build` already owns 
 
 The exceptions are `censat` and `satellite`, which do tile. That tiling is *semantic*, not a gap-fill: `p_arm` and `q_arm` have to be told apart, and only the annotation knows where the centromere is. `build`'s gap-fill has exactly one label and could not make that distinction.
 
-Sequences a set deliberately does not cover — `_alt`/`_random`/`_fix` scaffolds, `chrUn_*` contigs, organelles — are reported for the spec's top-level `exclude:` rather than given a placeholder label. Older hand-written sets used a literal `exclude` label for this; that predates `build`'s real `exclude:` list, and a placeholder label is worse because it claims the sequence for the feature set instead of leaving it uncovered.
+Sequences a set deliberately does not cover — `_alt`/`_random`/`_fix` scaffolds, `chrUn_*` contigs, organelles — are reported for the spec's top-level `exclude:` rather than given a placeholder label. Older hand-written sets used a literal `exclude` label for this, which predates `build`'s `exclude:` list. A label claims the sequence for the feature set; `exclude:` leaves it uncovered.
 
 ### Matching seqids to your assembly
 
@@ -58,7 +58,7 @@ Annotation seqids often differ from the assembly's. Two options, on every subcom
 
 `--hierarchy` is written wherever the source format implies one. `--colors` and `--priority` are optional and produced only when you name an output path.
 
-Colours are emitted only where an established KaryoScope palette exists — `repeatmasker`, `gff-gene` and `cytoband`. For those, the palette reproduces the shipped reference databases. For `edta` there is no such convention, so no colours are written and `build` assigns them, which beats an invented palette.
+Colours are emitted only where an established KaryoScope palette exists — `repeatmasker`, `gff-gene` and `cytoband`. For those, the palette reproduces the shipped reference databases. For `edta` there is no such convention, so no colours are written and `build` assigns them.
 
 Where a set has many leaves in few colours, the colours file also fills in `legend_group` (the optional 4th column) so the legend collapses. `cytoband` groups by Giemsa stain, turning several hundred bands into nine legend rows; `repeatmasker` groups the five RNA leaves, which share one colour. See [`build`'s legend section](build.md#grouping-the-legend).
 
@@ -94,11 +94,11 @@ Run `karyoscope prep-bed SUBCOMMAND --help` for the full list.
 
 ### `repeatmasker`
 
-Reads either the native `.out` table or the UCSC BED repackaging of it, detected from the file's own content and reported in the output. Sniffing is safe here in a way it would not be in `build`: both are the *same tool's* output, and the choice is reported rather than silently assumed.
+Reads either the native `.out` table or the UCSC BED repackaging of it. The dialect is detected from the file's own content and named in the output.
 
 Leaves are the RepeatMasker classes, with the `?` uncertainty marker stripped (`DNA?` is still `DNA`).
 
-A class the converter has no leaf for is labelled `other_repeat` and reported. It is deliberately **not** folded into `Unknown`: that is a real RepeatMasker class, meaning "RepeatMasker could not classify this element", and a class *we* cannot place is a different claim — the annotation is confident, we are the ones without a leaf for it. Nor is it dropped, which would leave those bases to the `nonrepeat` gap-fill and assert the opposite of what the annotation says. `other_repeat` joins the hierarchy and the palette only when something actually lands on it, so a file whose classes are all recognised produces the reference tree unchanged.
+A class the converter has no leaf for is labelled `other_repeat` and reported. It is not folded into `Unknown`, which is a real RepeatMasker class meaning the element could not be classified — a distinct case from a class this converter has no leaf for. It is also not dropped, which would leave those bases to the `nonrepeat` gap-fill. `other_repeat` joins the hierarchy and the palette only when something lands on it, so a file whose classes are all recognised produces the reference tree unchanged.
 
 ### `gff-gene`
 
@@ -114,9 +114,9 @@ The result tiles every sequence in `--lengths`, so the stanza sets `background: 
 
 Band labels keep their chromosome (`chr1` + `p36.33` → `1p36.33`) so no label is ambiguous across chromosomes, and the hierarchy nests three deep: chromosome → band group → band. A band with no sub-band (`1p33`) hangs directly off its chromosome.
 
-UCSC ships the band column bare in both shapes — the 5-column golden-path table and the 6-column `cytoBandMapped` BED, where the qualified name sits in a *separate* column that is ignored and rebuilt, so one code path serves both. A redistributed file that puts the qualified name in column 4 directly is also handled: a band already beginning with its own chromosome is left alone rather than becoming `11p36.33`. Bare cytogenetic bands always start with the arm, `p` or `q`, which is what makes the two safe to tell apart.
+UCSC ships the band column bare in both shapes — the 5-column golden-path table and the 6-column `cytoBandMapped` BED, where the qualified name sits in a *separate* column that is ignored and rebuilt, so one code path serves both. A file that puts the qualified name in column 4 directly is also handled: a band already beginning with its own chromosome is left alone, rather than becoming `11p36.33`. Bare cytogenetic bands always start with the arm, `p` or `q`, which distinguishes the two cases.
 
-The hierarchy is checked before anything is written — every band must be a node with a clean path to the root, and no label may be both a band and a group. That is far cheaper than discovering it part-way through a multi-hour `build`.
+The hierarchy is checked before anything is written: every band must be a node with a clean path to the root, and no label may be both a band and a group.
 
 ### `censat`
 
@@ -132,7 +132,7 @@ Sequences with no CenSat annotation at all are left uncovered and reported for `
 
 Monomers within `--merge-gap` coalesce into bands; the default bridges the 1–2 bp monomer-boundary artefacts tandem-repeat finders emit without swallowing real interior insertions, which run to kilobases. Bands then cluster within `--cluster-gap` and the **densest** cluster is taken as the centromere core — a raw min-to-max extent would be dragged across the arm by scattered pericentromeric remnants.
 
-Arms are assigned by coordinate, so this assumes the assembly is oriented short-arm-first. The labels `p_arm` and `q_arm` are load-bearing: `centromere_detection` treats anything else as the centromere catch-all.
+Arms are assigned by coordinate, so this assumes the assembly is oriented short-arm-first. Keep the labels `p_arm` and `q_arm`: `centromere_detection` treats anything else as the centromere catch-all.
 
 Input coordinates follow the file suffix — `.gff`/`.gff3` are read 1-based inclusive, anything else 0-based half-open.
 

--- a/docs/commands/prep-bed.md
+++ b/docs/commands/prep-bed.md
@@ -1,0 +1,155 @@
+# karyoscope prep-bed
+
+Convert a source annotation into the feature-set BED that [`karyoscope build`](build.md) consumes.
+
+## Synopsis
+
+```
+karyoscope prep-bed repeatmasker --input FILE --output BED --hierarchy TSV [OPTIONS]
+karyoscope prep-bed edta         --input FILE --output BED --hierarchy TSV [OPTIONS]
+karyoscope prep-bed gff-gene     --input FILE --lengths FAI --output BED --hierarchy TSV [OPTIONS]
+karyoscope prep-bed cytoband     --input FILE --lengths FAI --output BED --hierarchy TSV [OPTIONS]
+karyoscope prep-bed fai          --lengths FAI --output BED [OPTIONS]
+karyoscope prep-bed satellite    --input FILE --lengths FAI --output BED --hierarchy TSV [OPTIONS]
+```
+
+## Description
+
+`build` starts from a final labelled BED. `prep-bed` produces one from the annotation formats those BEDs usually come from, so that step is a documented command rather than a bespoke script per dataset.
+
+There is one subcommand **per source format**, not per feature set. Unrelated formats produce the same kind of set — RepeatMasker output and an EDTA GFF3 both yield a `repeat` set but share no parsing at all — so keying on the format is what lets each subcommand carry exactly the options that apply to it, with no flags that are silently ignored depending on the input.
+
+| Subcommand | Input | Produces |
+| --- | --- | --- |
+| `repeatmasker` | RepeatMasker `.out` or the UCSC BED repackaging | `repeat`: one leaf per RepeatMasker class |
+| `edta` | EDTA TE GFF3 | `repeat`: one leaf per TE superfamily |
+| `gff-gene` | GFF3 or GTF gene models | `gene`: `exon` / `intron` / `intergenic` |
+| `cytoband` | UCSC `cytoBand.txt` or `cytoBandMapped` BED | `cytoband`: one leaf per band |
+| `fai` | samtools `.fai` | `chromosome`: one leaf per sequence |
+| `satellite` | centromeric satellite monomers (GFF or BED) | `region`: satellite bands plus `p_arm`/`q_arm` |
+
+Each subcommand writes its BED (and, where the format implies one, a hierarchy) and prints the matching build-spec stanza. **The stanza goes to stdout and everything else to stderr**, so you can append it straight to a spec:
+
+```bash
+karyoscope prep-bed edta --input EDTA.TEanno.gff3.gz \
+    --output repeat.bed --hierarchy repeat.tsv >> build.yaml
+```
+
+### What prep-bed does not do
+
+It does not gap-fill, flatten overlaps, or drop sequences. `build` already owns all three — `background:`, `flatten:` and `exclude:` — and doing them twice would mean two places to get them wrong. So a converter emits only the bases its source annotates, and names the gap-fill label in the stanza rather than materialising it.
+
+The one exception is `satellite`, which does tile. That tiling is *semantic*, not a gap-fill: `p_arm` and `q_arm` have to be told apart, and only the satellite annotation knows where the centromere is. `build`'s gap-fill has exactly one label and could not make that distinction.
+
+Sequences a set deliberately does not cover — `_alt`/`_random`/`_fix` scaffolds, `chrUn_*` contigs, organelles — are reported for the spec's top-level `exclude:` rather than given a placeholder label. Older hand-written sets used a literal `exclude` label for this; that predates `build`'s real `exclude:` list, and a placeholder label is worse because it claims the sequence for the feature set instead of leaving it uncovered.
+
+### Matching seqids to your assembly
+
+Annotation seqids often differ from the assembly's. Two options, on every subcommand:
+
+- `--seqid-map FILE` — a two-column `old new` table, for accession-style names (`NC_060925.1` → `chr1`).
+- `--rename-prefix OLD:NEW` — a leading-prefix rewrite, for systematic differences (`Col-CEN_chr` → `Chr`). Names not starting with `OLD` are left alone.
+
+`--seqid-map` takes precedence where both apply. Converters that take `--lengths` report any annotation seqid absent from the `.fai`, so a mismatch surfaces as a warning rather than an empty output.
+
+### Hierarchies, colours and priorities
+
+`--hierarchy` is written wherever the source format implies one. `--colors` and `--priority` are optional and produced only when you name an output path.
+
+Colours are emitted only where an established KaryoScope palette exists — `repeatmasker`, `gff-gene` and `cytoband`. For those, the palette reproduces the shipped reference databases. For `edta` there is no such convention, so no colours are written and `build` assigns them, which beats an invented palette.
+
+Where a set has many leaves in few colours, the colours file also fills in `legend_group` (the optional 4th column) so the legend collapses. `cytoband` groups by Giemsa stain, turning several hundred bands into nine legend rows; `repeatmasker` groups the five RNA leaves, which share one colour. See [`build`'s legend section](build.md#grouping-the-legend).
+
+## Options
+
+Common to every subcommand:
+
+| Option | Description |
+| --- | --- |
+| `--output PATH` | Output feature-set BED. Required. |
+| `--hierarchy PATH` | Output `child<TAB>parent` hierarchy. Required except on `fai`, where it is optional. |
+| `--name NAME` | Feature-set name used in the printed stanza. Defaults to the conventional name for the format. |
+| `--seqid-map PATH` | Two-column `old new` seqid table. |
+| `--rename-prefix OLD:NEW` | Leading-prefix seqid rewrite. |
+| `--force` | Overwrite existing outputs. Without it, `prep-bed` refuses rather than clobbering. |
+
+Format-specific options of note:
+
+| Subcommand | Option | Description |
+| --- | --- | --- |
+| `repeatmasker`, `edta` | `--background LABEL` | Gap-fill label named in the stanza (default `nonrepeat`). |
+| `repeatmasker`, `edta`, `cytoband`, `satellite` | `--priority PATH` | Also write the tree as a 3-column priority file. |
+| `gff-gene` | `--feature-type TYPE` | Column-3 type read as an exon (default `exon`). |
+| `cytoband` | `--primary-pattern REGEX` | Which seqids carry banding (default `^chr([0-9]+\|X\|Y)$`). |
+| `satellite` | `--satellite LABEL` | Leaf label for the bands, e.g. `CEN180` or `aSat`. |
+| `satellite` | `--merge-gap N` | Merge monomers within N bases into one band (default 10). |
+| `satellite` | `--cluster-gap N` | Gap for clustering bands into the centromere core (default 500000). |
+
+Run `karyoscope prep-bed SUBCOMMAND --help` for the full list.
+
+## Notes on individual converters
+
+### `repeatmasker`
+
+Reads either the native `.out` table or the UCSC BED repackaging of it, detected from the file's own content and reported in the output. Sniffing is safe here in a way it would not be in `build`: both are the *same tool's* output, and the choice is reported rather than silently assumed.
+
+Leaves are the RepeatMasker classes, with the `?` uncertainty marker stripped (`DNA?` is still `DNA`). A class the converter does not recognise is labelled `Unknown` — RepeatMasker's own catch-all — and reported, rather than dropped. Dropping it would leave those bases to the `nonrepeat` gap-fill, which asserts the opposite of what the annotation says.
+
+### `gff-gene`
+
+Exons are read directly; introns are derived **per transcript** as the gaps between that transcript's consecutive exons; everything else is intergenic. Where transcripts disagree about a base the more specific label wins — `exon` over `intron` over `intergenic` — so alternative splicing never double-labels a base.
+
+Deriving introns from a chromosome-wide exon list instead, rather than per transcript, makes every gap between neighbouring *genes* an intron. On a compact genome the error is large: it moves *A. thaliana* from ~21% intron to ~42%.
+
+Only records of `--feature-type` (default `exon`) are read. If your annotation puts UTRs in separate `five_prime_UTR`/`three_prime_UTR` records with no matching `exon`, those bases are not exonic.
+
+The result tiles every sequence in `--lengths`, so the stanza sets `background: null`.
+
+### `cytoband`
+
+Band labels keep their chromosome (`chr1` + `p36.33` → `1p36.33`) so no label is ambiguous across chromosomes, and the hierarchy nests three deep: chromosome → band group → band. A band with no sub-band (`1p33`) hangs directly off its chromosome.
+
+The hierarchy is checked before anything is written — every band must be a node with a clean path to the root, and no label may be both a band and a group. That is far cheaper than discovering it part-way through a multi-hour `build`.
+
+### `satellite`
+
+Monomers within `--merge-gap` coalesce into bands; the default bridges the 1–2 bp monomer-boundary artefacts tandem-repeat finders emit without swallowing real interior insertions, which run to kilobases. Bands then cluster within `--cluster-gap` and the **densest** cluster is taken as the centromere core — a raw min-to-max extent would be dragged across the arm by scattered pericentromeric remnants.
+
+Arms are assigned by coordinate, so this assumes the assembly is oriented short-arm-first. The labels `p_arm` and `q_arm` are load-bearing: `centromere_detection` treats anything else as the centromere catch-all.
+
+Input coordinates follow the file suffix — `.gff`/`.gff3` are read 1-based inclusive, anything else 0-based half-open.
+
+### `fai`
+
+One whole-length record per sequence, labelled with its own name, in the `.fai`'s own order. No grouping hierarchy is derived: how sequences group (autosome vs sex vs organelle, metacentric vs acrocentric, haplotype) is organism-specific curation a `.fai` cannot supply. `--hierarchy` gives a flat list to edit by hand.
+
+Keep non-karyotype sequences out with `build`'s `exclude:`, not by filtering here, so every feature set agrees about what exists.
+
+## Examples
+
+```bash
+# A repeat set from RepeatMasker, with the reference palette and legend groups
+karyoscope prep-bed repeatmasker --input CHM13.RepeatMasker.bed \
+    --output repeat.bed --hierarchy repeat.tsv --colors repeat_colors.tsv
+
+# A gene set from a RefSeq GTF whose seqids are accessions
+karyoscope prep-bed gff-gene --input CHM13.gtf.gz --lengths CHM13.fa.gz.fai \
+    --seqid-map refseq_to_chr.tsv --output gene.bed --hierarchy gene.tsv
+
+# A cytoband set, appending the stanza (and its exclude: list) to a spec
+karyoscope prep-bed cytoband --input hg38.cytoBand.txt.gz --lengths hg38.fa.fai \
+    --output cytoband.bed --hierarchy cytoband.tsv \
+    --colors cytoband_colors.tsv >> build.yaml
+
+# A centromeric region set for a non-human assembly
+karyoscope prep-bed satellite --input ColCEN_CEN180.gff3 --lengths ColCEN.fa.gz.fai \
+    --satellite CEN180 --rename-prefix Col-CEN_chr:Chr \
+    --output region.bed --hierarchy region.tsv
+
+# Then build from the assembled spec
+karyoscope build --spec build.yaml
+```
+
+## See also
+
+- [`karyoscope build`](build.md) — turn these BEDs into an HKS database.

--- a/docs/commands/prep-bed.md
+++ b/docs/commands/prep-bed.md
@@ -96,7 +96,9 @@ Run `karyoscope prep-bed SUBCOMMAND --help` for the full list.
 
 Reads either the native `.out` table or the UCSC BED repackaging of it, detected from the file's own content and reported in the output. Sniffing is safe here in a way it would not be in `build`: both are the *same tool's* output, and the choice is reported rather than silently assumed.
 
-Leaves are the RepeatMasker classes, with the `?` uncertainty marker stripped (`DNA?` is still `DNA`). A class the converter does not recognise is labelled `Unknown` — RepeatMasker's own catch-all — and reported, rather than dropped. Dropping it would leave those bases to the `nonrepeat` gap-fill, which asserts the opposite of what the annotation says.
+Leaves are the RepeatMasker classes, with the `?` uncertainty marker stripped (`DNA?` is still `DNA`).
+
+A class the converter has no leaf for is labelled `other_repeat` and reported. It is deliberately **not** folded into `Unknown`: that is a real RepeatMasker class, meaning "RepeatMasker could not classify this element", and a class *we* cannot place is a different claim — the annotation is confident, we are the ones without a leaf for it. Nor is it dropped, which would leave those bases to the `nonrepeat` gap-fill and assert the opposite of what the annotation says. `other_repeat` joins the hierarchy and the palette only when something actually lands on it, so a file whose classes are all recognised produces the reference tree unchanged.
 
 ### `gff-gene`
 

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -23,11 +23,11 @@ For **gzipped** files, compare the checksum of the *decompressed* content as wel
 zcat <file.gz> | sha256sum
 ```
 
-This matters more than it looks. Re-compressing a file changes its bytes without changing a single base, so a `.gz` checksum mismatch may mean nothing at all — while a matching *content* checksum is proof. The CHM13 genome is exactly this case: the copy these databases were built from was re-bgzipped locally, so its `.gz` never matched upstream.
+Re-compressing a file changes its bytes without changing a base, so a `.gz` checksum mismatch does not by itself indicate different content, while a matching content checksum does indicate the same content. The CHM13 genome is such a case: the copy these databases were built from was re-bgzipped locally, so its `.gz` does not match upstream.
 
-## Two traps worth knowing about
+## Before substituting an input
 
-**The same annotation is often published more than once, in more than one form.** Two real examples, both of which silently produce a *different* feature set rather than an error:
+**The same annotation is often published more than once, in more than one form.** Two examples, each of which produces a *different* feature set rather than an error:
 
 - The T2T bucket's `chm13v2.0_RepeatMasker_4.1.2p1.2022Apr14.bed` and UCSC's `chm13v2.0_rmsk.bb` are the same RepeatMasker run. The first lists one row per *fragment*; the second joins fragments into blocked records. The CHM13 `repeat` set uses the second.
 - The Col-CEN gene annotation exists as GTF-style attributes on GitHub and GFF3-style on TAIR. Same content; only the punctuation differs.
@@ -51,4 +51,4 @@ Every other hierarchy and priority file in these recipes is written by `prep-bed
 
 ## A note on exact reproduction
 
-These recipes rebuild the feature sets, and the BEDs they produce are byte-identical to the ones the shipped databases were built from — with one deliberate exception, described in each recipe: the shipped BEDs label the mitochondrion with a literal `exclude` *label*, a convention that predates `build`'s `exclude:` list. The recipes use `exclude:`, which is better: a label claims the sequence for the feature set, whereas `exclude:` leaves it genuinely uncovered so it reads as `none` everywhere.
+These recipes rebuild the feature sets, and the BEDs they produce are byte-identical to the ones the shipped databases were built from — with one deliberate exception, described in each recipe: the shipped BEDs label the mitochondrion with a literal `exclude` *label*, a convention that predates `build`'s `exclude:` list. The recipes use `exclude:`. A label claims the sequence for the feature set; `exclude:` leaves it uncovered, so it reads as `none` everywhere.

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -36,13 +36,19 @@ This is why every input here is pinned by checksum rather than by name.
 
 **A file's coordinates belong to a specific assembly.** An annotation built on a different version of "the same" genome produces coordinates that are in-bounds and plausible but subtly wrong. If you substitute an input, verify the assembly identity by comparing per-sequence sequence md5, not by spot-checking that a feature lands somewhere sensible.
 
-## What these recipes do not cover
+## Supporting files
 
-- The `cytoband` databases.
-- The CHM13 `acrocentric` and `subtelomeric` feature sets.
+[`files/`](files/) holds the few inputs that nothing derives, because they encode curation or a naming convention rather than data:
+
+| File | Used by |
+| --- | --- |
+| `chm13v2_chromosome.hierarchy.txt` | which human chromosomes are metacentric / submetacentric / acrocentric / sex |
+| `colcen_chromosome.hierarchy.txt` | which Col-CEN sequences are nuclear |
+| `chm13v2_repeat.priority.txt` | the published order in which repeat classes win an overlap |
+| `chm13v2_refseq_to_chr.tsv` | RefSeq accession → chromosome name |
+
+Every other hierarchy and priority file in these recipes is written by `prep-bed` as it converts, so there is nothing to supply.
 
 ## A note on exact reproduction
 
 These recipes rebuild the feature sets, and the BEDs they produce are byte-identical to the ones the shipped databases were built from — with one deliberate exception, described in each recipe: the shipped BEDs label the mitochondrion with a literal `exclude` *label*, a convention that predates `build`'s `exclude:` list. The recipes use `exclude:`, which is better: a label claims the sequence for the feature set, whereas `exclude:` leaves it genuinely uncovered so it reads as `none` everywhere.
-
-The CHM13 `repeat` set has one further difference, noted in that recipe.

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -1,0 +1,48 @@
+# Database recipes
+
+Complete, runnable recipes for rebuilding KaryoScope databases from published source annotations — starting from the download.
+
+| Recipe | Database | Feature sets |
+| --- | --- | --- |
+| [human-chm13v2.md](human-chm13v2.md) | `HKS_human_CHM13_v2` | `chromosome`, `region`, `repeat`, `gene` |
+| [arabidopsis-colcen.md](arabidopsis-colcen.md) | `HKS_arabidopsis_ColCEN` | `chromosome`, `region`, `repeat`, `gene` |
+
+Each recipe gives the exact download URL for every input, a checksum to verify it, the [`prep-bed`](../commands/prep-bed.md) command that converts it, and the [`build`](../commands/build.md) spec that assembles the result.
+
+## Verify your downloads
+
+Every input below is pinned by SHA-256. Check one with:
+
+```bash
+sha256sum <file>
+```
+
+For **gzipped** files, compare the checksum of the *decompressed* content as well as the file:
+
+```bash
+zcat <file.gz> | sha256sum
+```
+
+This matters more than it looks. Re-compressing a file changes its bytes without changing a single base, so a `.gz` checksum mismatch may mean nothing at all — while a matching *content* checksum is proof. The CHM13 genome is exactly this case: the copy these databases were built from was re-bgzipped locally, so its `.gz` never matched upstream.
+
+## Two traps worth knowing about
+
+**The same annotation is often published more than once, in more than one form.** Two real examples, both of which silently produce a *different* feature set rather than an error:
+
+- The T2T bucket's `chm13v2.0_RepeatMasker_4.1.2p1.2022Apr14.bed` and UCSC's `chm13v2.0_rmsk.bb` are the same RepeatMasker run. The first lists one row per *fragment*; the second joins fragments into blocked records. The CHM13 `repeat` set uses the second.
+- The Col-CEN gene annotation exists as GTF-style attributes on GitHub and GFF3-style on TAIR. Same content; only the punctuation differs.
+
+This is why every input here is pinned by checksum rather than by name.
+
+**A file's coordinates belong to a specific assembly.** An annotation built on a different version of "the same" genome produces coordinates that are in-bounds and plausible but subtly wrong. If you substitute an input, verify the assembly identity by comparing per-sequence sequence md5, not by spot-checking that a feature lands somewhere sensible.
+
+## What these recipes do not cover
+
+- The `cytoband` databases.
+- The CHM13 `acrocentric` and `subtelomeric` feature sets.
+
+## A note on exact reproduction
+
+These recipes rebuild the feature sets, and the BEDs they produce are byte-identical to the ones the shipped databases were built from — with one deliberate exception, described in each recipe: the shipped BEDs label the mitochondrion with a literal `exclude` *label*, a convention that predates `build`'s `exclude:` list. The recipes use `exclude:`, which is better: a label claims the sequence for the feature set, whereas `exclude:` leaves it genuinely uncovered so it reads as `none` everywhere.
+
+The CHM13 `repeat` set has one further difference, noted in that recipe.

--- a/docs/recipes/arabidopsis-colcen.md
+++ b/docs/recipes/arabidopsis-colcen.md
@@ -1,0 +1,181 @@
+# Recipe: `HKS_arabidopsis_ColCEN`
+
+Rebuild the *Arabidopsis thaliana* Col-CEN (T2T v1.2) database in full: `chromosome`, `region`, `repeat` and `gene`.
+
+This is the whole database, and it is the cheap one — a 135 Mb genome, about 50 s to build at `-t 16` and ~6 GB peak RSS. It is the best recipe to try first, and a worked example of building KaryoScope for a non-human organism.
+
+**Requirements:** `karyoscope`, `samtools`, `hks`.
+
+## 1. Genome
+
+```bash
+curl -L -o Col-CEN_v1.2.fasta.gz \
+  https://raw.githubusercontent.com/schatzlab/Col-CEN/main/v1.2/Col-CEN_v1.2.fasta.gz
+# sha256: b059bf9b589a7a6cd13c67179b80293b91809c3c61cb8b9393a518619d8b5fa8
+
+samtools faidx Col-CEN_v1.2.fasta.gz
+```
+
+Seven sequences: `Chr1`–`Chr5`, plus the mitochondrion `ChrM` and chloroplast `ChrC`.
+
+## 2. `chromosome`
+
+```bash
+karyoscope prep-bed fai \
+    --lengths Col-CEN_v1.2.fasta.gz.fai \
+    --output ath_chromosome.bed
+```
+
+<sub>`ath_chromosome.bed` → `28fb5d5a098ac105be5e2052ef53932e5c47d5817a97757f6e6c8c403b284b9b` (7 rows)</sub>
+
+The organelles are excluded at build time rather than filtered here, so every feature set agrees about which sequences exist.
+
+The nuclear chromosomes are then grouped by hand. This is curation — nothing in a `.fai` says which sequences are nuclear — so `prep-bed` does not invent it:
+
+```bash
+cat > ath_chromosome.hierarchy.txt <<'EOF'
+nuclear	categorized
+Chr1	nuclear
+Chr2	nuclear
+Chr3	nuclear
+Chr4	nuclear
+Chr5	nuclear
+EOF
+```
+
+## 3. `region` — CEN180 centromeric satellite
+
+The CEN180 monomer catalog comes from TAIR. Note the endpoint: `/download/file?path=…` is the *web page*, and returns an HTML shell. The file itself is served from `/api/download-files/download?filePath=…`.
+
+```bash
+curl -L -o ColCEN_CEN180.gff3 \
+  "https://www.arabidopsis.org/api/download-files/download?filePath=Genes/Col-CEN_genome_assembly_release/ColCEN_CEN180.gff3"
+# sha256: ccf54c224050a16dc65362623eee90621e803402bb95f8e7c191444028abedd1
+
+karyoscope prep-bed satellite \
+    --input ColCEN_CEN180.gff3 \
+    --lengths Col-CEN_v1.2.fasta.gz.fai \
+    --satellite CEN180 \
+    --rename-prefix Col-CEN_chr:Chr \
+    --output ath_region.bed \
+    --hierarchy ath_region.tsv
+```
+
+<sub>`ath_region.bed` → `339e5e7e6a74bc6c41adb3b0972f3e02d0b695051909030e685f2e2abdcc7a7d` (2,041 rows)</sub>
+
+Three things are worth understanding here, because each is a general problem rather than an Arabidopsis quirk:
+
+- **`--rename-prefix` is required.** This file names sequences `Col-CEN_chr1`, the genome names them `Chr1`. Without the rewrite nothing matches and the feature set comes out empty.
+- **It is a monomer catalog, not a feature annotation.** Unlike human CenSat it says only "CEN180 monomer here", 66,131 times. `prep-bed satellite` merges monomers within `--merge-gap` (default 10 bp, which bridges the 1–2 bp monomer-boundary artefacts tandem-repeat finders emit without swallowing real kilobase-scale insertions), then takes the densest cluster of bands as the centromere. A raw min-to-max extent would be dragged across the arm by scattered pericentromeric remnants.
+- **The file has an uncommented header row.** `prep-bed` skips rows whose coordinates are not integers, so it is handled — but `grep -v '^#'` alone would let a junk record through.
+
+Arms are assigned by coordinate, which assumes short-arm-first orientation.
+
+## 4. `repeat` — EDTA transposons
+
+```bash
+curl -L -o EDTA.TEanno.gff3.gz \
+  https://raw.githubusercontent.com/schatzlab/Col-CEN/main/v1.2/t2t-col.20201227.fasta.mod.EDTA.TEanno.gff3.gz
+# sha256: d209f344edd10e9e37da498b6625454a0472e24ff975c0979d3d12763cb6bcd6
+
+karyoscope prep-bed edta \
+    --input EDTA.TEanno.gff3.gz \
+    --output ath_repeat.bed \
+    --hierarchy ath_repeat.tsv
+```
+
+<sub>`ath_repeat.bed` → `0ec9610c801e5edd4785f0ad9949e3092e09a033f7d4e35b72347c2e7f9eafd4` (42,927 rows)</sub>
+
+EDTA's `Classification=` vocabulary aliases each superfamily under both spelled-out and Wicker three-letter names — `DNA/HAT` and `DNA/DTA` are both hAT — so `prep-bed` normalises them to one leaf per superfamily, keeping the BED labels and the hierarchy leaves consistent by construction.
+
+No colours file is emitted: there is no established KaryoScope palette for the EDTA vocabulary, and `build`'s automatic assignment beats an invented one.
+
+## 5. `gene` — Araport11
+
+```bash
+curl -L -o Col-CEN_v1.2_genes.araport11.gff3.gz \
+  https://raw.githubusercontent.com/schatzlab/Col-CEN/main/v1.2/Col-CEN_v1.2_genes.araport11.gff3.gz
+# sha256: baa6ad8aa24f098e4e957682ba945da15fa3736eaacceb02b9a2f5de4ec86e8f
+
+karyoscope prep-bed gff-gene \
+    --input Col-CEN_v1.2_genes.araport11.gff3.gz \
+    --lengths Col-CEN_v1.2.fasta.gz.fai \
+    --output ath_gene.bed \
+    --hierarchy ath_gene.tsv
+```
+
+<sub>`ath_gene.bed` → `52e8059b9275f65135495d6406b5d7bb5be3758935754cc58ced5aa49fbcd142` (284,461 rows)</sub>
+
+Two notes:
+
+- Despite the `.gff3` extension this file uses **GTF-style attributes** (`transcript_id "AT1G01010";`). `prep-bed` reads both syntaxes, so it needs no flag. TAIR publishes the same annotation with true GFF3 attributes as `ColCEN_GENES_Araport11.gff3.gz`; either produces this identical output.
+- Introns are derived **per transcript**, from that transcript's own consecutive exons. Deriving them from a merged exon list instead makes every gap between neighbouring genes an intron, which on a compact genome like this one is the difference between ~21% and ~42% intron. The result tiles every sequence, so no gap-fill.
+
+## 6. Build
+
+```yaml
+# build.yaml
+id: HKS_arabidopsis_ColCEN
+version: "1.1.0"
+sequence: Col-CEN_v1.2.fasta.gz
+kmer:
+  s: 31
+build:
+  threads: 16
+  mem_gigas: 8
+# Organelles are real sequence but not karyotype chromosomes. Excluding them
+# from the whole build means no feature set covers them, so they read as "none"
+# uniformly rather than appearing as chromosomes.
+exclude: [ChrM, ChrC]
+feature_sets:
+  - name: chromosome
+    bed: ath_chromosome.bed
+    hierarchy: ath_chromosome.hierarchy.txt
+    background: null            # already tiles every base
+  - name: region
+    bed: ath_region.bed
+    hierarchy: ath_region.tsv
+    background: null            # the CEN180 + arm split tiles every base
+  - name: repeat
+    bed: ath_repeat.bed
+    hierarchy: ath_repeat.tsv
+    background: nonrepeat
+  - name: gene
+    bed: ath_gene.bed            # no hierarchy: the three labels are a flat star,
+    background: null             # which build derives on its own
+roles:
+  chromosome_assignment: chromosome
+  region_assignment: region
+  centromere_detection: region
+smoothing:
+  recommended_window_bp: 1000
+```
+
+```bash
+karyoscope build --spec build.yaml
+karyoscope info HKS_arabidopsis_ColCEN
+```
+
+This recipe has been run end to end from the URLs above, on nothing but the
+downloaded files: all four BEDs match the checksums given here, and all five
+index files — the shared base index and one per feature set — come out
+bit-identical to the database in use.
+
+The `region` set's arm labels are load-bearing: centromere detection reads anything that is not `p_arm`/`q_arm`/`arm`/`telomere`/`novel` as the centromere catch-all, so `CEN180` and `cen_gap` must be leaves.
+
+## 7. Render a karyotype
+
+```bash
+karyoscope karyotype -i Col-CEN_v1.2=Col-CEN_v1.2.fasta.gz \
+    --db HKS_arabidopsis_ColCEN \
+    --sample-label Col-CEN_v1.2 --telo-motif CCCTAAA \
+    --sex unknown --format svg --format png -t 16 -o out/
+```
+
+`--telo-motif CCCTAAA` matters: plant telomeres are `TTTAGGG`, and the human default finds none. See [`examples/karyotypes/`](../../examples/karyotypes/) for what this produces.
+
+## See also
+
+- [`karyoscope prep-bed`](../commands/prep-bed.md)
+- [`karyoscope build`](../commands/build.md)
+- [Recipe: human CHM13v2](human-chm13v2.md)

--- a/docs/recipes/arabidopsis-colcen.md
+++ b/docs/recipes/arabidopsis-colcen.md
@@ -121,7 +121,7 @@ sha256sum ath_gene.bed
 # 52e8059b9275f65135495d6406b5d7bb5be3758935754cc58ced5aa49fbcd142   (284,461 rows)
 ```
 
-`prep-bed` writes a hierarchy file too, but the build spec below leaves it out: `exon`/`intron`/`intergenic` is a flat star that `build` derives on its own, and omitting it is how the shipped database was built.
+`prep-bed` writes the hierarchy file itself — there is nothing to supply.
 
 Two notes:
 
@@ -133,7 +133,7 @@ Two notes:
 ```yaml
 # build.yaml
 id: HKS_arabidopsis_ColCEN
-version: "1.1.0"
+version: "1.2.0"
 sequence: Col-CEN_v1.2.fasta.gz
 kmer:
   s: 31
@@ -159,6 +159,7 @@ feature_sets:
     background: nonrepeat
   - name: gene
     bed: ath_gene.bed
+    hierarchy: ath_gene.tsv
     background: null            # exon/intron/intergenic tiles every base
 roles:
   chromosome_assignment: chromosome

--- a/docs/recipes/arabidopsis-colcen.md
+++ b/docs/recipes/arabidopsis-colcen.md
@@ -35,7 +35,7 @@ sha256sum ath_chromosome.bed
 
 The organelles are excluded at build time rather than filtered here, so every feature set agrees about which sequences exist.
 
-Grouping the five nuclear chromosomes is curation — nothing in a `.fai` says which sequences are nuclear — so it is provided rather than derived:
+Grouping the five nuclear chromosomes is curation — nothing in a `.fai` says which sequences are nuclear — so it is provided rather than derived, and passed to [the build](#6-build) below:
 
 ```bash
 cp docs/recipes/files/colcen_chromosome.hierarchy.txt .
@@ -43,7 +43,7 @@ cp docs/recipes/files/colcen_chromosome.hierarchy.txt .
 
 ## 3. `region` — CEN180 centromeric satellite
 
-The CEN180 monomer catalog comes from TAIR. Note the endpoint: `/download/file?path=…` is the *web page*, and returns an HTML shell. The file itself is served from `/api/download-files/download?filePath=…`.
+The CEN180 monomer catalog comes from TAIR.
 
 ```bash
 curl -L -o ColCEN_CEN180.gff3 \
@@ -68,11 +68,10 @@ sha256sum ath_region.bed
 
 `prep-bed` writes the hierarchy file itself — there is nothing to supply.
 
-Three details, none of them specific to Arabidopsis:
+Two details:
 
-- **`--rename-prefix` is required.** This file names sequences `Col-CEN_chr1`, the genome names them `Chr1`. Without the rewrite nothing matches and the feature set comes out empty.
-- **It is a monomer catalog, not a feature annotation.** Unlike human CenSat it says only "CEN180 monomer here", 66,131 times. `prep-bed satellite` merges monomers within `--merge-gap` (default 10 bp, which bridges the 1–2 bp monomer-boundary artefacts tandem-repeat finders emit without swallowing real kilobase-scale insertions), then takes the densest cluster of bands as the centromere. A raw min-to-max extent would be dragged across the arm by scattered pericentromeric remnants.
-- **The file has an uncommented header row.** `prep-bed` skips rows whose coordinates are not integers, so it is handled — but `grep -v '^#'` alone would let a junk record through.
+- **`--rename-prefix` is required here.** This file names sequences `Col-CEN_chr1` where the genome names them `Chr1`. Without the rewrite nothing matches and the feature set comes out empty. Any annotation whose seqids differ from the assembly needs this, or `--seqid-map`.
+- **This is a catalog of monomers, not of features.** It marks each CEN180 repeat unit individually, 66,131 times, and says nothing about where the centromere is. `prep-bed satellite` merges nearby monomers into bands (`--merge-gap`) and takes the densest cluster of bands as the centromere core (`--cluster-gap`); everything else becomes `p_arm` or `q_arm`. Human CenSat, by contrast, names its features directly, which is why it has a converter of its own.
 
 Arms are assigned by coordinate, which assumes short-arm-first orientation.
 

--- a/docs/recipes/arabidopsis-colcen.md
+++ b/docs/recipes/arabidopsis-colcen.md
@@ -6,12 +6,16 @@ This is the whole database, and it is the cheap one — a 135 Mb genome, about 5
 
 **Requirements:** `karyoscope`, `samtools`, `hks`.
 
+One file in [`files/`](files/) is used below — the curated chromosome grouping, which nothing derives. Every other hierarchy here is written by `prep-bed`.
+
 ## 1. Genome
 
 ```bash
 curl -L -o Col-CEN_v1.2.fasta.gz \
   https://raw.githubusercontent.com/schatzlab/Col-CEN/main/v1.2/Col-CEN_v1.2.fasta.gz
-# sha256: b059bf9b589a7a6cd13c67179b80293b91809c3c61cb8b9393a518619d8b5fa8
+
+sha256sum Col-CEN_v1.2.fasta.gz
+# b059bf9b589a7a6cd13c67179b80293b91809c3c61cb8b9393a518619d8b5fa8
 
 samtools faidx Col-CEN_v1.2.fasta.gz
 ```
@@ -24,23 +28,17 @@ Seven sequences: `Chr1`–`Chr5`, plus the mitochondrion `ChrM` and chloroplast 
 karyoscope prep-bed fai \
     --lengths Col-CEN_v1.2.fasta.gz.fai \
     --output ath_chromosome.bed
-```
 
-<sub>`ath_chromosome.bed` → `28fb5d5a098ac105be5e2052ef53932e5c47d5817a97757f6e6c8c403b284b9b` (7 rows)</sub>
+sha256sum ath_chromosome.bed
+# 28fb5d5a098ac105be5e2052ef53932e5c47d5817a97757f6e6c8c403b284b9b   (7 rows)
+```
 
 The organelles are excluded at build time rather than filtered here, so every feature set agrees about which sequences exist.
 
-The nuclear chromosomes are then grouped by hand. This is curation — nothing in a `.fai` says which sequences are nuclear — so `prep-bed` does not invent it:
+Grouping the five nuclear chromosomes is curation — nothing in a `.fai` says which sequences are nuclear — so it is provided rather than derived:
 
 ```bash
-cat > ath_chromosome.hierarchy.txt <<'EOF'
-nuclear	categorized
-Chr1	nuclear
-Chr2	nuclear
-Chr3	nuclear
-Chr4	nuclear
-Chr5	nuclear
-EOF
+cp docs/recipes/files/colcen_chromosome.hierarchy.txt .
 ```
 
 ## 3. `region` — CEN180 centromeric satellite
@@ -50,8 +48,12 @@ The CEN180 monomer catalog comes from TAIR. Note the endpoint: `/download/file?p
 ```bash
 curl -L -o ColCEN_CEN180.gff3 \
   "https://www.arabidopsis.org/api/download-files/download?filePath=Genes/Col-CEN_genome_assembly_release/ColCEN_CEN180.gff3"
-# sha256: ccf54c224050a16dc65362623eee90621e803402bb95f8e7c191444028abedd1
 
+sha256sum ColCEN_CEN180.gff3
+# ccf54c224050a16dc65362623eee90621e803402bb95f8e7c191444028abedd1
+```
+
+```bash
 karyoscope prep-bed satellite \
     --input ColCEN_CEN180.gff3 \
     --lengths Col-CEN_v1.2.fasta.gz.fai \
@@ -59,9 +61,12 @@ karyoscope prep-bed satellite \
     --rename-prefix Col-CEN_chr:Chr \
     --output ath_region.bed \
     --hierarchy ath_region.tsv
+
+sha256sum ath_region.bed
+# 339e5e7e6a74bc6c41adb3b0972f3e02d0b695051909030e685f2e2abdcc7a7d   (2,041 rows)
 ```
 
-<sub>`ath_region.bed` → `339e5e7e6a74bc6c41adb3b0972f3e02d0b695051909030e685f2e2abdcc7a7d` (2,041 rows)</sub>
+`prep-bed` writes the hierarchy itself — there is nothing to supply.
 
 Three things are worth understanding here, because each is a general problem rather than an Arabidopsis quirk:
 
@@ -76,15 +81,20 @@ Arms are assigned by coordinate, which assumes short-arm-first orientation.
 ```bash
 curl -L -o EDTA.TEanno.gff3.gz \
   https://raw.githubusercontent.com/schatzlab/Col-CEN/main/v1.2/t2t-col.20201227.fasta.mod.EDTA.TEanno.gff3.gz
-# sha256: d209f344edd10e9e37da498b6625454a0472e24ff975c0979d3d12763cb6bcd6
 
+sha256sum EDTA.TEanno.gff3.gz
+# d209f344edd10e9e37da498b6625454a0472e24ff975c0979d3d12763cb6bcd6
+```
+
+```bash
 karyoscope prep-bed edta \
     --input EDTA.TEanno.gff3.gz \
     --output ath_repeat.bed \
     --hierarchy ath_repeat.tsv
-```
 
-<sub>`ath_repeat.bed` → `0ec9610c801e5edd4785f0ad9949e3092e09a033f7d4e35b72347c2e7f9eafd4` (42,927 rows)</sub>
+sha256sum ath_repeat.bed
+# 0ec9610c801e5edd4785f0ad9949e3092e09a033f7d4e35b72347c2e7f9eafd4   (42,927 rows)
+```
 
 EDTA's `Classification=` vocabulary aliases each superfamily under both spelled-out and Wicker three-letter names — `DNA/HAT` and `DNA/DTA` are both hAT — so `prep-bed` normalises them to one leaf per superfamily, keeping the BED labels and the hierarchy leaves consistent by construction.
 
@@ -95,16 +105,21 @@ No colours file is emitted: there is no established KaryoScope palette for the E
 ```bash
 curl -L -o Col-CEN_v1.2_genes.araport11.gff3.gz \
   https://raw.githubusercontent.com/schatzlab/Col-CEN/main/v1.2/Col-CEN_v1.2_genes.araport11.gff3.gz
-# sha256: baa6ad8aa24f098e4e957682ba945da15fa3736eaacceb02b9a2f5de4ec86e8f
 
+sha256sum Col-CEN_v1.2_genes.araport11.gff3.gz
+# baa6ad8aa24f098e4e957682ba945da15fa3736eaacceb02b9a2f5de4ec86e8f
+```
+
+```bash
 karyoscope prep-bed gff-gene \
     --input Col-CEN_v1.2_genes.araport11.gff3.gz \
     --lengths Col-CEN_v1.2.fasta.gz.fai \
     --output ath_gene.bed \
     --hierarchy ath_gene.tsv
-```
 
-<sub>`ath_gene.bed` → `52e8059b9275f65135495d6406b5d7bb5be3758935754cc58ced5aa49fbcd142` (284,461 rows)</sub>
+sha256sum ath_gene.bed
+# 52e8059b9275f65135495d6406b5d7bb5be3758935754cc58ced5aa49fbcd142   (284,461 rows)
+```
 
 Two notes:
 
@@ -130,7 +145,7 @@ exclude: [ChrM, ChrC]
 feature_sets:
   - name: chromosome
     bed: ath_chromosome.bed
-    hierarchy: ath_chromosome.hierarchy.txt
+    hierarchy: colcen_chromosome.hierarchy.txt
     background: null            # already tiles every base
   - name: region
     bed: ath_region.bed

--- a/docs/recipes/arabidopsis-colcen.md
+++ b/docs/recipes/arabidopsis-colcen.md
@@ -2,7 +2,7 @@
 
 Rebuild the *Arabidopsis thaliana* Col-CEN (T2T v1.2) database in full: `chromosome`, `region`, `repeat` and `gene`.
 
-This is the whole database, and it is the cheap one — a 135 Mb genome, about 50 s to build at `-t 16` and ~6 GB peak RSS. It is the best recipe to try first, and a worked example of building KaryoScope for a non-human organism.
+A 135 Mb genome: about 50 s to build at `-t 16`, ~6 GB peak RSS. Also a worked example of building KaryoScope for a non-human organism.
 
 **Requirements:** `karyoscope`, `samtools`, `hks`.
 
@@ -68,7 +68,7 @@ sha256sum ath_region.bed
 
 `prep-bed` writes the hierarchy file itself — there is nothing to supply.
 
-Three things are worth understanding here, because each is a general problem rather than an Arabidopsis quirk:
+Three details, none of them specific to Arabidopsis:
 
 - **`--rename-prefix` is required.** This file names sequences `Col-CEN_chr1`, the genome names them `Chr1`. Without the rewrite nothing matches and the feature set comes out empty.
 - **It is a monomer catalog, not a feature annotation.** Unlike human CenSat it says only "CEN180 monomer here", 66,131 times. `prep-bed satellite` merges monomers within `--merge-gap` (default 10 bp, which bridges the 1–2 bp monomer-boundary artefacts tandem-repeat finders emit without swallowing real kilobase-scale insertions), then takes the densest cluster of bands as the centromere. A raw min-to-max extent would be dragged across the arm by scattered pericentromeric remnants.
@@ -98,7 +98,7 @@ sha256sum ath_repeat.bed
 
 EDTA's `Classification=` vocabulary aliases each superfamily under both spelled-out and Wicker three-letter names — `DNA/HAT` and `DNA/DTA` are both hAT — so `prep-bed` normalises them to one leaf per superfamily, keeping the BED labels and the hierarchy leaves consistent by construction.
 
-No colours file is emitted: there is no established KaryoScope palette for the EDTA vocabulary, and `build`'s automatic assignment beats an invented one.
+No colours file is emitted: there is no established KaryoScope palette for the EDTA vocabulary, so `build` assigns them.
 
 ## 5. `gene` — Araport11
 
@@ -179,7 +179,7 @@ downloaded files: all four BEDs match the checksums given here, and all five
 index files — the shared base index and one per feature set — come out
 bit-identical to the database in use.
 
-The `region` set's arm labels are load-bearing: centromere detection reads anything that is not `p_arm`/`q_arm`/`arm`/`telomere`/`novel` as the centromere catch-all, so `CEN180` and `cen_gap` must be leaves.
+Centromere detection reads anything that is not `p_arm`/`q_arm`/`arm`/`telomere`/`novel` as the centromere catch-all, so `CEN180` and `cen_gap` must be leaves.
 
 ## 7. Render a karyotype
 

--- a/docs/recipes/arabidopsis-colcen.md
+++ b/docs/recipes/arabidopsis-colcen.md
@@ -66,7 +66,7 @@ sha256sum ath_region.bed
 # 339e5e7e6a74bc6c41adb3b0972f3e02d0b695051909030e685f2e2abdcc7a7d   (2,041 rows)
 ```
 
-`prep-bed` writes the hierarchy itself — there is nothing to supply.
+`prep-bed` writes the hierarchy file itself — there is nothing to supply.
 
 Three things are worth understanding here, because each is a general problem rather than an Arabidopsis quirk:
 
@@ -121,6 +121,8 @@ sha256sum ath_gene.bed
 # 52e8059b9275f65135495d6406b5d7bb5be3758935754cc58ced5aa49fbcd142   (284,461 rows)
 ```
 
+`prep-bed` writes a hierarchy file too, but the build spec below leaves it out: `exon`/`intron`/`intergenic` is a flat star that `build` derives on its own, and omitting it is how the shipped database was built.
+
 Two notes:
 
 - Despite the `.gff3` extension this file uses **GTF-style attributes** (`transcript_id "AT1G01010";`). `prep-bed` reads both syntaxes, so it needs no flag. TAIR publishes the same annotation with true GFF3 attributes as `ColCEN_GENES_Araport11.gff3.gz`; either produces this identical output.
@@ -156,8 +158,8 @@ feature_sets:
     hierarchy: ath_repeat.tsv
     background: nonrepeat
   - name: gene
-    bed: ath_gene.bed            # no hierarchy: the three labels are a flat star,
-    background: null             # which build derives on its own
+    bed: ath_gene.bed
+    background: null            # exon/intron/intergenic tiles every base
 roles:
   chromosome_assignment: chromosome
   region_assignment: region

--- a/docs/recipes/files/chm13v2_chromosome.hierarchy.txt
+++ b/docs/recipes/files/chm13v2_chromosome.hierarchy.txt
@@ -1,0 +1,31 @@
+# Curated grouping of the CHM13v2.0 chromosomes by centromere position.
+# Human cytogenetics, not derivable from a .fai -- pass to build as 'hierarchy:'.
+autosome	categorized
+acrocentric	autosome
+chr13	acrocentric
+chr14	acrocentric
+chr15	acrocentric
+chr21	acrocentric
+chr22	acrocentric
+metacentric	autosome
+chr1	metacentric
+chr3	metacentric
+chr16	metacentric
+chr19	metacentric
+chr20	metacentric
+submetacentric	autosome
+chr2	submetacentric
+chr4	submetacentric
+chr5	submetacentric
+chr6	submetacentric
+chr7	submetacentric
+chr8	submetacentric
+chr9	submetacentric
+chr10	submetacentric
+chr11	submetacentric
+chr12	submetacentric
+chr17	submetacentric
+chr18	submetacentric
+sex	categorized
+chrX	sex
+chrY	sex

--- a/docs/recipes/files/chm13v2_refseq_to_chr.tsv
+++ b/docs/recipes/files/chm13v2_refseq_to_chr.tsv
@@ -1,0 +1,27 @@
+# RefSeq accession -> chromosome name, for the GCF_009914755.1 T2T-CHM13v2.0
+# annotation. Used with `karyoscope prep-bed gff-gene --seqid-map`.
+NC_060925.1	chr1
+NC_060926.1	chr2
+NC_060927.1	chr3
+NC_060928.1	chr4
+NC_060929.1	chr5
+NC_060930.1	chr6
+NC_060931.1	chr7
+NC_060932.1	chr8
+NC_060933.1	chr9
+NC_060934.1	chr10
+NC_060935.1	chr11
+NC_060936.1	chr12
+NC_060937.1	chr13
+NC_060938.1	chr14
+NC_060939.1	chr15
+NC_060940.1	chr16
+NC_060941.1	chr17
+NC_060942.1	chr18
+NC_060943.1	chr19
+NC_060944.1	chr20
+NC_060945.1	chr21
+NC_060946.1	chr22
+NC_060947.1	chrX
+NC_060948.1	chrY
+NC_012920.1	chrM

--- a/docs/recipes/files/chm13v2_repeat.priority.txt
+++ b/docs/recipes/files/chm13v2_repeat.priority.txt
@@ -1,0 +1,28 @@
+# Priority order for the CHM13 v2 repeat set, highest priority (1) first:
+#   rRNA, scRNA, snRNA, srpRNA, tRNA, Satellite, RC, Retroposon, DNA, LTR, SINE, LINE, Simple_repeat, Low_complexity, Unknown
+# Interior nodes carry values only to satisfy HKS's rule that siblings be
+# all-equal or all-distinct; they never appear as BED labels.
+# 3-column 'child priority parent' -- this supplies the hierarchy too.
+repeat	1	categorized
+Interspersed_Repeat	1	repeat
+RNA	1	Interspersed_Repeat
+rRNA	1	RNA
+scRNA	2	RNA
+snRNA	3	RNA
+srpRNA	4	RNA
+tRNA	5	RNA
+Transposable_Element	2	Interspersed_Repeat
+Class_I_Retrotransposition	1	Transposable_Element
+LINE	12	Class_I_Retrotransposition
+LINE-dependent_Retroposon	1	Class_I_Retrotransposition
+Retroposon	8	LINE-dependent_Retroposon
+SINE	11	LINE-dependent_Retroposon
+LTR	10	Class_I_Retrotransposition
+Class_II_DNA_Transposition	2	Transposable_Element
+DNA	9	Class_II_DNA_Transposition
+RC	7	Class_II_DNA_Transposition
+Unknown	15	Interspersed_Repeat
+Satellite	6	repeat
+Noninterspersed	2	repeat
+Low_complexity	14	Noninterspersed
+Simple_repeat	13	Noninterspersed

--- a/docs/recipes/files/colcen_chromosome.hierarchy.txt
+++ b/docs/recipes/files/colcen_chromosome.hierarchy.txt
@@ -1,0 +1,8 @@
+# Curated grouping of the Col-CEN chromosomes: the five nuclear chromosomes.
+# The organelles ChrM/ChrC are excluded at build time, not grouped here.
+nuclear	categorized
+Chr1	nuclear
+Chr2	nuclear
+Chr3	nuclear
+Chr4	nuclear
+Chr5	nuclear

--- a/docs/recipes/human-chm13v2.md
+++ b/docs/recipes/human-chm13v2.md
@@ -106,7 +106,7 @@ sha256sum chm13_repeat.bed
 
 `prep-bed` writes the hierarchy and colours files itself — there is nothing to supply.
 
-RepeatMasker names each element `name#class/family`, as in `L1MA#LINE/L1`. `prep-bed` keeps the class, giving the 15 leaves the hierarchy names, and a class it does not recognise becomes `Unknown` rather than being dropped — so those bases are never mistaken for non-repeat. The colours file groups the five RNA leaves into a single legend row, since they share a colour.
+RepeatMasker names each element `name#class/family`, as in `L1MA#LINE/L1`. `prep-bed` keeps the class, giving the 15 leaves the hierarchy names. The colours file groups the five RNA leaves into a single legend row, since they share a colour.
 
 Repeat annotations overlap heavily, and this database resolves that by assigning each base to the highest-priority class. The priority order is provided, and passed to [the build](#6-build) below:
 

--- a/docs/recipes/human-chm13v2.md
+++ b/docs/recipes/human-chm13v2.md
@@ -2,10 +2,12 @@
 
 Rebuild the human T2T-CHM13v2.0 database's `chromosome`, `region`, `repeat` and `gene` feature sets from published sources.
 
-> The shipped database also carries `acrocentric` and `subtelomeric` feature sets and a separate `cytoband` database. Those are outside this recipe.
+> The shipped database also carries `acrocentric` and `subtelomeric` feature sets, which are outside this recipe.
 
 **Requirements:** `karyoscope`, `samtools`, `hks`, and UCSC's [`bigBedToBed`](https://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/bigBedToBed).
 **Cost:** roughly 25 GB of downloads, ~1 GB of intermediates, and a build that takes minutes at `-t 16` but needs substantial RAM — see [Resource requirements](../commands/build.md#resource-requirements).
+
+Three files in [`files/`](files/) are used below. They are shipped because nothing derives them: two encode curation (which chromosomes are acrocentric; which repeat class outranks which) and one is an accession mapping.
 
 ## 1. Genome
 
@@ -33,28 +35,40 @@ One record per sequence, labelled with its own name. Derived from the `.fai`, so
 karyoscope prep-bed fai \
     --lengths CHM13.fasta.gz.fai \
     --output chm13_chromosome.bed
+
+sha256sum chm13_chromosome.bed
+# da23139f348285a17085e264f8fac86644327965c647a12ced3ad810ea7e1827   (25 rows)
 ```
 
-<sub>`chm13_chromosome.bed` → `da23139f348285a17085e264f8fac86644327965c647a12ced3ad810ea7e1827` (25 rows)</sub>
+The shipped database groups these by centromere position — metacentric, submetacentric, acrocentric, sex. That is human cytogenetics and cannot be read off a `.fai`, so it is provided rather than derived:
 
-The shipped database groups these sequences by centromere position (metacentric / submetacentric / acrocentric / sex). That grouping is human cytogenetic curation and cannot be read off a `.fai`, so `prep-bed` does not invent it — write it by hand as a `child<TAB>parent` file and pass it as `hierarchy:` if you want it.
+```bash
+cp docs/recipes/files/chm13v2_chromosome.hierarchy.txt .
+```
 
 ## 3. `region` — centromeric satellites
 
 ```bash
 curl -L -o chm13v2.0.cenSatv2.1.bed \
   https://raw.githubusercontent.com/hloucks/CenSatData/refs/heads/main/CHM13/chm13v2.0.cenSatv2.1.bed
-# sha256: c6f35d83e4b28f33807c2f65df76b78444f246aa9fb82a3c262bde35e6a6a78c
 
+sha256sum chm13v2.0.cenSatv2.1.bed
+# c6f35d83e4b28f33807c2f65df76b78444f246aa9fb82a3c262bde35e6a6a78c
+```
+
+```bash
 karyoscope prep-bed censat \
     --input chm13v2.0.cenSatv2.1.bed \
     --lengths CHM13.fasta.gz.fai \
     --output chm13_region.bed \
     --hierarchy chm13_region.tsv \
     --priority chm13_region.priority.txt
+
+sha256sum chm13_region.bed
+# c3b0959f9221d89a854e680186589e428c101eb4de069e1c2dab01fb58540bd3   (3,452 rows)
 ```
 
-<sub>`chm13_region.bed` → `c3b0959f9221d89a854e680186589e428c101eb4de069e1c2dab01fb58540bd3` (3,452 rows)</sub>
+`prep-bed` writes the hierarchy and priority files itself — there is nothing to supply.
 
 CenSat labels every feature with the specific arrays it contains — `gSat(TAR1)`, `hor(S1C10H1-B)` — several hundred distinct values. `prep-bed` keeps the part before the parenthesis, giving the 14 leaves the hierarchy names, then labels everything else `p_arm` or `q_arm` by which side of the centromere it falls on. The centromere comes from the `ct` (centromeric transition) features that bracket it.
 
@@ -67,52 +81,70 @@ The source is the UCSC bigBed, **not** the similarly-named BED in the T2T annota
 ```bash
 curl -L -o chm13v2.0_rmsk.bb \
   https://hgdownload.soe.ucsc.edu/gbdb/hs1/t2tRepeatMasker/chm13v2.0_rmsk.bb
-# sha256: 92dfe2d85113752ebf140d9424d5979e56de64718a40b5c2374e1c1c454482f0
 
+sha256sum chm13v2.0_rmsk.bb
+# 92dfe2d85113752ebf140d9424d5979e56de64718a40b5c2374e1c1c454482f0
+```
+
+```bash
 bigBedToBed chm13v2.0_rmsk.bb CHM13.RepeatMasker.bed
-# sha256: e061ca26b34aa9e9c0b6cbc70f0d6faefd123000af6cd2716b9452e4d717b0ed  (4,636,653 rows)
 
+sha256sum CHM13.RepeatMasker.bed
+# e061ca26b34aa9e9c0b6cbc70f0d6faefd123000af6cd2716b9452e4d717b0ed   (4,636,653 rows)
+```
+
+```bash
 karyoscope prep-bed repeatmasker \
     --input CHM13.RepeatMasker.bed \
     --output chm13_repeat.bed \
     --hierarchy chm13_repeat.tsv \
     --colors chm13_repeat.colors.tsv
+
+sha256sum chm13_repeat.bed
+# 067d8020ec3480aafb30a9ff07280c1b2cb8ed58174d895212ebf9b2b96fc10e   (4,636,653 rows)
 ```
 
-<sub>`chm13_repeat.bed` → `067d8020ec3480aafb30a9ff07280c1b2cb8ed58174d895212ebf9b2b96fc10e` (4,636,653 rows)</sub>
+Leaves are the 15 RepeatMasker classes. The emitted colours file groups the five RNA leaves into a single legend row, since they share a colour.
 
-Leaves are the 15 RepeatMasker classes. `build` adds the `nonrepeat` gap-fill. The emitted colours file groups the five RNA leaves into a single legend row, since they share a colour.
+Repeat annotations overlap heavily, and this database resolves that by assigning each base to the highest-priority class. The order is published curation, so it is provided:
 
-**This is the one set that does not reproduce the shipped database exactly.** The shipped `repeat` set was additionally flattened to one label per base by a priority-ordered merge before indexing. That step predates the HKS backend, which resolves overlaps per k-mer through the hierarchy and makes pre-flattening unnecessary — so this recipe omits it, and the result is an equivalent but not byte-identical index. To reproduce the shipped set exactly you would need to re-apply that merge with the order `D20S16,rRNA,scRNA,snRNA,tRNA,RC,Retroposon,DNA,LTR,SINE,LINE,Unknown`.
+```bash
+cp docs/recipes/files/chm13v2_repeat.priority.txt .
+```
+
+```
+rRNA, scRNA, snRNA, srpRNA, tRNA, Satellite, RC, Retroposon, DNA, LTR, SINE, LINE,
+Simple_repeat, Low_complexity, Unknown          (highest priority first)
+```
+
+The build spec applies it with `flatten: true`. That file is 3-column, so it supplies the hierarchy as well — `chm13_repeat.tsv` from the step above is the same tree without the ranking, and the spec does not need it.
 
 ## 5. `gene` — RefSeq
 
 ```bash
 curl -L -o CHM13.gtf.gz \
   https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/009/914/755/GCF_009914755.1_T2T-CHM13v2.0/GCF_009914755.1_T2T-CHM13v2.0_genomic.gtf.gz
-# sha256: fd8a27c06da23b4defc140d1bb03f5f0eb8b5ba780eeee6730617fe709c6a16e
+
+sha256sum CHM13.gtf.gz
+# fd8a27c06da23b4defc140d1bb03f5f0eb8b5ba780eeee6730617fe709c6a16e
 ```
 
 RefSeq names sequences by accession (`NC_060925.1`), so it needs a mapping to the assembly's `chr` names:
 
 ```bash
-python - > refseq_to_chr.tsv <<'EOF'
-names = [f"chr{i}" for i in range(1, 23)] + ["chrX", "chrY"]
-for i, name in enumerate(names):
-    print(f"NC_0609{25 + i}.1\t{name}")
-print("NC_012920.1\tchrM")
-EOF
+cp docs/recipes/files/chm13v2_refseq_to_chr.tsv .
 
 karyoscope prep-bed gff-gene \
     --input CHM13.gtf.gz \
     --lengths CHM13.fasta.gz.fai \
-    --seqid-map refseq_to_chr.tsv \
+    --seqid-map chm13v2_refseq_to_chr.tsv \
     --output chm13_gene.bed \
     --hierarchy chm13_gene.tsv \
     --colors chm13_gene.colors.tsv
-```
 
-<sub>`chm13_gene.bed` → `03ae30a1a9c90a574b96eb4dfaa34a0c834ef51f5b3eec4181f39d4e8c9063e9` (612,909 rows)</sub>
+sha256sum chm13_gene.bed
+# 03ae30a1a9c90a574b96eb4dfaa34a0c834ef51f5b3eec4181f39d4e8c9063e9   (612,909 rows)
+```
 
 Introns are derived per transcript from that transcript's own consecutive exons; where transcripts disagree, `exon` beats `intron` beats `intergenic`. The result tiles every sequence, so the set needs no gap-fill.
 
@@ -134,14 +166,16 @@ exclude: [chrM]
 feature_sets:
   - name: chromosome
     bed: chm13_chromosome.bed
+    hierarchy: chm13v2_chromosome.hierarchy.txt
     background: null            # one record per sequence already tiles everything
   - name: region
     bed: chm13_region.bed
-    priority: chm13_region.priority.txt
+    priority: chm13_region.priority.txt   # 3-column: supplies the hierarchy too
     background: null            # the arm split already tiles every base
   - name: repeat
     bed: chm13_repeat.bed
-    hierarchy: chm13_repeat.tsv
+    priority: chm13v2_repeat.priority.txt # 3-column: supplies the hierarchy too
+    flatten: true               # one class per base, by the order above
     colors: chm13_repeat.colors.tsv
     background: nonrepeat
   - name: gene
@@ -162,7 +196,9 @@ karyoscope build --spec build.yaml
 karyoscope info HKS_human_CHM13_v2
 ```
 
-`region` uses `priority:` rather than `hierarchy:` because the CenSat priority file is the 3-column form, which supplies both.
+All four feature sets reproduce the shipped database's inputs exactly. For `repeat`, flattening the BED above by the published order and gap-filling with `nonrepeat` was checked against the file the database was built from: 4,423,197 rows, identical.
+
+The one deliberate difference throughout is `chrM`. The original BEDs gave it a literal `exclude` *label*, a convention that predates `build`'s `exclude:` list. Using `exclude:` is better — a label claims the sequence for that feature set, whereas `exclude:` leaves it genuinely uncovered so it reads as `none` everywhere.
 
 ## See also
 

--- a/docs/recipes/human-chm13v2.md
+++ b/docs/recipes/human-chm13v2.md
@@ -1,0 +1,171 @@
+# Recipe: `HKS_human_CHM13_v2`
+
+Rebuild the human T2T-CHM13v2.0 database's `chromosome`, `region`, `repeat` and `gene` feature sets from published sources.
+
+> The shipped database also carries `acrocentric` and `subtelomeric` feature sets and a separate `cytoband` database. Those are outside this recipe.
+
+**Requirements:** `karyoscope`, `samtools`, `hks`, and UCSC's [`bigBedToBed`](https://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/bigBedToBed).
+**Cost:** roughly 25 GB of downloads, ~1 GB of intermediates, and a build that takes minutes at `-t 16` but needs substantial RAM — see [Resource requirements](../commands/build.md#resource-requirements).
+
+## 1. Genome
+
+```bash
+curl -L -o chm13v2.0.fa.gz \
+  https://s3-us-west-2.amazonaws.com/human-pangenomics/T2T/CHM13/assemblies/analysis_set/chm13v2.0.fa.gz
+
+# Re-compress with bgzip, which build and samtools need for random access
+zcat chm13v2.0.fa.gz | bgzip > CHM13.fasta.gz
+samtools faidx CHM13.fasta.gz
+```
+
+Verify by **content**, not by file — bgzip changes the container:
+
+```bash
+zcat CHM13.fasta.gz | sha256sum
+# 15a4ba1246f6021a89699bf5083da7f2bad3f79c86acd7bc1eb0ca3a13164e85
+```
+
+## 2. `chromosome`
+
+One record per sequence, labelled with its own name. Derived from the `.fai`, so it needs no separate download.
+
+```bash
+karyoscope prep-bed fai \
+    --lengths CHM13.fasta.gz.fai \
+    --output chm13_chromosome.bed
+```
+
+<sub>`chm13_chromosome.bed` → `da23139f348285a17085e264f8fac86644327965c647a12ced3ad810ea7e1827` (25 rows)</sub>
+
+The shipped database groups these sequences by centromere position (metacentric / submetacentric / acrocentric / sex). That grouping is human cytogenetic curation and cannot be read off a `.fai`, so `prep-bed` does not invent it — write it by hand as a `child<TAB>parent` file and pass it as `hierarchy:` if you want it.
+
+## 3. `region` — centromeric satellites
+
+```bash
+curl -L -o chm13v2.0.cenSatv2.1.bed \
+  https://raw.githubusercontent.com/hloucks/CenSatData/refs/heads/main/CHM13/chm13v2.0.cenSatv2.1.bed
+# sha256: c6f35d83e4b28f33807c2f65df76b78444f246aa9fb82a3c262bde35e6a6a78c
+
+karyoscope prep-bed censat \
+    --input chm13v2.0.cenSatv2.1.bed \
+    --lengths CHM13.fasta.gz.fai \
+    --output chm13_region.bed \
+    --hierarchy chm13_region.tsv \
+    --priority chm13_region.priority.txt
+```
+
+<sub>`chm13_region.bed` → `c3b0959f9221d89a854e680186589e428c101eb4de069e1c2dab01fb58540bd3` (3,452 rows)</sub>
+
+CenSat labels every feature with the specific arrays it contains — `gSat(TAR1)`, `hor(S1C10H1-B)` — several hundred distinct values. `prep-bed` keeps the part before the parenthesis, giving the 14 leaves the hierarchy names, then labels everything else `p_arm` or `q_arm` by which side of the centromere it falls on. The centromere comes from the `ct` (centromeric transition) features that bracket it.
+
+`chrM` has no CenSat annotation and is reported for `exclude:` rather than labelled.
+
+## 4. `repeat` — RepeatMasker
+
+The source is the UCSC bigBed, **not** the similarly-named BED in the T2T annotation bucket. Both are RepeatMasker 4.1.2p1 2022Apr14; the bucket's BED lists one row per fragment, while the bigBed joins fragments into blocked records, and only the latter matches this database.
+
+```bash
+curl -L -o chm13v2.0_rmsk.bb \
+  https://hgdownload.soe.ucsc.edu/gbdb/hs1/t2tRepeatMasker/chm13v2.0_rmsk.bb
+# sha256: 92dfe2d85113752ebf140d9424d5979e56de64718a40b5c2374e1c1c454482f0
+
+bigBedToBed chm13v2.0_rmsk.bb CHM13.RepeatMasker.bed
+# sha256: e061ca26b34aa9e9c0b6cbc70f0d6faefd123000af6cd2716b9452e4d717b0ed  (4,636,653 rows)
+
+karyoscope prep-bed repeatmasker \
+    --input CHM13.RepeatMasker.bed \
+    --output chm13_repeat.bed \
+    --hierarchy chm13_repeat.tsv \
+    --colors chm13_repeat.colors.tsv
+```
+
+<sub>`chm13_repeat.bed` → `067d8020ec3480aafb30a9ff07280c1b2cb8ed58174d895212ebf9b2b96fc10e` (4,636,653 rows)</sub>
+
+Leaves are the 15 RepeatMasker classes. `build` adds the `nonrepeat` gap-fill. The emitted colours file groups the five RNA leaves into a single legend row, since they share a colour.
+
+**This is the one set that does not reproduce the shipped database exactly.** The shipped `repeat` set was additionally flattened to one label per base by a priority-ordered merge before indexing. That step predates the HKS backend, which resolves overlaps per k-mer through the hierarchy and makes pre-flattening unnecessary — so this recipe omits it, and the result is an equivalent but not byte-identical index. To reproduce the shipped set exactly you would need to re-apply that merge with the order `D20S16,rRNA,scRNA,snRNA,tRNA,RC,Retroposon,DNA,LTR,SINE,LINE,Unknown`.
+
+## 5. `gene` — RefSeq
+
+```bash
+curl -L -o CHM13.gtf.gz \
+  https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/009/914/755/GCF_009914755.1_T2T-CHM13v2.0/GCF_009914755.1_T2T-CHM13v2.0_genomic.gtf.gz
+# sha256: fd8a27c06da23b4defc140d1bb03f5f0eb8b5ba780eeee6730617fe709c6a16e
+```
+
+RefSeq names sequences by accession (`NC_060925.1`), so it needs a mapping to the assembly's `chr` names:
+
+```bash
+python - > refseq_to_chr.tsv <<'EOF'
+names = [f"chr{i}" for i in range(1, 23)] + ["chrX", "chrY"]
+for i, name in enumerate(names):
+    print(f"NC_0609{25 + i}.1\t{name}")
+print("NC_012920.1\tchrM")
+EOF
+
+karyoscope prep-bed gff-gene \
+    --input CHM13.gtf.gz \
+    --lengths CHM13.fasta.gz.fai \
+    --seqid-map refseq_to_chr.tsv \
+    --output chm13_gene.bed \
+    --hierarchy chm13_gene.tsv \
+    --colors chm13_gene.colors.tsv
+```
+
+<sub>`chm13_gene.bed` → `03ae30a1a9c90a574b96eb4dfaa34a0c834ef51f5b3eec4181f39d4e8c9063e9` (612,909 rows)</sub>
+
+Introns are derived per transcript from that transcript's own consecutive exons; where transcripts disagree, `exon` beats `intron` beats `intergenic`. The result tiles every sequence, so the set needs no gap-fill.
+
+## 6. Build
+
+```yaml
+# build.yaml
+id: HKS_human_CHM13_v2
+version: "2.0.0"
+sequence: CHM13.fasta.gz
+kmer:
+  s: 31
+build:
+  threads: 16
+  mem_gigas: 8
+# chrM is not a karyotype chromosome and no feature set covers it, so it reads
+# as "none" everywhere rather than being claimed by a placeholder label.
+exclude: [chrM]
+feature_sets:
+  - name: chromosome
+    bed: chm13_chromosome.bed
+    background: null            # one record per sequence already tiles everything
+  - name: region
+    bed: chm13_region.bed
+    priority: chm13_region.priority.txt
+    background: null            # the arm split already tiles every base
+  - name: repeat
+    bed: chm13_repeat.bed
+    hierarchy: chm13_repeat.tsv
+    colors: chm13_repeat.colors.tsv
+    background: nonrepeat
+  - name: gene
+    bed: chm13_gene.bed
+    hierarchy: chm13_gene.tsv
+    colors: chm13_gene.colors.tsv
+    background: null            # exon/intron/intergenic already tiles every base
+roles:
+  chromosome_assignment: chromosome
+  region_assignment: region
+  centromere_detection: region
+smoothing:
+  recommended_window_bp: 1000
+```
+
+```bash
+karyoscope build --spec build.yaml
+karyoscope info HKS_human_CHM13_v2
+```
+
+`region` uses `priority:` rather than `hierarchy:` because the CenSat priority file is the 3-column form, which supplies both.
+
+## See also
+
+- [`karyoscope prep-bed`](../commands/prep-bed.md)
+- [`karyoscope build`](../commands/build.md)
+- [Recipe: Arabidopsis Col-CEN](arabidopsis-colcen.md)

--- a/docs/recipes/human-chm13v2.md
+++ b/docs/recipes/human-chm13v2.md
@@ -40,7 +40,7 @@ sha256sum chm13_chromosome.bed
 # da23139f348285a17085e264f8fac86644327965c647a12ced3ad810ea7e1827   (25 rows)
 ```
 
-The shipped database groups these by centromere position — metacentric, submetacentric, acrocentric, sex. That is human cytogenetics and cannot be read off a `.fai`, so it is provided rather than derived:
+The shipped database groups these by centromere position — metacentric, submetacentric, acrocentric, sex. That is human cytogenetics and cannot be read off a `.fai`, so it is provided rather than derived, and passed to [the build](#6-build) below:
 
 ```bash
 cp docs/recipes/files/chm13v2_chromosome.hierarchy.txt .
@@ -104,20 +104,15 @@ sha256sum chm13_repeat.bed
 # 067d8020ec3480aafb30a9ff07280c1b2cb8ed58174d895212ebf9b2b96fc10e   (4,636,653 rows)
 ```
 
-Leaves are the 15 RepeatMasker classes. The emitted colours file groups the five RNA leaves into a single legend row, since they share a colour.
+`prep-bed` writes the hierarchy and colours files itself — there is nothing to supply.
 
-Repeat annotations overlap heavily, and this database resolves that by assigning each base to the highest-priority class. The order is published curation, so it is provided:
+RepeatMasker names each element `name#class/family`, as in `L1MA#LINE/L1`. `prep-bed` keeps the class, giving the 15 leaves the hierarchy names, and a class it does not recognise becomes `Unknown` rather than being dropped — so those bases are never mistaken for non-repeat. The colours file groups the five RNA leaves into a single legend row, since they share a colour.
+
+Repeat annotations overlap heavily, and this database resolves that by assigning each base to the highest-priority class. The priority order is provided, and passed to [the build](#6-build) below:
 
 ```bash
 cp docs/recipes/files/chm13v2_repeat.priority.txt .
 ```
-
-```
-rRNA, scRNA, snRNA, srpRNA, tRNA, Satellite, RC, Retroposon, DNA, LTR, SINE, LINE,
-Simple_repeat, Low_complexity, Unknown          (highest priority first)
-```
-
-The build spec applies it with `flatten: true`. That file is 3-column, so it supplies the hierarchy as well — `chm13_repeat.tsv` from the step above is the same tree without the ranking, and the spec does not need it.
 
 ## 5. `gene` — RefSeq
 
@@ -146,6 +141,8 @@ sha256sum chm13_gene.bed
 # 03ae30a1a9c90a574b96eb4dfaa34a0c834ef51f5b3eec4181f39d4e8c9063e9   (612,909 rows)
 ```
 
+`prep-bed` writes the hierarchy and colours files itself — there is nothing to supply.
+
 Introns are derived per transcript from that transcript's own consecutive exons; where transcripts disagree, `exon` beats `intron` beats `intergenic`. The result tiles every sequence, so the set needs no gap-fill.
 
 ## 6. Build
@@ -170,12 +167,14 @@ feature_sets:
     background: null            # one record per sequence already tiles everything
   - name: region
     bed: chm13_region.bed
-    priority: chm13_region.priority.txt   # 3-column: supplies the hierarchy too
+    hierarchy: chm13_region.tsv
+    priority: chm13_region.priority.txt
     background: null            # the arm split already tiles every base
   - name: repeat
     bed: chm13_repeat.bed
-    priority: chm13v2_repeat.priority.txt # 3-column: supplies the hierarchy too
-    flatten: true               # one class per base, by the order above
+    hierarchy: chm13_repeat.tsv
+    priority: chm13v2_repeat.priority.txt
+    flatten: true               # one class per base, by the priority order
     colors: chm13_repeat.colors.tsv
     background: nonrepeat
   - name: gene
@@ -196,7 +195,7 @@ karyoscope build --spec build.yaml
 karyoscope info HKS_human_CHM13_v2
 ```
 
-All four feature sets reproduce the shipped database's inputs exactly. For `repeat`, flattening the BED above by the published order and gap-filling with `nonrepeat` was checked against the file the database was built from: 4,423,197 rows, identical.
+All four feature sets reproduce the shipped database's inputs exactly.
 
 The one deliberate difference throughout is `chrM`. The original BEDs gave it a literal `exclude` *label*, a convention that predates `build`'s `exclude:` list. Using `exclude:` is better — a label claims the sequence for that feature set, whereas `exclude:` leaves it genuinely uncovered so it reads as `none` everywhere.
 

--- a/docs/recipes/human-chm13v2.md
+++ b/docs/recipes/human-chm13v2.md
@@ -197,7 +197,7 @@ karyoscope info HKS_human_CHM13_v2
 
 All four feature sets reproduce the shipped database's inputs exactly.
 
-The one deliberate difference throughout is `chrM`. The original BEDs gave it a literal `exclude` *label*, a convention that predates `build`'s `exclude:` list. Using `exclude:` is better — a label claims the sequence for that feature set, whereas `exclude:` leaves it genuinely uncovered so it reads as `none` everywhere.
+The one difference throughout is `chrM`. The original BEDs gave it a literal `exclude` *label*, a convention that predates `build`'s `exclude:` list. This recipe uses `exclude:`. A label claims the sequence for that feature set; `exclude:` leaves it uncovered, so it reads as `none` everywhere.
 
 ## See also
 

--- a/examples/karyotypes/README.md
+++ b/examples/karyotypes/README.md
@@ -14,7 +14,8 @@ karyoscope karyotype -i hap1=asm.hap1.fa.gz -i hap2=asm.hap2.fa.gz \
 ```
 
 All human plots use the shipped `HKS_human_CHM13_v2` database. Arabidopsis uses
-a database built locally with [`karyoscope build`](../../docs/commands/build.md).
+`HKS_arabidopsis_ColCEN`, which you can build yourself by following the
+[Col-CEN recipe](../../docs/recipes/arabidopsis-colcen.md).
 
 ## The three views
 
@@ -45,7 +46,7 @@ cap stands out.
 | [HG008N](hg008n.genome.chromosome.png) | HG008N v6.3 | Diploid normal — the control half of a tumour/normal pair. |
 | [HG008T](hg008t.genome.chromosome.png) | HG008T v3.2 | Matched tumour. Extensive somatic rearrangement. |
 | [NA19185](na19185.genome.chromosome.png) | HPRC release 2 | A routine population assembly, not curated to T2T. |
-| [Arabidopsis](arabidopsis.genome.chromosome.png) | Col-CEN v1.2 | Non-human, non-mammalian, own database. |
+| [Arabidopsis](arabidopsis.genome.chromosome.png) | Col-CEN v1.2 | Non-human, non-mammalian, own database ([recipe](../../docs/recipes/arabidopsis-colcen.md)). |
 
 ### CHM13 — the baseline
 
@@ -95,9 +96,12 @@ probably look like** — the curated assemblies are the exception, not the norm.
 
 ### Arabidopsis — a non-human genome and a user-built database
 
-Five chromosomes, annotated against `HKS_arabidopsis_ColCEN`, built from a
-genome plus BED files with [`karyoscope build`](../../docs/commands/build.md).
-It demonstrates that nothing in the method is human-specific.
+Five chromosomes, annotated against `HKS_arabidopsis_ColCEN`. It demonstrates
+that nothing in the method is human-specific. The
+[Col-CEN recipe](../../docs/recipes/arabidopsis-colcen.md) builds that database
+from published sources — every download URL and checksum, the `prep-bed` command
+for each of the four feature sets, and the build spec — so this plot is
+reproducible end to end rather than resting on a database only we have.
 
 Two things differ from the human examples, both instructive:
 
@@ -135,6 +139,8 @@ karyoscope karyotype -i hap1=NA19185_hap1_hprc_r2_v1.0.1.fa.gz \
     --sex unknown --format svg --format png -t 16 -o out/
 
 # Arabidopsis — a locally built database, and the plant telomere motif
+#   --db-root is only needed if you built into a non-default database root;
+#   `karyoscope build` registers into the default one.
 karyoscope karyotype -i Col-CEN_v1.2=Col-CEN_v1.2.fasta.gz \
     --db HKS_arabidopsis_ColCEN --db-root /path/to/your/db \
     --sample-label Col-CEN_v1.2 --telo-motif CCCTAAA \
@@ -142,9 +148,10 @@ karyoscope karyotype -i Col-CEN_v1.2=Col-CEN_v1.2.fasta.gz \
 ```
 
 The exact assemblies are named in the table above. The human plots use the
-shipped `HKS_human_CHM13_v2`; the Arabidopsis one needs a database you build
-yourself with [`karyoscope build`](../../docs/commands/build.md), so
-`--db-root` has to point wherever you built it.
+shipped `HKS_human_CHM13_v2`; the Arabidopsis one needs `HKS_arabidopsis_ColCEN`,
+which the [Col-CEN recipe](../../docs/recipes/arabidopsis-colcen.md) builds from
+published sources. Follow that recipe and the database registers into your
+default database root, so `--db-root` is only needed if you built it elsewhere.
 
 Rendering is deterministic given the same assembly, database, and KaryoScope
 version — so a rebuild reproduces these images, with the caveat that changes to

--- a/src/karyoscope/cli.py
+++ b/src/karyoscope/cli.py
@@ -38,7 +38,7 @@ from karyoscope._version import __version__
 #: Subcommand name -> ``module:attribute`` holding its ``click.Command``.
 #:
 #: Imported on demand rather than up front. Registering the subcommands used to
-#: mean importing all eleven command modules, and one of them (``download``)
+#: mean importing every command module, and one of them (``download``)
 #: pulls in ``requests`` -- ~190 ms of the ~290 ms it took to import this
 #: module, paid by every invocation including ``karyoscope --version`` and
 #: every ``annotate`` run, for an HTTP library they never touch.
@@ -50,6 +50,7 @@ from karyoscope._version import __version__
 _LAZY_COMMANDS: dict[str, str] = {
     "download": "karyoscope.commands.download:cmd",
     "register": "karyoscope.commands.register:cmd",
+    "prep-bed": "karyoscope.commands.prep_bed:cmd",
     "build": "karyoscope.commands.build:cmd",
     "annotate": "karyoscope.commands.annotate:cmd",
     "scaffold": "karyoscope.commands.scaffold:cmd",

--- a/src/karyoscope/commands/prep_bed.py
+++ b/src/karyoscope/commands/prep_bed.py
@@ -485,6 +485,80 @@ def fai(
     )
 
 
+@cmd.command("censat")
+@click.option(
+    "--input",
+    "input_path",
+    type=click.Path(**_IN),
+    required=True,
+    help="CenSat annotation BED (e.g. chm13v2.0.cenSatv2.1.bed; plain or gzipped).",
+)
+@click.option(
+    "--lengths",
+    type=click.Path(**_IN),
+    required=True,
+    help="samtools .fai (or 2-column sizes file) for the target assembly.",
+)
+@click.option("--output", type=click.Path(**_OUT), required=True, help="Output feature-set BED.")
+@click.option(
+    "--hierarchy",
+    type=click.Path(**_OUT),
+    required=True,
+    help="Output 'child<TAB>parent' hierarchy (CenSat v2.1 tree).",
+)
+@click.option(
+    "--priority",
+    type=click.Path(**_OUT),
+    default=None,
+    help="Also write the tree as a 3-column priority file, ranking centromeric over rDNA over arm.",
+)
+@click.option("--name", default="region", show_default=True, help="Feature-set name in the stanza.")
+@_seqid_options
+@click.option("--force", is_flag=True, help="Overwrite existing output files.")
+def censat(
+    input_path: Path,
+    lengths: Path,
+    output: Path,
+    hierarchy: Path,
+    priority: Path | None,
+    name: str,
+    rename_prefix: str | None,
+    seqid_map: Path | None,
+    force: bool,
+) -> None:
+    """A CenSat annotation -> a fully-tiled `region` feature set.
+
+    \b
+    CenSat qualifies every label with the specific arrays it contains
+    (`gSat(TAR1)`); the part before the parenthesis is the leaf, so hundreds of
+    distinct values collapse to the 14 features the hierarchy names.
+
+    \b
+    Every remaining base is labelled by which arm it falls on, split at the
+    centromere -- located from the `ct` (centromeric transition) features that
+    bracket it, or from the extent of all centromeric features where a sequence
+    has no `ct`. Pericentromeric remnants far out on an arm keep their own
+    labels; only the gaps around them become arm.
+
+    \b
+    Example:
+        karyoscope prep-bed censat --input chm13v2.0.cenSatv2.1.bed \\
+            --lengths CHM13.fa.gz.fai --output region.bed --hierarchy region.tsv
+    """
+    _run(
+        structural_prep.from_censat,
+        [output, hierarchy, priority],
+        force,
+        input_path=input_path,
+        lengths=lengths,
+        output=output,
+        hierarchy=hierarchy,
+        priority=priority,
+        name=name,
+        rename=_rewriter(rename_prefix, seqid_map),
+    )
+
+
 @cmd.command("satellite")
 @click.option(
     "--input",

--- a/src/karyoscope/commands/prep_bed.py
+++ b/src/karyoscope/commands/prep_bed.py
@@ -1,0 +1,588 @@
+"""``karyoscope prep-bed`` — turn a source annotation into a feature-set BED.
+
+One subcommand per *source format*, because unrelated formats produce the same
+kind of feature set: RepeatMasker output and an EDTA GFF3 both yield a
+``repeat`` set but share no parsing. Keying on the format means each subcommand
+carries exactly the options that apply to it, with no flags that are silently
+ignored depending on the input.
+
+Each subcommand writes the BED (and, where the format implies one, a hierarchy)
+and prints the matching ``feature_sets:`` stanza on **stdout**, with progress
+and warnings on stderr — so the stanza can be redirected into a build spec
+without capturing the commentary.
+
+What these subcommands deliberately do *not* do is gap-fill, flatten overlaps,
+or drop sequences: ``karyoscope build`` already owns all three, via
+``background:``, ``flatten:`` and ``exclude:``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import click
+
+from karyoscope.core.prep import cytoband as cytoband_prep
+from karyoscope.core.prep import genes as genes_prep
+from karyoscope.core.prep import repeats as repeats_prep
+from karyoscope.core.prep import structural as structural_prep
+from karyoscope.core.prep.common import PrepError, PrepResult, SeqidRewriter, render_stanza
+
+logger = logging.getLogger(__name__)
+
+_IN = dict(exists=True, dir_okay=False, path_type=Path)
+_OUT = dict(dir_okay=False, writable=True, path_type=Path)
+
+
+def _seqid_options(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Attach the two seqid-rewriting options every converter shares."""
+    func = click.option(
+        "--seqid-map",
+        type=click.Path(**_IN),
+        default=None,
+        help="Two-column 'old new' table renaming annotation seqids to match the assembly "
+        "(e.g. NC_060925.1 -> chr1). Takes precedence over --rename-prefix.",
+    )(func)
+    return click.option(
+        "--rename-prefix",
+        metavar="OLD:NEW",
+        default=None,
+        help="Rewrite a leading seqid prefix, e.g. 'Col-CEN_chr:Chr'. Names not starting "
+        "with OLD are left alone.",
+    )(func)
+
+
+def _rewriter(rename_prefix: str | None, seqid_map: Path | None) -> SeqidRewriter:
+    """Build the rewriter, reporting a malformed option as a usage error.
+
+    This runs while assembling ``_run``'s arguments, outside its handler, so it
+    has to translate the error itself or the user gets a bare traceback.
+    """
+    try:
+        return SeqidRewriter.build(rename_prefix=rename_prefix, seqid_map=seqid_map)
+    except PrepError as e:
+        raise click.UsageError(str(e)) from e
+
+
+def _report(result: PrepResult) -> None:
+    """Commentary to stderr, the pasteable stanza to stdout."""
+    for note in result.notes:
+        click.echo(f"note: {note}", err=True)
+    click.echo(result.summary(), err=True)
+    click.echo(err=True)
+    click.echo(render_stanza(result))
+
+
+def _guard(paths: list[Path | None], force: bool) -> None:
+    existing = [str(p) for p in paths if p is not None and p.exists()]
+    if existing and not force:
+        raise click.ClickException(
+            "refusing to overwrite (pass --force): " + ", ".join(sorted(existing))
+        )
+
+
+def _run(
+    fn: Callable[..., PrepResult], outputs: list[Path | None], force: bool, **kwargs: Any
+) -> None:
+    _guard(outputs, force)
+    try:
+        result = fn(**kwargs)
+    except PrepError as e:
+        raise click.ClickException(str(e)) from e
+    _report(result)
+
+
+@click.group(
+    "prep-bed",
+    help="Convert a source annotation (RepeatMasker, EDTA, GFF3/GTF, UCSC cytoband, .fai) "
+    "into a feature-set BED for `karyoscope build`.",
+    no_args_is_help=True,
+)
+def cmd() -> None:
+    """Prepare feature-set BEDs from source annotation formats."""
+
+
+# -- repeat sets ------------------------------------------------------
+
+
+@cmd.command("repeatmasker")
+@click.option(
+    "--input",
+    "input_path",
+    type=click.Path(**_IN),
+    required=True,
+    help="RepeatMasker output: the native .out table or the UCSC BED repackaging "
+    "(auto-detected; plain or gzipped).",
+)
+@click.option("--output", type=click.Path(**_OUT), required=True, help="Output feature-set BED.")
+@click.option(
+    "--hierarchy",
+    type=click.Path(**_OUT),
+    required=True,
+    help="Output 'child<TAB>parent' hierarchy.",
+)
+@click.option(
+    "--colors",
+    type=click.Path(**_OUT),
+    default=None,
+    help="Also write a colours file using the reference KaryoScope repeat palette, "
+    "with the five RNA leaves sharing one legend row.",
+)
+@click.option(
+    "--priority",
+    type=click.Path(**_OUT),
+    default=None,
+    help="Also write the tree as a 3-column priority file, for a priority-mode build.",
+)
+@click.option("--name", default="repeat", show_default=True, help="Feature-set name in the stanza.")
+@click.option(
+    "--background",
+    default="nonrepeat",
+    show_default=True,
+    help="Gap-fill label build should use for the bases no repeat covers.",
+)
+@_seqid_options
+@click.option("--force", is_flag=True, help="Overwrite existing output files.")
+def repeatmasker(
+    input_path: Path,
+    output: Path,
+    hierarchy: Path,
+    colors: Path | None,
+    priority: Path | None,
+    name: str,
+    background: str,
+    rename_prefix: str | None,
+    seqid_map: Path | None,
+    force: bool,
+) -> None:
+    """RepeatMasker output -> a `repeat` feature set.
+
+    \b
+    Leaves are the RepeatMasker classes; the hierarchy and palette reproduce the
+    shipped HKS_human_CHM13_v2 `repeat` set. Unrecognised classes are labelled
+    `Unknown` rather than dropped, so their bases are never mistaken for
+    non-repeat by the gap-fill.
+
+    \b
+    Example:
+        karyoscope prep-bed repeatmasker --input rm.bed \\
+            --output repeat.bed --hierarchy repeat.tsv --colors repeat_colors.tsv
+    """
+    _run(
+        repeats_prep.from_repeatmasker,
+        [output, hierarchy, colors, priority],
+        force,
+        input_path=input_path,
+        output=output,
+        hierarchy=hierarchy,
+        colors=colors,
+        priority=priority,
+        name=name,
+        background=background,
+        rename=_rewriter(rename_prefix, seqid_map),
+    )
+
+
+@cmd.command("edta")
+@click.option(
+    "--input",
+    "input_path",
+    type=click.Path(**_IN),
+    required=True,
+    help="EDTA TE GFF3 (plain or gzipped).",
+)
+@click.option("--output", type=click.Path(**_OUT), required=True, help="Output feature-set BED.")
+@click.option(
+    "--hierarchy",
+    type=click.Path(**_OUT),
+    required=True,
+    help="Output 'child<TAB>parent' hierarchy.",
+)
+@click.option(
+    "--priority",
+    type=click.Path(**_OUT),
+    default=None,
+    help="Also write the tree as a 3-column priority file, for a priority-mode build.",
+)
+@click.option("--name", default="repeat", show_default=True, help="Feature-set name in the stanza.")
+@click.option(
+    "--background",
+    default="nonrepeat",
+    show_default=True,
+    help="Gap-fill label build should use for the bases no TE covers.",
+)
+@_seqid_options
+@click.option("--force", is_flag=True, help="Overwrite existing output files.")
+def edta(
+    input_path: Path,
+    output: Path,
+    hierarchy: Path,
+    priority: Path | None,
+    name: str,
+    background: str,
+    rename_prefix: str | None,
+    seqid_map: Path | None,
+    force: bool,
+) -> None:
+    """An EDTA TE GFF3 -> a `repeat` feature set.
+
+    \b
+    EDTA's `Classification=` vocabulary aliases each superfamily under both
+    spelled-out and Wicker three-letter names (DNA/HAT and DNA/DTA are both
+    hAT); those are normalised to one leaf per superfamily so the BED labels and
+    the hierarchy leaves agree by construction.
+
+    \b
+    No colours are written: there is no established palette for the EDTA
+    vocabulary, so build's automatic assignment beats an invented one.
+    """
+    _run(
+        repeats_prep.from_edta,
+        [output, hierarchy, priority],
+        force,
+        input_path=input_path,
+        output=output,
+        hierarchy=hierarchy,
+        priority=priority,
+        name=name,
+        background=background,
+        rename=_rewriter(rename_prefix, seqid_map),
+    )
+
+
+# -- gene set ---------------------------------------------------------
+
+
+@cmd.command("gff-gene")
+@click.option(
+    "--input",
+    "input_path",
+    type=click.Path(**_IN),
+    required=True,
+    help="Gene annotation in GFF3 or GTF (plain or gzipped; dialect auto-detected).",
+)
+@click.option(
+    "--lengths",
+    type=click.Path(**_IN),
+    required=True,
+    help="samtools .fai (or 2-column sizes file) for the target assembly.",
+)
+@click.option("--output", type=click.Path(**_OUT), required=True, help="Output feature-set BED.")
+@click.option(
+    "--hierarchy",
+    type=click.Path(**_OUT),
+    required=True,
+    help="Output 'child<TAB>parent' hierarchy.",
+)
+@click.option(
+    "--colors",
+    type=click.Path(**_OUT),
+    default=None,
+    help="Also write a colours file using the reference exon/intron/intergenic palette.",
+)
+@click.option("--name", default="gene", show_default=True, help="Feature-set name in the stanza.")
+@click.option(
+    "--feature-type",
+    default="exon",
+    show_default=True,
+    help="GFF/GTF column-3 type to read as an exon.",
+)
+@_seqid_options
+@click.option("--force", is_flag=True, help="Overwrite existing output files.")
+def gff_gene(
+    input_path: Path,
+    lengths: Path,
+    output: Path,
+    hierarchy: Path,
+    colors: Path | None,
+    name: str,
+    feature_type: str,
+    rename_prefix: str | None,
+    seqid_map: Path | None,
+    force: bool,
+) -> None:
+    """A GFF3/GTF gene annotation -> an `exon`/`intron`/`intergenic` set.
+
+    \b
+    Introns are derived per transcript as the gaps between its exons. Where
+    transcripts disagree the more specific label wins (exon > intron >
+    intergenic), so alternative splicing never double-labels a base.
+
+    \b
+    The result tiles every sequence in --lengths, so the stanza sets
+    `background: null`. If the annotation uses accessions rather than
+    chromosome names, map them with --seqid-map.
+
+    \b
+    Example:
+        karyoscope prep-bed gff-gene --input genes.gtf.gz --lengths ref.fa.fai \\
+            --output gene.bed --hierarchy gene.tsv
+    """
+    _run(
+        genes_prep.from_gff,
+        [output, hierarchy, colors],
+        force,
+        input_path=input_path,
+        lengths=lengths,
+        output=output,
+        hierarchy=hierarchy,
+        colors=colors,
+        name=name,
+        feature_type=feature_type,
+        rename=_rewriter(rename_prefix, seqid_map),
+    )
+
+
+# -- cytoband set -----------------------------------------------------
+
+
+@cmd.command("cytoband")
+@click.option(
+    "--input",
+    "input_path",
+    type=click.Path(**_IN),
+    required=True,
+    help="UCSC cytoBand.txt(.gz) (5 columns) or cytoBandMapped BED (6 columns).",
+)
+@click.option(
+    "--lengths",
+    type=click.Path(**_IN),
+    required=True,
+    help="samtools .fai (or 2-column sizes file) for the target assembly.",
+)
+@click.option("--output", type=click.Path(**_OUT), required=True, help="Output feature-set BED.")
+@click.option(
+    "--hierarchy",
+    type=click.Path(**_OUT),
+    required=True,
+    help="Output 'child<TAB>parent' hierarchy (chromosome -> band group -> band).",
+)
+@click.option(
+    "--colors",
+    type=click.Path(**_OUT),
+    default=None,
+    help="Also write a colours file keyed on Giemsa stain, grouping the legend by "
+    "stain so several hundred bands collapse to a handful of rows.",
+)
+@click.option(
+    "--priority",
+    type=click.Path(**_OUT),
+    default=None,
+    help="Also write the tree as a 3-column priority file, for a priority-mode build.",
+)
+@click.option(
+    "--name", default="cytoband", show_default=True, help="Feature-set name in the stanza."
+)
+@click.option(
+    "--primary-pattern",
+    default=cytoband_prep.DEFAULT_PRIMARY_PATTERN,
+    show_default=True,
+    help="Regex of seqids that carry banding. The default drops alt/random/fix "
+    "scaffolds, unplaced contigs and the mitochondrion.",
+)
+@_seqid_options
+@click.option("--force", is_flag=True, help="Overwrite existing output files.")
+def cytoband(
+    input_path: Path,
+    lengths: Path,
+    output: Path,
+    hierarchy: Path,
+    colors: Path | None,
+    priority: Path | None,
+    name: str,
+    primary_pattern: str,
+    rename_prefix: str | None,
+    seqid_map: Path | None,
+    force: bool,
+) -> None:
+    """A UCSC cytoband table -> a `cytoband` feature set.
+
+    \b
+    Band labels keep their chromosome (chr1 + p36.33 -> 1p36.33) so no label is
+    ambiguous, and nest three deep: chromosome -> band group -> band.
+
+    \b
+    Sequences with no banding are not given a placeholder label. They are
+    reported for the spec's top-level `exclude:`, so no feature set claims them.
+
+    \b
+    Example:
+        karyoscope prep-bed cytoband --input cytoBand.txt.gz --lengths ref.fa.fai \\
+            --output cytoband.bed --hierarchy cytoband.tsv --colors cytoband_colors.tsv
+    """
+    _run(
+        cytoband_prep.from_ucsc,
+        [output, hierarchy, colors, priority],
+        force,
+        input_path=input_path,
+        lengths=lengths,
+        output=output,
+        hierarchy=hierarchy,
+        colors=colors,
+        priority=priority,
+        name=name,
+        primary_pattern=primary_pattern,
+        rename=_rewriter(rename_prefix, seqid_map),
+    )
+
+
+# -- structural sets --------------------------------------------------
+
+
+@cmd.command("fai")
+@click.option(
+    "--lengths",
+    type=click.Path(**_IN),
+    required=True,
+    help="samtools .fai (or 2-column sizes file) for the target assembly.",
+)
+@click.option("--output", type=click.Path(**_OUT), required=True, help="Output feature-set BED.")
+@click.option(
+    "--hierarchy",
+    type=click.Path(**_OUT),
+    default=None,
+    help="Also write a flat hierarchy with every sequence under the root, as a "
+    "starting point for hand-curated grouping.",
+)
+@click.option(
+    "--name", default="chromosome", show_default=True, help="Feature-set name in the stanza."
+)
+@_seqid_options
+@click.option("--force", is_flag=True, help="Overwrite existing output files.")
+def fai(
+    lengths: Path,
+    output: Path,
+    hierarchy: Path | None,
+    name: str,
+    rename_prefix: str | None,
+    seqid_map: Path | None,
+    force: bool,
+) -> None:
+    """A samtools .fai -> a `chromosome` feature set.
+
+    \b
+    One whole-length record per sequence, labelled with its own name. No
+    grouping hierarchy is derived: how sequences group (autosome vs sex,
+    metacentric vs acrocentric, haplotype) is organism-specific curation that a
+    .fai cannot supply. Use --hierarchy to get a flat starting point to edit.
+
+    \b
+    Keep non-karyotype sequences out with build's `exclude:` rather than by
+    filtering here, so every feature set agrees about what exists.
+    """
+    _run(
+        structural_prep.from_fai,
+        [output, hierarchy],
+        force,
+        lengths=lengths,
+        output=output,
+        hierarchy=hierarchy,
+        name=name,
+        rename=_rewriter(rename_prefix, seqid_map),
+    )
+
+
+@cmd.command("satellite")
+@click.option(
+    "--input",
+    "input_path",
+    type=click.Path(**_IN),
+    required=True,
+    help="Centromeric satellite monomers as GFF/GFF3 (1-based) or BED (0-based); "
+    "the coordinate convention follows the file suffix.",
+)
+@click.option(
+    "--lengths",
+    type=click.Path(**_IN),
+    required=True,
+    help="samtools .fai (or 2-column sizes file) for the target assembly.",
+)
+@click.option("--output", type=click.Path(**_OUT), required=True, help="Output feature-set BED.")
+@click.option(
+    "--hierarchy",
+    type=click.Path(**_OUT),
+    required=True,
+    help="Output 'child<TAB>parent' hierarchy.",
+)
+@click.option(
+    "--priority",
+    type=click.Path(**_OUT),
+    default=None,
+    help="Also write the tree as a 3-column priority file, for a priority-mode build.",
+)
+@click.option("--name", default="region", show_default=True, help="Feature-set name in the stanza.")
+@click.option(
+    "--satellite",
+    default="satellite",
+    show_default=True,
+    help="Leaf label for the satellite bands, e.g. 'CEN180' or 'aSat'.",
+)
+@click.option(
+    "--merge-gap",
+    type=int,
+    default=10,
+    show_default=True,
+    help="Merge monomers separated by at most this many bases into one band. The "
+    "default bridges 1-2 bp monomer-boundary artefacts without swallowing real "
+    "interior insertions; 0 keeps strict monomer bands.",
+)
+@click.option(
+    "--cluster-gap",
+    type=int,
+    default=500_000,
+    show_default=True,
+    help="Gap for clustering bands when locating the centromere core.",
+)
+@_seqid_options
+@click.option("--force", is_flag=True, help="Overwrite existing output files.")
+def satellite(
+    input_path: Path,
+    lengths: Path,
+    output: Path,
+    hierarchy: Path,
+    priority: Path | None,
+    name: str,
+    satellite: str,
+    merge_gap: int,
+    cluster_gap: int,
+    rename_prefix: str | None,
+    seqid_map: Path | None,
+    force: bool,
+) -> None:
+    """A centromeric-satellite annotation -> a fully-tiled `region` set.
+
+    \b
+    Monomers merge into bands, the densest cluster of bands is taken as the
+    centromere core, and every remaining base is labelled by which side of the
+    core it falls on: p_arm, the satellite itself, cen_gap inside the core, and
+    q_arm. This is the one converter that tiles, because only the satellite
+    annotation knows where the centromere is — build's gap-fill has just one
+    label and could not tell the arms apart.
+
+    \b
+    p and q are assigned by coordinate, so this assumes the assembly is oriented
+    short-arm-first.
+
+    \b
+    Example:
+        karyoscope prep-bed satellite --input CEN180.gff --lengths ref.fa.fai \\
+            --satellite CEN180 --output region.bed --hierarchy region.tsv
+    """
+    _run(
+        structural_prep.from_satellite,
+        [output, hierarchy, priority],
+        force,
+        input_path=input_path,
+        lengths=lengths,
+        output=output,
+        hierarchy=hierarchy,
+        priority=priority,
+        name=name,
+        satellite=satellite,
+        merge_gap=merge_gap,
+        cluster_gap=cluster_gap,
+        rename=_rewriter(rename_prefix, seqid_map),
+    )

--- a/src/karyoscope/core/prep/__init__.py
+++ b/src/karyoscope/core/prep/__init__.py
@@ -1,0 +1,18 @@
+"""Source-format converters behind ``karyoscope prep-bed``.
+
+Each converter turns one *source annotation format* into the two files
+``karyoscope build`` consumes for a feature set: a 4-column BED whose 4th
+column is a leaf label, and (where the format implies one) a ``child parent``
+hierarchy. Converters are keyed by input format rather than by feature-set
+name because unrelated formats can produce the same kind of set — RepeatMasker
+output and an EDTA GFF3 both yield a ``repeat`` set but share no parsing at all.
+
+Converters do **not** tile, gap-fill, flatten overlaps, or drop sequences:
+``build`` already does all of that (``background:``, ``flatten:``, ``exclude:``).
+The one exception is semantic tiling that only the source format can do — the
+p-arm/q-arm split around a satellite core in :mod:`.structural`.
+"""
+
+from karyoscope.core.prep.common import PrepResult, render_stanza
+
+__all__ = ["PrepResult", "render_stanza"]

--- a/src/karyoscope/core/prep/common.py
+++ b/src/karyoscope/core/prep/common.py
@@ -1,0 +1,287 @@
+"""Shared plumbing for the ``prep-bed`` converters.
+
+Readers (:func:`open_text`, :func:`read_fai`), the seqid rewriting every
+converter offers, the file writers, and :class:`PrepResult` — the description of
+what a converter produced, which :func:`render_stanza` turns into the
+build-spec fragment ``prep-bed`` prints on stdout.
+"""
+
+from __future__ import annotations
+
+import gzip
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import IO
+
+from karyoscope.exceptions import KaryoscopeError
+
+#: One BED record: ``(seqid, start, end, label)``, start/end 0-based half-open.
+Record = tuple[str, int, int, str]
+
+#: One ``child parent`` hierarchy edge.
+Edge = tuple[str, str]
+
+#: One colours row: ``(feature, hex_color, legend_group)``; group ``""`` = none.
+ColorRow = tuple[str, str, str]
+
+
+class PrepError(KaryoscopeError):
+    """A source annotation could not be converted."""
+
+
+# -- readers ----------------------------------------------------------
+
+
+def open_text(path: Path) -> IO[str]:
+    """Open ``path`` as text, transparently handling gzip.
+
+    Detects gzip by magic bytes rather than by suffix: annotation downloads are
+    routinely renamed, and a mis-suffixed file would otherwise fail deep inside
+    a parser with an unreadable error.
+    """
+    try:
+        with path.open("rb") as probe:
+            is_gzip = probe.read(2) == b"\x1f\x8b"
+    except OSError as e:
+        raise PrepError(f"could not read {path}: {e}") from e
+    return gzip.open(path, "rt") if is_gzip else path.open()
+
+
+def read_fai(path: Path) -> dict[str, int]:
+    """Read sequence lengths from a samtools ``.fai`` or a 2-column sizes file.
+
+    Insertion order is the file's order, and every converter iterates it as
+    given. The ``.fai`` is the assembly's own declaration of what order its
+    sequences come in; re-sorting it would invent an ordering the assembly never
+    stated, and any rule for doing so is guesswork outside human chromosome
+    naming.
+    """
+    sizes: dict[str, int] = {}
+    with path.open() as fh:
+        for lineno, raw in enumerate(fh, 1):
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            if len(parts) < 2:
+                raise PrepError(f"{path}:{lineno}: expected 'name length', got {raw.rstrip()!r}")
+            try:
+                sizes[parts[0]] = int(parts[1])
+            except ValueError as e:
+                raise PrepError(f"{path}:{lineno}: length is not an integer: {parts[1]!r}") from e
+    if not sizes:
+        raise PrepError(f"{path}: no sequences found")
+    return sizes
+
+
+def iter_gff(path: Path) -> Iterator[tuple[list[str], int]]:
+    """Yield ``(fields, lineno)`` for each data line of a GFF3/GTF file.
+
+    Comments, blank lines, and the FASTA section some GFF3 files append are
+    skipped; short lines raise, since a truncated annotation should not silently
+    produce a partial feature set.
+    """
+    with open_text(path) as fh:
+        for lineno, raw in enumerate(fh, 1):
+            if raw.startswith("#"):
+                if raw.startswith("##FASTA"):
+                    return
+                continue
+            line = raw.rstrip("\n")
+            if not line.strip():
+                continue
+            fields = line.split("\t")
+            if len(fields) < 9:
+                raise PrepError(
+                    f"{path}:{lineno}: expected 9 tab-separated columns, got {len(fields)}"
+                )
+            yield fields, lineno
+
+
+# -- seqid rewriting --------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SeqidRewriter:
+    """Rewrites annotation seqids so they match the assembly FASTA.
+
+    Two mechanisms, applied in order: an exact ``old -> new`` table (for
+    accession-style names like ``NC_060925.1`` -> ``chr1``), then a prefix
+    substitution (for systematic differences like ``Col-CEN_chr`` -> ``Chr``).
+    A name matched by neither is passed through unchanged.
+    """
+
+    table: dict[str, str] = field(default_factory=dict)
+    old_prefix: str = ""
+    new_prefix: str = ""
+
+    def __call__(self, seqid: str) -> str:
+        mapped = self.table.get(seqid)
+        if mapped is not None:
+            return mapped
+        if self.old_prefix and seqid.startswith(self.old_prefix):
+            return self.new_prefix + seqid[len(self.old_prefix) :]
+        return seqid
+
+    @classmethod
+    def build(cls, *, rename_prefix: str | None, seqid_map: Path | None) -> SeqidRewriter:
+        """Assemble a rewriter from the ``--rename-prefix`` / ``--seqid-map`` options."""
+        old_prefix = new_prefix = ""
+        if rename_prefix:
+            if ":" not in rename_prefix:
+                raise PrepError(f"--rename-prefix needs OLD:NEW form, got {rename_prefix!r}")
+            old_prefix, _, new_prefix = rename_prefix.partition(":")
+            if not old_prefix:
+                raise PrepError("--rename-prefix: the OLD prefix must not be empty")
+        table: dict[str, str] = {}
+        if seqid_map is not None:
+            with seqid_map.open() as fh:
+                for lineno, raw in enumerate(fh, 1):
+                    line = raw.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    parts = line.split()
+                    if len(parts) < 2:
+                        raise PrepError(f"{seqid_map}:{lineno}: expected 'old new', got {line!r}")
+                    table[parts[0]] = parts[1]
+        return cls(table=table, old_prefix=old_prefix, new_prefix=new_prefix)
+
+
+# -- ordering ---------------------------------------------------------
+
+
+def coalesce(records: Iterable[Record]) -> list[Record]:
+    """Merge abutting records that share a sequence and a label."""
+    out: list[list] = []
+    for seqid, start, end, label in records:
+        if out and out[-1][0] == seqid and out[-1][3] == label and out[-1][2] == start:
+            out[-1][2] = end
+        else:
+            out.append([seqid, start, end, label])
+    return [(c, s, e, lbl) for c, s, e, lbl in out]
+
+
+# -- writers ----------------------------------------------------------
+
+
+def write_bed(path: Path, records: Iterable[Record]) -> int:
+    """Write 4-column BED, returning the record count."""
+    n = 0
+    with path.open("w") as out:
+        for seqid, start, end, label in records:
+            if end <= start:
+                continue
+            out.write(f"{seqid}\t{start}\t{end}\t{label}\n")
+            n += 1
+    if n == 0:
+        raise PrepError(f"{path}: no records produced — check the input and any seqid renaming")
+    return n
+
+
+def write_hierarchy(path: Path, edges: Iterable[Edge]) -> int:
+    """Write a 2-column ``child<TAB>parent`` hierarchy, returning the edge count."""
+    n = 0
+    with path.open("w") as out:
+        for child, parent in edges:
+            out.write(f"{child}\t{parent}\n")
+            n += 1
+    return n
+
+
+def write_priority(path: Path, edges: Iterable[Edge], priority: int = 1) -> int:
+    """Write the same tree as 3-column ``child<TAB>priority<TAB>parent``."""
+    n = 0
+    with path.open("w") as out:
+        for child, parent in edges:
+            out.write(f"{child}\t{priority}\t{parent}\n")
+            n += 1
+    return n
+
+
+def write_colors(path: Path, set_name: str, rows: Iterable[ColorRow]) -> int:
+    """Write a colours file in the 4-column shape ``build`` both reads and emits.
+
+    The ``legend_group`` column is written only when some feature declares one,
+    so an ungrouped set stays a plain 3-column file.
+    """
+    rows = list(rows)
+    grouped = any(group for _f, _c, group in rows)
+    with path.open("w") as out:
+        out.write(
+            "feature_set\tfeature\tcolor\tlegend_group\n"
+            if grouped
+            else "feature_set\tfeature\tcolor\n"
+        )
+        for feature, color, group in rows:
+            if grouped:
+                out.write(f"{set_name}\t{feature}\t{color}\t{group}\n")
+            else:
+                out.write(f"{set_name}\t{feature}\t{color}\n")
+    return len(rows)
+
+
+# -- result and build-spec stanza -------------------------------------
+
+
+@dataclass
+class PrepResult:
+    """What a converter produced, and how ``build`` should be told about it."""
+
+    name: str
+    bed: Path
+    n_records: int
+    #: ``None`` means the set already tiles every base, so gap-fill must be off.
+    background: str | None = None
+    hierarchy: Path | None = None
+    n_edges: int = 0
+    priority: Path | None = None
+    colors: Path | None = None
+    n_colors: int = 0
+    #: Sequences present in the assembly that this set deliberately does not
+    #: cover — suggested for the spec's top-level ``exclude:``.
+    exclude: list[str] = field(default_factory=list)
+    #: Human-readable remarks for stderr (unmapped classes, dropped rows, ...).
+    notes: list[str] = field(default_factory=list)
+
+    def summary(self) -> str:
+        """One line naming every file written, for stderr."""
+        parts = [f"{self.bed} ({self.n_records:,} records)"]
+        if self.hierarchy is not None:
+            parts.append(f"{self.hierarchy} ({self.n_edges:,} edges)")
+        if self.priority is not None:
+            parts.append(f"{self.priority} ({self.n_edges:,} rows)")
+        if self.colors is not None:
+            parts.append(f"{self.colors} ({self.n_colors:,} features)")
+        return "wrote " + ", ".join(parts)
+
+
+def render_stanza(result: PrepResult) -> str:
+    """Render the ``feature_sets:`` fragment to paste into a build spec.
+
+    Hand-rendered rather than dumped through PyYAML so the keys stay in the
+    order the docs present them and the paths appear exactly as the user typed
+    them.
+    """
+    lines = [
+        "# add to your build spec:",
+        "feature_sets:",
+        f"  - name: {result.name}",
+        f"    bed: {result.bed}",
+    ]
+    if result.hierarchy is not None:
+        lines.append(f"    hierarchy: {result.hierarchy}")
+    if result.priority is not None:
+        lines.append(f"    priority: {result.priority}")
+    if result.colors is not None:
+        lines.append(f"    colors: {result.colors}")
+    if result.background is None:
+        lines.append("    background: null   # this set already tiles every base")
+    else:
+        lines.append(f"    background: {result.background}")
+    if result.exclude:
+        lines.append("")
+        lines.append("# and at the top level, so no set covers these sequences:")
+        lines.append("exclude:")
+        lines.extend(f"  - {seqid}" for seqid in result.exclude)
+    return "\n".join(lines)

--- a/src/karyoscope/core/prep/cytoband.py
+++ b/src/karyoscope/core/prep/cytoband.py
@@ -1,0 +1,258 @@
+"""A UCSC cytoband table -> a ``cytoband`` feature set.
+
+Handles both shapes UCSC ships: the golden-path ``cytoBand.txt(.gz)``
+(``chrom start end band stain``) used for hg19/hg38, and the 6-column
+``cytoBandMapped`` BED used for CHM13. Both carry the Giemsa stain in column 5,
+which is what the colours and the legend grouping are built from.
+
+Band labels keep the chromosome (``chr1`` + ``p36.33`` -> ``1p36.33``) so a
+label is never ambiguous across chromosomes, and the hierarchy nests them three
+deep: chromosome -> band group -> band. Because a whole-genome cytoband set has
+several hundred leaves, the emitted colours file groups the legend by stain —
+the CHM13 set's 833 rendered features collapse to 9 legend rows.
+
+Sequences with no cytogenetic banding (``_alt``/``_random``/``_fix``
+scaffolds, ``chrUn_*`` contigs, and the mitochondrion) are not labelled. They
+are reported for the build spec's top-level ``exclude:`` rather than given a
+placeholder label, so no feature set claims them and they read as ``none``.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+from pathlib import Path
+
+from karyoscope.core.prep.common import (
+    ColorRow,
+    Edge,
+    PrepError,
+    PrepResult,
+    Record,
+    SeqidRewriter,
+    open_text,
+    read_fai,
+    write_bed,
+    write_colors,
+    write_hierarchy,
+    write_priority,
+)
+
+CATEGORIZED = "categorized"
+
+#: Sequences that carry cytogenetic banding. Deliberately strict: everything a
+#: reference FASTA adds beyond the primary chromosomes (alt loci, patches,
+#: unplaced contigs, organelles) has no banding to assign.
+DEFAULT_PRIMARY_PATTERN = r"^chr([0-9]+|X|Y)$"
+
+#: Colour for interior nodes (the root, chromosomes, band groups). They never
+#: render — smoothed output carries leaves — but ``build`` colours every node.
+INTERIOR_COLOR = "#B0C4DE"
+INTERIOR_GROUP = "mixed"
+
+#: Giemsa stain -> colour, as shipped in ``HKS_human_CHM13_cytoband``. Written
+#: in intensity order so the legend, which orders groups by first appearance,
+#: reads as the stain progression rather than alphabetically.
+STAIN_COLORS: dict[str, str] = {
+    "gneg": "#E0E0E0",
+    "gpos25": "#A8A8A8",
+    "gpos33": "#8C8C8C",  # interpolated; not present in the CHM13/hg38 tables
+    "gpos50": "#707070",
+    "gpos66": "#545454",  # interpolated; not present in the CHM13/hg38 tables
+    "gpos75": "#383838",
+    "gpos100": "#000000",
+    "acen": "#E41A1C",
+    "gvar": "#4292C6",
+    "stalk": "#41AB5D",
+}
+
+
+def short_name(seqid: str) -> str:
+    """``chr1`` -> ``1`` — the label prefix. The seqid itself is left alone."""
+    return seqid[3:] if seqid.startswith("chr") else seqid
+
+
+def band_group(fullname: str) -> str | None:
+    """Group node for a band, or ``None`` when it has no sub-band.
+
+    ``1p36.33`` -> ``1p36``; ``1p33`` -> ``None`` (it hangs off its chromosome).
+    """
+    return fullname.split(".", 1)[0] if "." in fullname else None
+
+
+def read_bands(path: Path) -> OrderedDict[str, list[tuple[int, int, str, str]]]:
+    """Read a cytoband table into ``{seqid: [(start, end, band, stain), ...]}``.
+
+    The 6-column BED's column 6 full name is ignored and rebuilt from chromosome
+    plus band, so both input shapes take the same code path and produce
+    identical labels.
+    """
+    by_seqid: OrderedDict[str, list[tuple[int, int, str, str]]] = OrderedDict()
+    with open_text(path) as fh:
+        for lineno, raw in enumerate(fh, 1):
+            line = raw.rstrip("\n")
+            if not line.strip() or line.startswith(("#", "track", "browser")):
+                continue
+            parts = line.split("\t")
+            if len(parts) < 4:
+                raise PrepError(f"{path}:{lineno}: expected at least 4 columns, got {len(parts)}")
+            band = parts[3].strip()
+            if not band:  # e.g. chrM's single unnamed band
+                continue
+            stain = parts[4].strip() if len(parts) >= 5 else ""
+            try:
+                start, end = int(parts[1]), int(parts[2])
+            except ValueError as e:
+                raise PrepError(f"{path}:{lineno}: non-integer coordinates") from e
+            by_seqid.setdefault(parts[0], []).append((start, end, band, stain))
+    if not by_seqid:
+        raise PrepError(f"{path}: no cytoband rows found")
+    return by_seqid
+
+
+def hierarchy_edges(chrom_bands: OrderedDict[str, list[tuple[int, int, str, str]]]) -> list[Edge]:
+    """Ordered edges: chromosome -> root, band group -> chromosome, band -> group."""
+    edges: list[Edge] = []
+    for seqid, bands in chrom_bands.items():
+        node = short_name(seqid)
+        edges.append((node, CATEGORIZED))
+        seen_groups: set[str] = set()
+        for _s, _e, fullname, _stain in bands:
+            group = band_group(fullname)
+            if group is None:
+                edges.append((fullname, node))
+            else:
+                if group not in seen_groups:
+                    edges.append((group, node))
+                    seen_groups.add(group)
+                edges.append((fullname, group))
+    return edges
+
+
+def verify(
+    chrom_bands: OrderedDict[str, list[tuple[int, int, str, str]]], edges: list[Edge]
+) -> None:
+    """Check every band label is a hierarchy node with a clean path to the root.
+
+    Cheap to do here and much cheaper than discovering it part-way through a
+    multi-hour ``build``.
+    """
+    children = [c for c, _p in edges]
+    duplicates = {c for c in children if children.count(c) > 1}
+    if duplicates:
+        raise PrepError(f"duplicate hierarchy node(s): {sorted(duplicates)}")
+    parent = dict(edges)
+    leaves = {full for bands in chrom_bands.values() for _s, _e, full, _st in bands}
+    collisions = leaves & {g for g in parent if g not in leaves and g != CATEGORIZED}
+    if collisions:
+        raise PrepError(f"label is both a band and a group: {sorted(collisions)}")
+    for leaf in leaves:
+        node, depth = leaf, 0
+        while node in parent and parent[node] != CATEGORIZED:
+            node, depth = parent[node], depth + 1
+            if depth > 5:
+                raise PrepError(f"parent chain too deep for band {leaf!r}")
+        if node not in parent:
+            raise PrepError(f"band {leaf!r} has no path to {CATEGORIZED!r}")
+
+
+def from_ucsc(
+    *,
+    input_path: Path,
+    lengths: Path,
+    output: Path,
+    hierarchy: Path,
+    colors: Path | None = None,
+    priority: Path | None = None,
+    name: str = "cytoband",
+    primary_pattern: str = DEFAULT_PRIMARY_PATTERN,
+    rename: SeqidRewriter | None = None,
+) -> PrepResult:
+    """Convert a UCSC cytoband table into a ``cytoband`` feature set."""
+    rename = rename or SeqidRewriter()
+    try:
+        primary = re.compile(primary_pattern)
+    except re.error as e:
+        raise PrepError(f"--primary-pattern is not a valid regex: {e}") from e
+
+    sizes = read_fai(lengths)
+    raw_bands = read_bands(input_path)
+    bands_by_seqid = {rename(seqid): bands for seqid, bands in raw_bands.items()}
+
+    chrom_bands: OrderedDict[str, list[tuple[int, int, str, str]]] = OrderedDict()
+    excluded: list[str] = []
+    unbanded: list[str] = []
+    for seqid in sizes:
+        if not primary.match(seqid):
+            excluded.append(seqid)
+            continue
+        if seqid not in bands_by_seqid:
+            unbanded.append(seqid)
+            continue
+        prefix = short_name(seqid)
+        chrom_bands[seqid] = [
+            (start, end, f"{prefix}{band}", stain)
+            for start, end, band, stain in bands_by_seqid[seqid]
+        ]
+    if not chrom_bands:
+        raise PrepError(
+            f"no sequences kept — {primary_pattern!r} matched none of the {len(sizes)} "
+            f"seqids in {lengths}; widen --primary-pattern or rename with --rename-prefix"
+        )
+
+    edges = hierarchy_edges(chrom_bands)
+    verify(chrom_bands, edges)
+
+    records: list[Record] = [
+        (seqid, start, end, fullname)
+        for seqid, bands in chrom_bands.items()
+        for start, end, fullname, _stain in bands
+    ]
+    n_records = write_bed(output, records)
+    n_edges = write_hierarchy(hierarchy, edges)
+    if priority is not None:
+        write_priority(priority, edges)
+
+    notes: list[str] = []
+    n_colors = 0
+    if colors is not None:
+        stain_of = {full: stain for bands in chrom_bands.values() for _s, _e, full, stain in bands}
+        unknown_stains: set[str] = set()
+        rows: list[ColorRow] = [(CATEGORIZED, INTERIOR_COLOR, INTERIOR_GROUP)]
+        for child, _parent in edges:
+            stain = stain_of.get(child)
+            if stain is None:  # a chromosome or band-group node
+                rows.append((child, INTERIOR_COLOR, INTERIOR_GROUP))
+            elif stain in STAIN_COLORS:
+                rows.append((child, STAIN_COLORS[stain], stain))
+            else:
+                unknown_stains.add(stain or "(blank)")
+                rows.append((child, INTERIOR_COLOR, stain or INTERIOR_GROUP))
+        n_colors = write_colors(colors, name, rows)
+        if unknown_stains:
+            notes.append(
+                f"no colour known for stain(s) {', '.join(sorted(unknown_stains))} — "
+                f"they were left at {INTERIOR_COLOR}; edit {colors} to give them one"
+            )
+
+    kept = len(chrom_bands)
+    notes.insert(0, f"kept {kept} banded sequence(s), {n_records:,} bands")
+    if unbanded:
+        notes.append(
+            f"{len(unbanded)} sequence(s) matched --primary-pattern but have no bands: "
+            + ", ".join(unbanded[:5])
+        )
+
+    return PrepResult(
+        name=name,
+        bed=output,
+        n_records=n_records,
+        background=None,  # UCSC bands tile each banded chromosome end to end
+        hierarchy=hierarchy,
+        n_edges=n_edges,
+        priority=priority,
+        colors=colors,
+        n_colors=n_colors,
+        exclude=excluded + unbanded,
+        notes=notes,
+    )

--- a/src/karyoscope/core/prep/cytoband.py
+++ b/src/karyoscope/core/prep/cytoband.py
@@ -153,8 +153,8 @@ def verify(
 ) -> None:
     """Check every band label is a hierarchy node with a clean path to the root.
 
-    Cheap to do here and much cheaper than discovering it part-way through a
-    multi-hour ``build``.
+    Run before anything is written, so a malformed tree is reported here rather
+    than during the build.
     """
     children = [c for c, _p in edges]
     duplicates = {c for c in children if children.count(c) > 1}

--- a/src/karyoscope/core/prep/cytoband.py
+++ b/src/karyoscope/core/prep/cytoband.py
@@ -72,6 +72,25 @@ def short_name(seqid: str) -> str:
     return seqid[3:] if seqid.startswith("chr") else seqid
 
 
+def full_band_name(seqid: str, band: str) -> str:
+    """Qualify a band with its chromosome, unless it already is.
+
+    UCSC ships the band column bare (``p36.33``) in both the 5-column
+    golden-path table and the 6-column ``cytoBandMapped`` BED — the latter
+    carries the qualified name in a *separate* column, which we ignore and
+    rebuild, so one code path serves both. But a redistributed or hand-cut file
+    may put the qualified name in column 4 directly, and blindly prefixing that
+    would give ``11p36.33``.
+
+    Bare cytogenetic bands always begin with the arm, ``p`` or ``q``, so a band
+    that instead begins with its own chromosome name is already qualified.
+    """
+    prefix = short_name(seqid)
+    if band.startswith(prefix) and band[len(prefix) :].startswith(("p", "q")):
+        return band
+    return f"{prefix}{band}"
+
+
 def band_group(fullname: str) -> str | None:
     """Group node for a band, or ``None`` when it has no sub-band.
 
@@ -189,9 +208,8 @@ def from_ucsc(
         if seqid not in bands_by_seqid:
             unbanded.append(seqid)
             continue
-        prefix = short_name(seqid)
         chrom_bands[seqid] = [
-            (start, end, f"{prefix}{band}", stain)
+            (start, end, full_band_name(seqid, band), stain)
             for start, end, band, stain in bands_by_seqid[seqid]
         ]
     if not chrom_bands:

--- a/src/karyoscope/core/prep/genes.py
+++ b/src/karyoscope/core/prep/genes.py
@@ -56,17 +56,34 @@ _GFF3_PARENT = re.compile(r"(?:^|;)\s*Parent=([^;]+)")
 def transcript_ids(attributes: str) -> list[str]:
     """Extract the transcript(s) an exon belongs to, from GFF3 or GTF attributes.
 
-    GFF3 exons point at their transcript with ``Parent=`` (possibly a
-    comma-separated list, when one exon is shared by several transcripts); GTF
-    exons carry ``transcript_id "..."``. Both are tried, so no ``--format``
-    flag is needed to tell the two dialects of the same file apart.
+    Tries three forms, so no ``--format`` flag is needed to tell dialects apart:
+    ``transcript_id=...`` (GFF3 syntax), ``transcript_id "..."`` (GTF syntax),
+    and finally ``Parent=`` (canonical GFF3, possibly comma-separated when one
+    exon is shared by several transcripts).
+
+    ``transcript_id`` wins over ``Parent`` when both are present, and that
+    precedence is load-bearing. In canonical GFF3 an exon's ``Parent`` is its
+    mRNA, but Liftoff-style output sets ``Parent`` to the **gene** while giving
+    the transcript in ``transcript_id`` — the same file content is published
+    both ways. Preferring ``Parent`` there would group every transcript of a
+    gene together, and introns derived from a merged exon list span the gaps
+    *between* transcripts, inflating intron at intergenic's expense. That is
+    the defect this converter exists to avoid.
     """
+    attrs = dict(_GTF_ATTR.findall(attributes))
+    tid = attrs.get("transcript_id") or _gff3_attr(attributes, "transcript_id")
+    if tid:
+        return [tid]
     parent = _GFF3_PARENT.search(attributes)
     if parent:
         return [p.strip() for p in parent.group(1).split(",") if p.strip()]
-    attrs = dict(_GTF_ATTR.findall(attributes))
-    tid = attrs.get("transcript_id")
-    return [tid] if tid else []
+    return []
+
+
+def _gff3_attr(attributes: str, key: str) -> str | None:
+    """Value of a GFF3 ``key=value`` attribute, or ``None``."""
+    match = re.search(rf"(?:^|;)\s*{re.escape(key)}=([^;]+)", attributes)
+    return match.group(1).strip() if match else None
 
 
 def _partition(

--- a/src/karyoscope/core/prep/genes.py
+++ b/src/karyoscope/core/prep/genes.py
@@ -1,0 +1,223 @@
+"""A gene annotation (GFF3 or GTF) -> an ``exon``/``intron``/``intergenic`` set.
+
+Exons are read directly; introns are derived per transcript as the gaps between
+its consecutive exons; everything else is intergenic. Where annotations of
+different transcripts disagree about a base, the more specific label wins —
+``exon`` over ``intron`` over ``intergenic`` — so overlapping transcripts and
+alternative splicing never produce a base labelled twice.
+
+The result tiles every sequence in the ``.fai``, so the set needs no gap-fill.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from itertools import pairwise
+from pathlib import Path
+
+from karyoscope.core.prep.common import (
+    ColorRow,
+    Edge,
+    PrepError,
+    PrepResult,
+    Record,
+    SeqidRewriter,
+    iter_gff,
+    read_fai,
+    write_bed,
+    write_colors,
+    write_hierarchy,
+)
+
+EXON = "exon"
+INTRON = "intron"
+INTERGENIC = "intergenic"
+
+#: All three labels are leaves directly under the root — there is no useful
+#: intermediate grouping, and this matches the shipped CHM13 v2 ``gene`` set.
+GENE_HIERARCHY: list[Edge] = [
+    (EXON, "categorized"),
+    (INTRON, "categorized"),
+    (INTERGENIC, "categorized"),
+]
+
+#: The shipped CHM13 v2 ``gene`` palette.
+GENE_COLORS: dict[str, str] = {
+    EXON: "#090088",
+    INTRON: "#198450",
+    INTERGENIC: "#E89EB8",
+}
+
+_GTF_ATTR = re.compile(r'(\w+)\s+"([^"]*)"')
+_GFF3_PARENT = re.compile(r"(?:^|;)\s*Parent=([^;]+)")
+
+
+def transcript_ids(attributes: str) -> list[str]:
+    """Extract the transcript(s) an exon belongs to, from GFF3 or GTF attributes.
+
+    GFF3 exons point at their transcript with ``Parent=`` (possibly a
+    comma-separated list, when one exon is shared by several transcripts); GTF
+    exons carry ``transcript_id "..."``. Both are tried, so no ``--format``
+    flag is needed to tell the two dialects of the same file apart.
+    """
+    parent = _GFF3_PARENT.search(attributes)
+    if parent:
+        return [p.strip() for p in parent.group(1).split(",") if p.strip()]
+    attrs = dict(_GTF_ATTR.findall(attributes))
+    tid = attrs.get("transcript_id")
+    return [tid] if tid else []
+
+
+def _partition(
+    length: int,
+    exons: list[tuple[int, int]],
+    introns: list[tuple[int, int]],
+) -> list[tuple[int, int, str]]:
+    """Resolve one sequence into non-overlapping labelled spans covering ``[0, length)``.
+
+    A boundary sweep carrying one depth counter per label: at each span the
+    highest-precedence non-zero counter names it.
+    """
+    deltas: dict[int, list[int]] = defaultdict(lambda: [0, 0])
+    for column, spans in ((0, exons), (1, introns)):
+        for start, end in spans:
+            start, end = max(0, start), min(length, end)
+            if end <= start:
+                continue
+            deltas[start][column] += 1
+            deltas[end][column] -= 1
+
+    out: list[tuple[int, int, str]] = []
+    depth_exon = depth_intron = 0
+    previous = 0
+    for position in sorted(deltas):
+        if position > previous:
+            if depth_exon > 0:
+                label = EXON
+            elif depth_intron > 0:
+                label = INTRON
+            else:
+                label = INTERGENIC
+            out.append((previous, position, label))
+        d_exon, d_intron = deltas[position]
+        depth_exon += d_exon
+        depth_intron += d_intron
+        previous = position
+    if previous < length:
+        out.append((previous, length, INTERGENIC))
+    return out
+
+
+def _merge_runs(spans: list[tuple[int, int, str]]) -> list[tuple[int, int, str]]:
+    """Join abutting spans that ended up with the same label.
+
+    The sweep emits a span per *boundary*, so a run of overlapping exons yields
+    one span per exon edge even though they all label ``exon``. Merging them is
+    not cosmetic: it is the difference between one record and dozens for every
+    multi-transcript gene.
+    """
+    merged: list[list] = []
+    for start, end, label in spans:
+        if merged and merged[-1][2] == label and merged[-1][1] == start:
+            merged[-1][1] = end
+        else:
+            merged.append([start, end, label])
+    return [(s, e, lbl) for s, e, lbl in merged]
+
+
+def from_gff(
+    *,
+    input_path: Path,
+    lengths: Path,
+    output: Path,
+    hierarchy: Path,
+    colors: Path | None = None,
+    name: str = "gene",
+    feature_type: str = "exon",
+    rename: SeqidRewriter | None = None,
+) -> PrepResult:
+    """Convert a GFF3/GTF gene annotation into a fully-tiled gene feature set."""
+    rename = rename or SeqidRewriter()
+    sizes = read_fai(lengths)
+
+    exons_by_transcript: dict[tuple[str, str], list[tuple[int, int]]] = defaultdict(list)
+    unknown_seqids: set[str] = set()
+    n_exons = 0
+
+    for fields, lineno in iter_gff(input_path):
+        if fields[2] != feature_type:
+            continue
+        seqid = rename(fields[0])
+        if seqid not in sizes:
+            unknown_seqids.add(seqid)
+            continue
+        try:
+            start, end = int(fields[3]) - 1, int(fields[4])
+        except ValueError as e:
+            raise PrepError(f"{input_path}:{lineno}: non-integer coordinates") from e
+        n_exons += 1
+        ids = transcript_ids(fields[8])
+        if not ids:
+            # No parent to derive introns from, but the exon itself still counts.
+            exons_by_transcript[(seqid, f"__orphan__:{lineno}")].append((start, end))
+            continue
+        for tid in ids:
+            exons_by_transcript[(seqid, tid)].append((start, end))
+
+    if n_exons == 0:
+        raise PrepError(
+            f"{input_path}: no '{feature_type}' features whose sequence is in {lengths} — "
+            "check --feature-type and whether the annotation seqids need --rename-prefix "
+            "or --seqid-map"
+        )
+
+    exons_by_seqid: dict[str, list[tuple[int, int]]] = defaultdict(list)
+    introns_by_seqid: dict[str, list[tuple[int, int]]] = defaultdict(list)
+    for (seqid, _tid), spans in exons_by_transcript.items():
+        exons_by_seqid[seqid].extend(spans)
+        for (_s, prev_end), (next_start, _e) in pairwise(sorted(spans)):
+            if next_start > prev_end:
+                introns_by_seqid[seqid].append((prev_end, next_start))
+
+    records: list[Record] = []
+    for seqid in sizes:
+        spans = _partition(
+            sizes[seqid], exons_by_seqid.get(seqid, []), introns_by_seqid.get(seqid, [])
+        )
+        for start, end, label in _merge_runs(spans):
+            records.append((seqid, start, end, label))
+
+    n_records = write_bed(output, records)
+    n_edges = write_hierarchy(hierarchy, GENE_HIERARCHY)
+    n_colors = 0
+    if colors is not None:
+        rows: list[ColorRow] = [(label, GENE_COLORS[label], "") for label, _p in GENE_HIERARCHY]
+        n_colors = write_colors(colors, name, rows)
+
+    notes = [f"{n_exons:,} '{feature_type}' features over {len(exons_by_seqid)} sequence(s)"]
+    if unknown_seqids:
+        shown = ", ".join(sorted(unknown_seqids)[:5])
+        more = f" (+{len(unknown_seqids) - 5} more)" if len(unknown_seqids) > 5 else ""
+        notes.append(
+            f"skipped {len(unknown_seqids)} annotation seqid(s) absent from {lengths}: {shown}{more}"
+        )
+    bare = sorted(s for s in sizes if s not in exons_by_seqid)
+    if bare:
+        shown = ", ".join(bare[:5])
+        more = f" (+{len(bare) - 5} more)" if len(bare) > 5 else ""
+        notes.append(
+            f"{len(bare)} sequence(s) have no annotation and are all intergenic: {shown}{more}"
+        )
+
+    return PrepResult(
+        name=name,
+        bed=output,
+        n_records=n_records,
+        background=None,  # exon/intron/intergenic already tiles every base
+        hierarchy=hierarchy,
+        n_edges=n_edges,
+        colors=colors,
+        n_colors=n_colors,
+        notes=notes,
+    )

--- a/src/karyoscope/core/prep/repeats.py
+++ b/src/karyoscope/core/prep/repeats.py
@@ -1,0 +1,383 @@
+"""Repeat annotations -> a ``repeat`` feature set.
+
+Two unrelated sources produce the same kind of set, which is why ``prep-bed``
+keys its subcommands on the input format rather than on the output name:
+
+* :func:`from_repeatmasker` — RepeatMasker, in either the native ``.out`` table
+  or the UCSC BED repackaging of it. Leaves are the RepeatMasker *classes*, and
+  the hierarchy and palette reproduce the shipped ``HKS_human_CHM13_v2``
+  ``repeat`` set exactly.
+* :func:`from_edta` — an EDTA TE GFF3, whose ``Classification=`` vocabulary
+  aliases each superfamily under both spelled-out and Wicker three-letter names.
+
+Neither gap-fills: ``build`` adds the background leaf (conventionally
+``nonrepeat``) itself.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+
+from karyoscope.core.prep.common import (
+    ColorRow,
+    Edge,
+    PrepError,
+    PrepResult,
+    Record,
+    SeqidRewriter,
+    open_text,
+    write_bed,
+    write_colors,
+    write_hierarchy,
+    write_priority,
+)
+
+# -- RepeatMasker -----------------------------------------------------
+
+#: RepeatMasker class -> leaf label. Keys are the class part of ``class/family``
+#: with any trailing ``?`` (RepeatMasker's "uncertain" marker) already stripped.
+#: The values are the 15 non-background leaves of the shipped CHM13 v2 set.
+RM_CLASS_TO_LEAF = {
+    "DNA": "DNA",
+    "LINE": "LINE",
+    "Low_complexity": "Low_complexity",
+    "LTR": "LTR",
+    "RC": "RC",
+    "Retroposon": "Retroposon",
+    "rRNA": "rRNA",
+    "Satellite": "Satellite",
+    "scRNA": "scRNA",
+    "Simple_repeat": "Simple_repeat",
+    "SINE": "SINE",
+    "snRNA": "snRNA",
+    "srpRNA": "srpRNA",
+    "tRNA": "tRNA",
+    "Unknown": "Unknown",
+}
+
+#: Classes RepeatMasker emits that carry no repeat signal worth a leaf of their
+#: own. Dropped rather than labelled, so ``build``'s gap-fill covers them.
+RM_DROP_CLASSES = frozenset({"ARTEFACT", "Artefact"})
+
+#: Leaf for a class absent from :data:`RM_CLASS_TO_LEAF`. RepeatMasker's own
+#: catch-all is ``Unknown``, so unrecognised classes join it rather than being
+#: skipped — skipping would leave those bases to the ``nonrepeat`` gap-fill,
+#: which asserts the opposite of what the annotation says.
+RM_FALLBACK_LEAF = "Unknown"
+
+#: ``child parent`` edges of the shipped CHM13 v2 ``repeat`` tree, root last.
+RM_HIERARCHY: list[Edge] = [
+    ("repeat", "categorized"),
+    ("Interspersed_Repeat", "repeat"),
+    ("RNA", "Interspersed_Repeat"),
+    ("rRNA", "RNA"),
+    ("scRNA", "RNA"),
+    ("snRNA", "RNA"),
+    ("srpRNA", "RNA"),
+    ("tRNA", "RNA"),
+    ("Transposable_Element", "Interspersed_Repeat"),
+    ("Class_I_Retrotransposition", "Transposable_Element"),
+    ("LINE", "Class_I_Retrotransposition"),
+    ("LINE-dependent_Retroposon", "Class_I_Retrotransposition"),
+    ("Retroposon", "LINE-dependent_Retroposon"),
+    ("SINE", "LINE-dependent_Retroposon"),
+    ("LTR", "Class_I_Retrotransposition"),
+    ("Class_II_DNA_Transposition", "Transposable_Element"),
+    ("DNA", "Class_II_DNA_Transposition"),
+    ("RC", "Class_II_DNA_Transposition"),
+    ("Unknown", "Interspersed_Repeat"),
+    ("Satellite", "repeat"),
+    ("Noninterspersed", "repeat"),
+    ("Low_complexity", "Noninterspersed"),
+    ("Simple_repeat", "Noninterspersed"),
+]
+
+#: ``node -> (colour, legend_group)`` for the shipped palette. The five RNA
+#: leaves share one colour, so grouping them collapses five legend rows into
+#: one without breaking the "same group ⇒ same colour" invariant ``build``
+#: enforces. Every other leaf has a colour of its own and stays ungrouped.
+_INTERIOR = "#B0C4DE"
+RM_COLORS: dict[str, tuple[str, str]] = {
+    "repeat": (_INTERIOR, ""),
+    "Interspersed_Repeat": (_INTERIOR, ""),
+    "RNA": ("#90D5FF", "RNA"),
+    "rRNA": ("#90D5FF", "RNA"),
+    "scRNA": ("#90D5FF", "RNA"),
+    "snRNA": ("#90D5FF", "RNA"),
+    "srpRNA": ("#90D5FF", "RNA"),
+    "tRNA": ("#90D5FF", "RNA"),
+    "Transposable_Element": (_INTERIOR, ""),
+    "Class_I_Retrotransposition": (_INTERIOR, ""),
+    "LINE": ("#00FF00", ""),
+    "LINE-dependent_Retroposon": (_INTERIOR, ""),
+    "Retroposon": ("#800080", ""),
+    "SINE": ("#FF0000", ""),
+    "LTR": ("#0000FF", ""),
+    "Class_II_DNA_Transposition": (_INTERIOR, ""),
+    "DNA": ("#FFC0CB", ""),
+    "RC": ("#FFEE8C", ""),
+    "Unknown": ("#FF5C00", ""),
+    "Satellite": ("#008B8B", ""),
+    "Noninterspersed": (_INTERIOR, ""),
+    "Low_complexity": ("#6B8E23", ""),
+    "Simple_repeat": ("#DAA520", ""),
+}
+
+#: Colour for the ``nonrepeat`` gap-fill leaf ``build`` adds.
+RM_BACKGROUND_COLOR = "#808080"
+
+
+def _rm_leaf(class_family: str) -> str | None:
+    """Map a RepeatMasker ``class/family`` to a leaf, or ``None`` to drop the row."""
+    klass = class_family.split("/", 1)[0].rstrip("?")
+    if klass in RM_DROP_CLASSES:
+        return None
+    return RM_CLASS_TO_LEAF.get(klass, RM_FALLBACK_LEAF)
+
+
+def _looks_like_bed(fields: list[str]) -> bool:
+    """True if a tab-split line is the UCSC BED repackaging rather than ``.out``."""
+    return len(fields) >= 4 and fields[1].isdigit() and fields[2].isdigit() and "#" in fields[3]
+
+
+def _parse_repeatmasker(
+    path: Path, rename: SeqidRewriter
+) -> tuple[list[Record], Counter[str], str]:
+    """Parse either RepeatMasker dialect into records, keeping a class tally.
+
+    Returns ``(records, class_counts, dialect)``. Sniffing here is safe in a way
+    it would not be in ``build``: both dialects are the *same tool's* output, and
+    the choice is reported rather than silently assumed.
+    """
+    records: list[Record] = []
+    seen_classes: Counter[str] = Counter()
+    dialect = ""
+    with open_text(path) as fh:
+        for lineno, raw in enumerate(fh, 1):
+            line = raw.rstrip("\n")
+            if not line.strip() or line.lstrip().startswith(("#", "track", "browser")):
+                continue
+            tab_fields = line.split("\t")
+            if not dialect:
+                dialect = "ucsc-bed" if _looks_like_bed(tab_fields) else "out"
+            if dialect == "ucsc-bed":
+                if not _looks_like_bed(tab_fields):
+                    raise PrepError(f"{path}:{lineno}: not a UCSC RepeatMasker BED line: {line!r}")
+                seqid, start, end = tab_fields[0], int(tab_fields[1]), int(tab_fields[2])
+                # Column 4 is ``name#class/family``, e.g. ``TAR1#Satellite/subtelo``.
+                class_family = (
+                    tab_fields[3].split("#", 1)[1] if "#" in tab_fields[3] else tab_fields[3]
+                )
+            else:
+                cols = line.split()
+                # The 3-line ``.out`` banner has no leading integer SW score.
+                if len(cols) < 11 or not cols[0].lstrip("-").isdigit():
+                    continue
+                seqid = cols[4]
+                # ``.out`` positions are 1-based inclusive.
+                start, end = int(cols[5]) - 1, int(cols[6])
+                class_family = cols[10]
+            seen_classes[class_family.split("/", 1)[0].rstrip("?")] += 1
+            leaf = _rm_leaf(class_family)
+            if leaf is None:
+                continue
+            records.append((rename(seqid), start, end, leaf))
+    if not dialect:
+        raise PrepError(f"{path}: no RepeatMasker records found")
+    return records, seen_classes, dialect
+
+
+def from_repeatmasker(
+    *,
+    input_path: Path,
+    output: Path,
+    hierarchy: Path,
+    colors: Path | None = None,
+    priority: Path | None = None,
+    name: str = "repeat",
+    background: str = "nonrepeat",
+    rename: SeqidRewriter | None = None,
+) -> PrepResult:
+    """Convert RepeatMasker output into a ``repeat`` feature set."""
+    rename = rename or SeqidRewriter()
+    records, seen_classes, dialect = _parse_repeatmasker(input_path, rename)
+
+    n_records = write_bed(output, records)
+    n_edges = write_hierarchy(hierarchy, RM_HIERARCHY)
+    n_colors = 0
+    if colors is not None:
+        rows: list[ColorRow] = [(node, *RM_COLORS[node]) for node, _p in RM_HIERARCHY]
+        rows.append((background, RM_BACKGROUND_COLOR, ""))
+        n_colors = write_colors(colors, name, rows)
+    if priority is not None:
+        write_priority(priority, RM_HIERARCHY)
+
+    notes = [f"read {input_path} as the RepeatMasker '{dialect}' dialect"]
+    unmapped = sorted(
+        c for c in seen_classes if c not in RM_CLASS_TO_LEAF and c not in RM_DROP_CLASSES
+    )
+    if unmapped:
+        total = sum(seen_classes[c] for c in unmapped)
+        notes.append(
+            f"{len(unmapped)} unrecognised class(es) ({total:,} rows) labelled "
+            f"{RM_FALLBACK_LEAF}: {', '.join(unmapped)}"
+        )
+    dropped = sorted(c for c in seen_classes if c in RM_DROP_CLASSES)
+    if dropped:
+        total = sum(seen_classes[c] for c in dropped)
+        notes.append(f"dropped {total:,} row(s) of non-repeat class: {', '.join(dropped)}")
+
+    return PrepResult(
+        name=name,
+        bed=output,
+        n_records=n_records,
+        background=background,
+        hierarchy=hierarchy,
+        n_edges=n_edges,
+        priority=priority,
+        colors=colors,
+        n_colors=n_colors,
+        notes=notes,
+    )
+
+
+# -- EDTA -------------------------------------------------------------
+
+#: EDTA ``Classification=`` value -> normalised leaf. EDTA aliases the same
+#: superfamily under both spelled-out and Wicker three-letter names (``DNA/HAT``
+#: and ``DNA/DTA`` are both hAT), so several keys collapse onto one leaf.
+EDTA_ALIAS = {
+    "LTR/Gypsy": "Gypsy",
+    "LTR/Copia": "Copia",
+    "LTR/unknown": "LTR_other",
+    "LTR?": "LTR_other",
+    "LINE/L1": "L1",
+    "LINE/unknown": "LINE_other",
+    "LINE?": "LINE_other",
+    "LINE_element": "LINE_other",
+    "SINE": "SINE_other",
+    "SINE_element": "SINE_other",
+    "RathE1_cons": "RathE",
+    "RathE2_cons": "RathE",
+    "RathE3_cons": "RathE",
+    "DNA/HAT": "hAT",
+    "DNA/DTA": "hAT",
+    "DNA/En-Spm": "CACTA",
+    "DNA/DTC": "CACTA",
+    "DNA/MuDR": "Mutator",
+    "DNA/DTM": "Mutator",
+    "DNA/Harbinger": "PIF_Harbinger",
+    "DNA/DTH": "PIF_Harbinger",
+    "DNA/Mariner": "Tc1_Mariner",
+    "DNA/Tc1": "Tc1_Mariner",
+    "DNA/DTT": "Tc1_Mariner",
+    "DNA/Pogo": "Tc1_Mariner",
+    "MITE/DTA": "MITE",
+    "MITE/DTM": "MITE",
+    "MITE/DTC": "MITE",
+    "MITE/DTT": "MITE",
+    "MITE/DTH": "MITE",
+    "RC/Helitron": "Helitron",
+    "DNA/Helitron": "Helitron",
+    "helitron": "Helitron",
+    "DNA": "DNA_other",
+    "Unknown": "TE_unclassified",
+    "Unassigned": "TE_unclassified",
+}
+
+EDTA_FALLBACK_LEAF = "TE_unclassified"
+
+#: ``child parent`` edges covering every :data:`EDTA_ALIAS` value.
+EDTA_HIERARCHY: list[Edge] = [
+    ("Transposable_Element", "categorized"),
+    ("Class_I_Retro", "Transposable_Element"),
+    ("LTR", "Class_I_Retro"),
+    ("Gypsy", "LTR"),
+    ("Copia", "LTR"),
+    ("LTR_other", "LTR"),
+    ("LINE", "Class_I_Retro"),
+    ("L1", "LINE"),
+    ("LINE_other", "LINE"),
+    ("SINE", "Class_I_Retro"),
+    ("SINE_other", "SINE"),
+    ("RathE", "SINE"),
+    ("Class_II_DNA", "Transposable_Element"),
+    ("TIR", "Class_II_DNA"),
+    ("hAT", "TIR"),
+    ("CACTA", "TIR"),
+    ("Mutator", "TIR"),
+    ("PIF_Harbinger", "TIR"),
+    ("Tc1_Mariner", "TIR"),
+    ("MITE", "TIR"),
+    ("Helitron", "Class_II_DNA"),
+    ("DNA_other", "Class_II_DNA"),
+    ("TE_unclassified", "Transposable_Element"),
+]
+
+_CLASSIFICATION = re.compile(r"Classification=([^;]+)")
+
+
+def from_edta(
+    *,
+    input_path: Path,
+    output: Path,
+    hierarchy: Path,
+    priority: Path | None = None,
+    name: str = "repeat",
+    background: str = "nonrepeat",
+    rename: SeqidRewriter | None = None,
+) -> PrepResult:
+    """Convert an EDTA TE GFF3 into a ``repeat`` feature set.
+
+    No colours are emitted: unlike RepeatMasker there is no established
+    KaryoScope palette for the EDTA vocabulary, so ``build``'s automatic
+    assignment is a better default than an invented one.
+    """
+    rename = rename or SeqidRewriter()
+    records: list[Record] = []
+    unmapped: Counter[str] = Counter()
+
+    with open_text(input_path) as gff:
+        for raw in gff:
+            if raw.startswith("#"):
+                if raw.startswith("##FASTA"):
+                    break
+                continue
+            parts = raw.rstrip("\n").split("\t")
+            if len(parts) < 9:
+                continue
+            match = _CLASSIFICATION.search(parts[8])
+            classification = match.group(1) if match else ""
+            leaf = EDTA_ALIAS.get(classification)
+            if leaf is None:
+                leaf = EDTA_FALLBACK_LEAF
+                if classification:
+                    unmapped[classification] += 1
+            # GFF3 is 1-based inclusive; BED is 0-based half-open.
+            records.append((rename(parts[0]), int(parts[3]) - 1, int(parts[4]), leaf))
+
+    n_records = write_bed(output, records)
+    n_edges = write_hierarchy(hierarchy, EDTA_HIERARCHY)
+    if priority is not None:
+        write_priority(priority, EDTA_HIERARCHY)
+
+    notes: list[str] = []
+    if unmapped:
+        total = sum(unmapped.values())
+        notes.append(
+            f"{len(unmapped)} classification(s) ({total:,} rows) fell to "
+            f"{EDTA_FALLBACK_LEAF}: {', '.join(sorted(unmapped))}"
+        )
+
+    return PrepResult(
+        name=name,
+        bed=output,
+        n_records=n_records,
+        background=background,
+        hierarchy=hierarchy,
+        n_edges=n_edges,
+        priority=priority,
+        notes=notes,
+    )

--- a/src/karyoscope/core/prep/repeats.py
+++ b/src/karyoscope/core/prep/repeats.py
@@ -61,11 +61,26 @@ RM_CLASS_TO_LEAF = {
 #: own. Dropped rather than labelled, so ``build``'s gap-fill covers them.
 RM_DROP_CLASSES = frozenset({"ARTEFACT", "Artefact"})
 
-#: Leaf for a class absent from :data:`RM_CLASS_TO_LEAF`. RepeatMasker's own
-#: catch-all is ``Unknown``, so unrecognised classes join it rather than being
-#: skipped — skipping would leave those bases to the ``nonrepeat`` gap-fill,
-#: which asserts the opposite of what the annotation says.
-RM_FALLBACK_LEAF = "Unknown"
+#: Leaf for a class absent from :data:`RM_CLASS_TO_LEAF`.
+#:
+#: Deliberately **not** ``Unknown``: that is a real RepeatMasker class (22,523
+#: records in CHM13 v2) meaning "RepeatMasker could not classify this element".
+#: A class we have no leaf for is a different claim — the annotation is
+#: confident and we are the ones unable to place it — and folding the two
+#: together would overstate what the source said.
+#:
+#: Nor are such rows dropped: that would leave their bases to the ``nonrepeat``
+#: gap-fill, asserting the opposite of what the annotation says. They get their
+#: own leaf, added to the hierarchy and palette only when actually used, so a
+#: file whose classes are all recognised produces the reference tree unchanged.
+RM_FALLBACK_LEAF = "other_repeat"
+
+#: Where the fallback leaf attaches — the subtree root, because nothing is
+#: known about whether such an element is interspersed.
+RM_FALLBACK_PARENT = "repeat"
+
+#: Colour for the fallback leaf, distinct from every colour in the palette.
+RM_FALLBACK_COLOR = "#9E4F9E"
 
 #: ``child parent`` edges of the shipped CHM13 v2 ``repeat`` tree, root last.
 RM_HIERARCHY: list[Edge] = [
@@ -204,15 +219,23 @@ def from_repeatmasker(
     rename = rename or SeqidRewriter()
     records, seen_classes, dialect = _parse_repeatmasker(input_path, rename)
 
+    # Carry the fallback leaf only when something landed on it, so a file whose
+    # classes are all recognised produces the reference hierarchy unchanged.
+    edges = list(RM_HIERARCHY)
+    if any(leaf == RM_FALLBACK_LEAF for _c, _s, _e, leaf in records):
+        edges.append((RM_FALLBACK_LEAF, RM_FALLBACK_PARENT))
+
     n_records = write_bed(output, records)
-    n_edges = write_hierarchy(hierarchy, RM_HIERARCHY)
+    n_edges = write_hierarchy(hierarchy, edges)
     n_colors = 0
     if colors is not None:
-        rows: list[ColorRow] = [(node, *RM_COLORS[node]) for node, _p in RM_HIERARCHY]
+        rows: list[ColorRow] = [
+            (node, *RM_COLORS.get(node, (RM_FALLBACK_COLOR, ""))) for node, _p in edges
+        ]
         rows.append((background, RM_BACKGROUND_COLOR, ""))
         n_colors = write_colors(colors, name, rows)
     if priority is not None:
-        write_priority(priority, RM_HIERARCHY)
+        write_priority(priority, edges)
 
     notes = [f"read {input_path} as the RepeatMasker '{dialect}' dialect"]
     unmapped = sorted(
@@ -221,8 +244,9 @@ def from_repeatmasker(
     if unmapped:
         total = sum(seen_classes[c] for c in unmapped)
         notes.append(
-            f"{len(unmapped)} unrecognised class(es) ({total:,} rows) labelled "
-            f"{RM_FALLBACK_LEAF}: {', '.join(unmapped)}"
+            f"{len(unmapped)} class(es) ({total:,} rows) have no leaf of their own and "
+            f"were labelled {RM_FALLBACK_LEAF!r} — this is NOT RepeatMasker's own "
+            f"'Unknown' class: {', '.join(unmapped)}"
         )
     dropped = sorted(c for c in seen_classes if c in RM_DROP_CLASSES)
     if dropped:

--- a/src/karyoscope/core/prep/structural.py
+++ b/src/karyoscope/core/prep/structural.py
@@ -1,13 +1,20 @@
-"""Structural feature sets: whole-sequence ``chromosome``, and satellite ``region``.
+"""Structural feature sets: whole-sequence ``chromosome``, and centromeric ``region``.
 
 :func:`from_fai` is the trivial one — every sequence becomes a single record
 labelled with its own name.
 
-:func:`from_satellite` is the one converter that legitimately tiles, because the
-tiling is *semantic* rather than a gap-fill: the arms either side of the
-centromere have to be told apart (``p_arm``/``q_arm``), and only the satellite
-annotation says where the centromere is. ``build``'s generic gap-fill cannot do
-that — it has exactly one background label.
+:func:`from_censat` (a CenSat annotation, as for human) and
+:func:`from_satellite` (a bare satellite-monomer catalog, as for the Arabidopsis
+CEN180 set) both build a ``region`` set, and are the two converters that
+legitimately tile. The tiling is *semantic* rather than a gap-fill: the arms
+either side of the centromere have to be told apart (``p_arm``/``q_arm``), only
+the annotation knows where the centromere is, and ``build``'s gap-fill has
+exactly one label where two are needed.
+
+They differ in what the input gives them. CenSat already names its features, so
+the work is normalising labels and locating the centromere from the ``ct``
+transitions; a monomer catalog names nothing, so the work is merging monomers
+into bands and finding the densest cluster.
 """
 
 from __future__ import annotations
@@ -78,6 +85,187 @@ def from_fai(
 INTERIOR = "cen_gap"
 P_ARM = "p_arm"
 Q_ARM = "q_arm"
+
+# -- CenSat -----------------------------------------------------------
+
+#: ``child parent`` edges of the CenSat v2.1 region tree, as used by the shipped
+#: CHM13 v2 ``region`` set. ``p_arm``/``q_arm`` must stay leaves: centromere
+#: detection reads anything that is not an arm as the centromere catch-all.
+CENSAT_HIERARCHY: list[Edge] = [
+    ("centromeric", "categorized"),
+    ("aSat", "centromeric"),
+    ("alpha_hor", "aSat"),
+    ("active_hor", "alpha_hor"),
+    ("dhor", "alpha_hor"),
+    ("hor", "alpha_hor"),
+    ("mixedAlpha", "alpha_hor"),
+    ("mon", "aSat"),
+    ("bSat", "centromeric"),
+    ("cenSat", "centromeric"),
+    ("ct", "centromeric"),
+    ("gSat", "centromeric"),
+    ("HSat", "centromeric"),
+    ("HSat1", "HSat"),
+    ("HSat1A", "HSat1"),
+    ("HSat1B", "HSat1"),
+    ("HSat2", "HSat"),
+    ("HSat3", "HSat"),
+    ("rDNA", "categorized"),
+    ("arm", "categorized"),
+    (P_ARM, "arm"),
+    (Q_ARM, "arm"),
+]
+
+#: Priorities for the three top-level branches; everything else is 1. Siblings
+#: must be all-equal or all-distinct, which this satisfies.
+CENSAT_PRIORITIES = {"centromeric": 1, "rDNA": 2, "arm": 3}
+
+#: Labels that are arms rather than centromeric features, when locating the
+#: centromere by feature extent.
+_NON_CENTROMERIC = frozenset({P_ARM, Q_ARM})
+
+
+def censat_label(raw: str) -> str:
+    """``gSat(TAR1)`` -> ``gSat``.
+
+    CenSat qualifies each label with the specific arrays it contains, in
+    parentheses — useful provenance, but hundreds of distinct values that all
+    mean the same feature. The part before the parenthesis is the leaf.
+    """
+    return raw.split("(", 1)[0]
+
+
+def _centromere_bounds(features: list[tuple[int, int, str]]) -> tuple[int, int] | None:
+    """Centromere extent for one sequence: first ``ct`` start to last ``ct`` end.
+
+    ``ct`` (centromeric transition) brackets the centromere, so it gives the
+    boundary directly. Where a sequence has none, fall back to the extent of
+    every centromeric feature — which is wider, but only used for deciding
+    which arm a gap belongs to.
+    """
+    ct = [(s, e) for s, e, label in features if label == "ct"]
+    if ct:
+        return min(s for s, _e in ct), max(e for _s, e in ct)
+    other = [(s, e) for s, e, label in features if label not in _NON_CENTROMERIC]
+    if other:
+        return min(s for s, _e in other), max(e for _s, e in other)
+    return None
+
+
+def from_censat(
+    *,
+    input_path: Path,
+    lengths: Path,
+    output: Path,
+    hierarchy: Path,
+    priority: Path | None = None,
+    name: str = "region",
+    rename: SeqidRewriter | None = None,
+) -> PrepResult:
+    """Turn a CenSat annotation into a fully-tiled ``region`` feature set.
+
+    CenSat labels are kept (minus their parenthetical array detail) and every
+    remaining base is labelled by which arm it falls on, split at the
+    centromere. Like :func:`from_satellite` this tiles, and for the same
+    reason: only the annotation knows where the centromere is, and a gap-fill
+    has one label where two are needed.
+
+    Scattered pericentromeric satellite remnants far out on an arm keep their
+    own labels; only the gaps around them become arm.
+    """
+    rename = rename or SeqidRewriter()
+    sizes = read_fai(lengths)
+
+    by_seqid: dict[str, list[tuple[int, int, str]]] = defaultdict(list)
+    unknown: set[str] = set()
+    with open_text(input_path) as fh:
+        for raw in fh:
+            line = raw.rstrip("\n")
+            if not line.strip() or line.startswith(("#", "track", "browser")):
+                continue
+            parts = line.split("\t")
+            if len(parts) < 4:
+                continue
+            seqid = rename(parts[0])
+            try:
+                start, end = int(parts[1]), int(parts[2])
+            except ValueError:
+                continue
+            if seqid not in sizes:
+                unknown.add(seqid)
+                continue
+            by_seqid[seqid].append((start, end, censat_label(parts[3])))
+
+    if not by_seqid:
+        raise PrepError(
+            f"{input_path}: no CenSat records matched a sequence in {lengths} — check "
+            "whether the annotation seqids need --rename-prefix or --seqid-map"
+        )
+
+    records: list[Record] = []
+    bare: list[str] = []
+    for seqid, length in sizes.items():
+        features = coalesce(
+            [(seqid, s, e, label) for s, e, label in sorted(by_seqid.get(seqid, []))]
+        )
+        if not features:
+            bare.append(seqid)
+            continue
+        bounds = _centromere_bounds([(s, e, label) for _c, s, e, label in features])
+        last = 0
+        for _c, start, end, label in features:
+            if start > last:
+                records.append((seqid, last, start, _arm_label(last, start, bounds)))
+            records.append((seqid, start, end, label))
+            last = end
+        if last < length:
+            records.append((seqid, last, length, _arm_label(last, length, bounds)))
+
+    n_records = write_bed(output, records)
+    n_edges = write_hierarchy(hierarchy, CENSAT_HIERARCHY)
+    if priority is not None:
+        with priority.open("w") as out:
+            for child, parent in CENSAT_HIERARCHY:
+                out.write(f"{child}\t{CENSAT_PRIORITIES.get(child, 1)}\t{parent}\n")
+
+    notes = [
+        f"{sum(len(v) for v in by_seqid.values()):,} CenSat records over {len(by_seqid)} sequence(s)"
+    ]
+    if unknown:
+        notes.append(
+            f"skipped {len(unknown)} annotation seqid(s) absent from {lengths}: "
+            + ", ".join(sorted(unknown)[:5])
+        )
+    if bare:
+        notes.append(
+            f"{len(bare)} sequence(s) have no CenSat annotation and are left uncovered "
+            "(list them under the spec's exclude:): " + ", ".join(bare[:5])
+        )
+
+    return PrepResult(
+        name=name,
+        bed=output,
+        n_records=n_records,
+        background=None,  # the arm split already tiles every annotated sequence
+        hierarchy=hierarchy,
+        n_edges=n_edges,
+        priority=priority,
+        exclude=bare,
+        notes=notes,
+    )
+
+
+def _arm_label(start: int, end: int, bounds: tuple[int, int] | None) -> str:
+    """Which arm a gap belongs to, given the centromere extent."""
+    if bounds is None:
+        return P_ARM
+    cen_start, cen_end = bounds
+    if end <= cen_start:
+        return P_ARM
+    if start >= cen_end:
+        return Q_ARM
+    # Inside the centromere: only reachable where CenSat coverage is incomplete.
+    return P_ARM
 
 
 def _hierarchy_for(satellite: str) -> list[Edge]:

--- a/src/karyoscope/core/prep/structural.py
+++ b/src/karyoscope/core/prep/structural.py
@@ -1,0 +1,252 @@
+"""Structural feature sets: whole-sequence ``chromosome``, and satellite ``region``.
+
+:func:`from_fai` is the trivial one — every sequence becomes a single record
+labelled with its own name.
+
+:func:`from_satellite` is the one converter that legitimately tiles, because the
+tiling is *semantic* rather than a gap-fill: the arms either side of the
+centromere have to be told apart (``p_arm``/``q_arm``), and only the satellite
+annotation says where the centromere is. ``build``'s generic gap-fill cannot do
+that — it has exactly one background label.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+from karyoscope.core.prep.common import (
+    Edge,
+    PrepError,
+    PrepResult,
+    Record,
+    SeqidRewriter,
+    coalesce,
+    open_text,
+    read_fai,
+    write_bed,
+    write_hierarchy,
+    write_priority,
+)
+
+# -- chromosome -------------------------------------------------------
+
+
+def from_fai(
+    *,
+    lengths: Path,
+    output: Path,
+    hierarchy: Path | None = None,
+    name: str = "chromosome",
+    rename: SeqidRewriter | None = None,
+) -> PrepResult:
+    """Emit one whole-length record per sequence, labelled with its own name.
+
+    No hierarchy is written by default: how sequences group (autosome vs sex vs
+    organelle, metacentric vs acrocentric, haplotype) is organism-specific
+    curation that cannot be read off a ``.fai``. Pass ``hierarchy`` only if you
+    intend to fill it in by hand afterwards.
+    """
+    rename = rename or SeqidRewriter()
+    sizes = read_fai(lengths)
+    records: list[Record] = [
+        (rename(seqid), 0, length, rename(seqid)) for seqid, length in sizes.items()
+    ]
+    n_records = write_bed(output, records)
+
+    n_edges = 0
+    if hierarchy is not None:
+        n_edges = write_hierarchy(hierarchy, [(rename(s), "categorized") for s in sizes])
+
+    return PrepResult(
+        name=name,
+        bed=output,
+        n_records=n_records,
+        background=None,  # one record per sequence already tiles everything
+        hierarchy=hierarchy,
+        n_edges=n_edges,
+        notes=[
+            f"{n_records} sequence(s) from {lengths}",
+            "no grouping hierarchy was derived — sequence grouping is organism-specific "
+            "curation; write it by hand and pass it to build as 'hierarchy:'",
+        ],
+    )
+
+
+# -- satellite / region -----------------------------------------------
+
+INTERIOR = "cen_gap"
+P_ARM = "p_arm"
+Q_ARM = "q_arm"
+
+
+def _hierarchy_for(satellite: str) -> list[Edge]:
+    """Arms and satellite as leaves under ``arm``/``centromeric``.
+
+    ``scaffold.get_simple_region`` reads ``p_arm``/``q_arm`` as arm and treats
+    everything else as the centromere catch-all, and binning prefers leaf
+    labels, so all four of these must be leaves rather than interior nodes.
+    """
+    return [
+        (satellite, "centromeric"),
+        (INTERIOR, "centromeric"),
+        ("centromeric", "categorized"),
+        (P_ARM, "arm"),
+        (Q_ARM, "arm"),
+        ("arm", "categorized"),
+    ]
+
+
+def merge_spans(spans: list[tuple[int, int]], gap: int) -> list[tuple[int, int]]:
+    """Coalesce ``[start, end)`` spans separated by at most ``gap`` bases."""
+    merged: list[list[int]] = []
+    for start, end in sorted(spans):
+        if merged and start - merged[-1][1] <= gap:
+            merged[-1][1] = max(merged[-1][1], end)
+        else:
+            merged.append([start, end])
+    return [(s, e) for s, e in merged]
+
+
+def core_cluster(bands: list[tuple[int, int]], cluster_gap: int) -> tuple[int, int]:
+    """Return the span of the highest-coverage cluster of satellite bands.
+
+    The centromere is the *densest* cluster, not the min-to-max extent: scattered
+    pericentromeric remnants would blow a raw extent out across most of the arm.
+    """
+    best, best_coverage = (0, 0), -1
+    for cluster_start, cluster_end in merge_spans(bands, cluster_gap):
+        coverage = sum(e - s for s, e in bands if s >= cluster_start and e <= cluster_end)
+        if coverage > best_coverage:
+            best, best_coverage = (cluster_start, cluster_end), coverage
+    return best
+
+
+def _fill(
+    records: list[Record], seqid: str, start: int, end: int, core: tuple[int, int] | None
+) -> None:
+    """Label a gap: ``p_arm`` before the core, ``cen_gap`` inside it, ``q_arm`` after."""
+    if end <= start:
+        return
+    if core is None:
+        records.append((seqid, start, end, P_ARM))
+        return
+    core_start, core_end = core
+    if start < core_start:
+        records.append((seqid, start, min(end, core_start), P_ARM))
+    inner_start, inner_end = max(start, core_start), min(end, core_end)
+    if inner_start < inner_end:
+        records.append((seqid, inner_start, inner_end, INTERIOR))
+    if end > core_end:
+        records.append((seqid, max(start, core_end), end, Q_ARM))
+
+
+def from_satellite(
+    *,
+    input_path: Path,
+    lengths: Path,
+    output: Path,
+    hierarchy: Path,
+    priority: Path | None = None,
+    name: str = "region",
+    satellite: str = "satellite",
+    merge_gap: int = 10,
+    cluster_gap: int = 500_000,
+    rename: SeqidRewriter | None = None,
+) -> PrepResult:
+    """Turn a centromeric-satellite GFF/BED into a fully-tiled ``region`` set.
+
+    Monomers within ``merge_gap`` bases coalesce into bands — the default bridges
+    the 1-2 bp monomer-boundary artefacts tandem-repeat finders emit without
+    merging real interior insertions, which run to kilobases. Bands then cluster
+    within ``cluster_gap`` to locate the centromere core, and every remaining
+    base is labelled by which side of that core it falls on.
+
+    p and q are assigned by coordinate, so this assumes the assembly is oriented
+    short-arm-first — the usual convention, but not guaranteed.
+    """
+    rename = rename or SeqidRewriter()
+    sizes = read_fai(lengths)
+
+    monomers: dict[str, list[tuple[int, int]]] = defaultdict(list)
+    unknown: set[str] = set()
+    is_gff = input_path.suffix.lower().lstrip(".").startswith("gff")
+    with open_text(input_path) as fh:
+        for raw in fh:
+            if raw.startswith("#"):
+                if raw.startswith("##FASTA"):
+                    break
+                continue
+            parts = raw.rstrip("\n").split("\t")
+            if len(parts) < 3:
+                continue
+            seqid = rename(parts[0])
+            try:
+                if is_gff:
+                    if len(parts) < 5:
+                        continue
+                    start, end = int(parts[3]) - 1, int(parts[4])
+                else:
+                    start, end = int(parts[1]), int(parts[2])
+            except ValueError:
+                continue  # header rows and other non-coordinate lines
+            if seqid not in sizes:
+                unknown.add(seqid)
+                continue
+            monomers[seqid].append((start, end))
+
+    if not monomers:
+        raise PrepError(
+            f"{input_path}: no satellite records matched a sequence in {lengths} — check "
+            "whether the annotation seqids need --rename-prefix or --seqid-map"
+        )
+
+    records: list[Record] = []
+    no_core: list[str] = []
+    for seqid, length in sizes.items():
+        bands = merge_spans(monomers.get(seqid, []), merge_gap)
+        if not bands:
+            # No satellite at all (an organelle, a small contig): all one arm.
+            no_core.append(seqid)
+            _fill(records, seqid, 0, length, None)
+            continue
+        core = core_cluster(bands, cluster_gap)
+        last = 0
+        for band_start, band_end in bands:
+            _fill(records, seqid, last, band_start, core)
+            records.append((seqid, band_start, band_end, satellite))
+            last = band_end
+        _fill(records, seqid, last, length, core)
+
+    edges = _hierarchy_for(satellite)
+    n_records = write_bed(output, coalesce(records))
+    n_edges = write_hierarchy(hierarchy, edges)
+    if priority is not None:
+        write_priority(priority, edges)
+
+    notes = [
+        f"{sum(len(v) for v in monomers.values()):,} monomers merged into "
+        f"{sum(len(merge_spans(v, merge_gap)) for v in monomers.values()):,} "
+        f"{satellite} bands across {len(monomers)} sequence(s)"
+    ]
+    if no_core:
+        notes.append(
+            f"{len(no_core)} sequence(s) have no {satellite} and are labelled {P_ARM} "
+            "end to end: " + ", ".join(no_core[:5])
+        )
+    if unknown:
+        notes.append(
+            f"skipped {len(unknown)} annotation seqid(s) absent from {lengths}: "
+            + ", ".join(sorted(unknown)[:5])
+        )
+
+    return PrepResult(
+        name=name,
+        bed=output,
+        n_records=n_records,
+        background=None,  # the arm/core split already tiles every base
+        hierarchy=hierarchy,
+        n_edges=n_edges,
+        priority=priority,
+        notes=notes,
+    )

--- a/tests/test_prep_bed.py
+++ b/tests/test_prep_bed.py
@@ -693,3 +693,42 @@ def test_a_bad_rename_prefix_is_a_clean_error_not_a_traceback(
     assert result.exit_code != 0
     assert "OLD:NEW" in result.output
     assert "Traceback" not in result.output
+
+
+def test_full_band_name_qualifies_a_bare_band() -> None:
+    assert cytoband_prep.full_band_name("chr1", "p36.33") == "1p36.33"
+    assert cytoband_prep.full_band_name("chr11", "q13.4") == "11q13.4"
+    assert cytoband_prep.full_band_name("chrX", "p22.33") == "Xp22.33"
+
+
+def test_full_band_name_does_not_double_prefix_an_already_qualified_band() -> None:
+    """A redistributed file may put the qualified name in column 4; prefixing
+    that again would give 11p36.33."""
+    assert cytoband_prep.full_band_name("chr1", "1p36.33") == "1p36.33"
+    assert cytoband_prep.full_band_name("chr11", "11q13.4") == "11q13.4"
+    assert cytoband_prep.full_band_name("chrX", "Xp22.33") == "Xp22.33"
+    # chr1's bands and chr11's must not be confused by a prefix test alone.
+    assert cytoband_prep.full_band_name("chr1", "1p36.33") != "11p36.33"
+
+
+def test_cytoband_accepts_both_the_bare_and_qualified_column_4(tmp_path: Path, fai: Path) -> None:
+    """The 5-column golden-path table and a file carrying qualified names must
+    produce the same feature set."""
+    bare = tmp_path / "bare.txt"
+    bare.write_text("chr1\t0\t1000\tp36.33\tgneg\nchr1\t1000\t2000\tq11.1\tgpos25\n")
+    qualified = tmp_path / "qualified.txt"
+    qualified.write_text("chr1\t0\t1000\t1p36.33\tgneg\nchr1\t1000\t2000\t1q11.1\tgpos25\n")
+
+    outputs = []
+    for i, source in enumerate((bare, qualified)):
+        out = tmp_path / f"c{i}.bed"
+        cytoband_prep.from_ucsc(
+            input_path=source,
+            lengths=fai,
+            output=out,
+            hierarchy=tmp_path / f"c{i}.tsv",
+            primary_pattern=r"^chr1$",
+        )
+        outputs.append(out.read_text())
+    assert outputs[0] == outputs[1]
+    assert "1p36.33" in outputs[0] and "11p36.33" not in outputs[0]

--- a/tests/test_prep_bed.py
+++ b/tests/test_prep_bed.py
@@ -1,0 +1,551 @@
+"""Tests for ``karyoscope prep-bed`` and the converters behind it.
+
+The converters were checked against the real reference feature sets during
+development — the EDTA, ``.fai``, satellite and UCSC-cytoband outputs are
+byte-identical to the files the bespoke scripts produced from the same inputs.
+What is pinned here is the behaviour that regression would silently break:
+coordinate conventions, the precedence rule, which rows survive, and the fact
+that the pasteable stanza goes to stdout while commentary goes to stderr.
+"""
+
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from karyoscope.cli import main
+from karyoscope.core.prep import cytoband as cytoband_prep
+from karyoscope.core.prep import genes as genes_prep
+from karyoscope.core.prep import repeats as repeats_prep
+from karyoscope.core.prep import structural as structural_prep
+from karyoscope.core.prep.common import (
+    PrepError,
+    PrepResult,
+    SeqidRewriter,
+    coalesce,
+    open_text,
+    read_fai,
+    render_stanza,
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def fai(tmp_path: Path) -> Path:
+    """A .fai deliberately NOT in natural order, to catch re-sorting."""
+    path = tmp_path / "ref.fa.fai"
+    path.write_text("chr2\t2000\t0\t60\t61\nchr1\t1000\t0\t60\t61\nchrM\t100\t0\t60\t61\n")
+    return path
+
+
+def bed_rows(path: Path) -> list[list[str]]:
+    return [line.split("\t") for line in path.read_text().splitlines()]
+
+
+# -- shared plumbing --------------------------------------------------
+
+
+def test_open_text_detects_gzip_by_content_not_suffix(tmp_path: Path) -> None:
+    """A gzipped file with a misleading name still reads: we sniff magic bytes."""
+    path = tmp_path / "annotation.gff3"  # no .gz, but gzipped
+    path.write_bytes(gzip.compress(b"chr1\tx\texon\t1\t10\t.\t+\t.\tID=a\n"))
+    with open_text(path) as fh:
+        assert fh.read().startswith("chr1")
+
+
+def test_read_fai_preserves_file_order(fai: Path) -> None:
+    assert list(read_fai(fai)) == ["chr2", "chr1", "chrM"]
+
+
+def test_read_fai_rejects_a_non_integer_length(tmp_path: Path) -> None:
+    path = tmp_path / "bad.fai"
+    path.write_text("chr1\tlots\n")
+    with pytest.raises(PrepError, match="not an integer"):
+        read_fai(path)
+
+
+def test_seqid_rewriter_table_beats_prefix(tmp_path: Path) -> None:
+    table = tmp_path / "map.tsv"
+    table.write_text("chrA_1\trenamed\n")
+    rewriter = SeqidRewriter.build(rename_prefix="chrA_:Chr", seqid_map=table)
+    assert rewriter("chrA_1") == "renamed"  # exact table entry wins
+    assert rewriter("chrA_2") == "Chr2"  # falls through to the prefix rule
+    assert rewriter("scaffold_9") == "scaffold_9"  # matched by neither
+
+
+def test_seqid_rewriter_rejects_a_prefix_without_a_colon() -> None:
+    with pytest.raises(PrepError, match="OLD:NEW"):
+        SeqidRewriter.build(rename_prefix="nocolon", seqid_map=None)
+
+
+def test_coalesce_joins_only_abutting_same_label_runs() -> None:
+    assert coalesce([("c", 0, 5, "a"), ("c", 5, 9, "a"), ("c", 9, 12, "b"), ("d", 0, 4, "a")]) == [
+        ("c", 0, 9, "a"),
+        ("c", 9, 12, "b"),
+        ("d", 0, 4, "a"),
+    ]
+
+
+def test_render_stanza_marks_a_fully_tiled_set_and_lists_exclusions(tmp_path: Path) -> None:
+    stanza = render_stanza(
+        PrepResult(
+            name="cytoband",
+            bed=Path("cytoband.bed"),
+            n_records=3,
+            background=None,
+            hierarchy=Path("cytoband.tsv"),
+            exclude=["chrM", "chrUn_x"],
+        )
+    )
+    assert "background: null" in stanza
+    assert "exclude:\n  - chrM\n  - chrUn_x" in stanza
+
+
+def test_render_stanza_names_the_background_when_there_is_one() -> None:
+    stanza = render_stanza(
+        PrepResult(name="repeat", bed=Path("r.bed"), n_records=1, background="nonrepeat")
+    )
+    assert "background: nonrepeat" in stanza
+    assert "exclude:" not in stanza
+
+
+# -- RepeatMasker -----------------------------------------------------
+
+RM_OUT = """\
+   SW   perc perc perc  query     position in query      matching  repeat  position in repeat
+score   div. del. ins.  sequence  begin end (left) strand repeat    class/family  begin end (left)  ID
+
+  463   1.3  0.6  1.7  chr1        11     60  (940) +   L1MA        LINE/L1         1   50  (0)  1
+  200  10.0  0.0  0.0  chr1       101    150  (850) C   AluSx       SINE/Alu        1   50  (0)  2
+  150  12.0  0.0  0.0  chr1       201    250  (750) +   (CA)n       Simple_repeat   1   50  (0)  3
+  120  15.0  0.0  0.0  chr1       301    350  (650) +   Weird       Novel_class     1   50  (0)  4
+"""
+
+RM_BED = "\n".join(
+    [
+        "chr1\t10\t60\tL1MA#LINE/L1\t.\t+\t10\t60\t0\t1\t50\t0",
+        "chr1\t100\t150\tAluSx#SINE/Alu\t.\t-\t100\t150\t0\t1\t50\t0",
+        "chr1\t200\t250\t(CA)n#Simple_repeat\t.\t+\t200\t250\t0\t1\t50\t0",
+        "chr1\t300\t350\tWeird#Novel_class\t.\t+\t300\t350\t0\t1\t50\t0",
+    ]
+)
+
+
+def _run_rm(tmp_path: Path, text: str, name: str, **kwargs: object) -> tuple[PrepResult, Path]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    source = tmp_path / name
+    source.write_text(text + "\n")
+    output = tmp_path / "repeat.bed"
+    result = repeats_prep.from_repeatmasker(
+        input_path=source,
+        output=output,
+        hierarchy=tmp_path / "repeat.tsv",
+        **kwargs,  # type: ignore[arg-type]
+    )
+    return result, output
+
+
+def test_repeatmasker_out_dialect_converts_1_based_inclusive_to_bed(tmp_path: Path) -> None:
+    result, output = _run_rm(tmp_path, RM_OUT, "rm.out")
+    assert "'out' dialect" in result.notes[0]
+    assert bed_rows(output)[0] == ["chr1", "10", "60", "LINE"]
+
+
+def test_repeatmasker_bed_dialect_gives_the_same_labels(tmp_path: Path) -> None:
+    """Both dialects of the same tool's output must agree, coordinates included."""
+    _, from_out = _run_rm(tmp_path / "a", RM_OUT, "rm.out")
+    _, from_bed = _run_rm(tmp_path / "b", RM_BED, "rm.bed")
+    assert from_out.read_text() == from_bed.read_text()
+
+
+def test_repeatmasker_labels_unknown_classes_rather_than_dropping_them(tmp_path: Path) -> None:
+    """Dropping them would leave those bases to the nonrepeat gap-fill, asserting
+    the opposite of what the annotation says."""
+    result, output = _run_rm(tmp_path, RM_OUT, "rm.out")
+    labels = [row[3] for row in bed_rows(output)]
+    assert labels == ["LINE", "SINE", "Simple_repeat", "Unknown"]
+    assert any("Novel_class" in note for note in result.notes)
+
+
+def test_repeatmasker_strips_the_uncertainty_marker(tmp_path: Path) -> None:
+    """RepeatMasker's ``DNA?`` is still DNA, not an unrecognised class."""
+    text = RM_OUT + "  100  1.0  0.0  0.0  chr1  401 450 (550) + X  DNA?/hAT  1 50 (0) 5\n"
+    _, output = _run_rm(tmp_path, text, "rm.out")
+    assert bed_rows(output)[-1][3] == "DNA"
+
+
+def test_repeatmasker_colors_group_the_rna_leaves_into_one_legend_row(tmp_path: Path) -> None:
+    colors = tmp_path / "colors.tsv"
+    _run_rm(tmp_path, RM_OUT, "rm.out", colors=colors)
+    rows = [line.split("\t") for line in colors.read_text().splitlines()[1:]]
+    groups = {feature: group for _set, feature, _color, group in rows}
+    assert groups["rRNA"] == groups["tRNA"] == "RNA"
+    assert groups["LINE"] == ""  # a colour of its own, so no grouping needed
+    # build enforces "same group => same colour"; make sure we honour it.
+    by_group: dict[str, set[str]] = {}
+    for _set, _feature, color, group in rows:
+        if group:
+            by_group.setdefault(group, set()).add(color)
+    assert all(len(colors_used) == 1 for colors_used in by_group.values())
+
+
+def test_repeatmasker_hierarchy_covers_every_leaf_it_can_emit(tmp_path: Path) -> None:
+    """A leaf missing from the hierarchy fails the build, so check it here."""
+    nodes = {child for child, _parent in repeats_prep.RM_HIERARCHY}
+    assert set(repeats_prep.RM_CLASS_TO_LEAF.values()) <= nodes
+    assert repeats_prep.RM_FALLBACK_LEAF in nodes
+    assert set(repeats_prep.RM_COLORS) == nodes
+
+
+# -- EDTA -------------------------------------------------------------
+
+EDTA_GFF = """\
+##gff-version 3
+Chr1\tEDTA\trepeat_region\t101\t200\t.\t+\t.\tID=TE_1;Classification=DNA/HAT
+Chr1\tEDTA\trepeat_region\t301\t400\t.\t+\t.\tID=TE_2;Classification=DNA/DTA
+Chr1\tEDTA\trepeat_region\t501\t600\t.\t+\t.\tID=TE_3;Classification=Nonsense/Made-up
+"""
+
+
+def test_edta_normalises_wicker_aliases_onto_one_leaf(tmp_path: Path) -> None:
+    """DNA/HAT and DNA/DTA are both hAT; they must not become two leaves."""
+    source = tmp_path / "te.gff3"
+    source.write_text(EDTA_GFF)
+    output = tmp_path / "repeat.bed"
+    result = repeats_prep.from_edta(
+        input_path=source, output=output, hierarchy=tmp_path / "repeat.tsv"
+    )
+    rows = bed_rows(output)
+    assert [row[3] for row in rows[:2]] == ["hAT", "hAT"]
+    assert rows[0][1:3] == ["100", "200"]  # GFF3 1-based inclusive -> BED half-open
+    assert rows[2][3] == repeats_prep.EDTA_FALLBACK_LEAF
+    assert any("Nonsense/Made-up" in note for note in result.notes)
+    assert result.background == "nonrepeat"
+
+
+def test_edta_hierarchy_covers_every_alias_target() -> None:
+    nodes = {child for child, _parent in repeats_prep.EDTA_HIERARCHY}
+    assert set(repeats_prep.EDTA_ALIAS.values()) <= nodes
+
+
+# -- gene -------------------------------------------------------------
+
+GTF = """\
+chr1\tsrc\texon\t101\t200\t.\t+\t.\ttranscript_id "t1"; gene_id "g1";
+chr1\tsrc\texon\t301\t400\t.\t+\t.\ttranscript_id "t1"; gene_id "g1";
+"""
+
+GFF3 = """\
+##gff-version 3
+chr1\tsrc\texon\t101\t200\t.\t+\t.\tID=e1;Parent=transcript:t1
+chr1\tsrc\texon\t301\t400\t.\t+\t.\tID=e2;Parent=transcript:t1
+"""
+
+
+def _run_gene(tmp_path: Path, text: str, fai: Path, **kwargs: object) -> Path:
+    source = tmp_path / "genes.gff3"
+    source.write_text(text)
+    output = tmp_path / "gene.bed"
+    genes_prep.from_gff(
+        input_path=source,
+        lengths=fai,
+        output=output,
+        hierarchy=tmp_path / "gene.tsv",
+        **kwargs,  # type: ignore[arg-type]
+    )
+    return output
+
+
+def test_transcript_ids_reads_both_attribute_dialects() -> None:
+    assert genes_prep.transcript_ids("ID=e1;Parent=transcript:t1") == ["transcript:t1"]
+    assert genes_prep.transcript_ids('transcript_id "t1"; gene_id "g1";') == ["t1"]
+    assert genes_prep.transcript_ids("Parent=a,b") == ["a", "b"]
+    assert genes_prep.transcript_ids("nothing_useful") == []
+
+
+@pytest.mark.parametrize("text", [GTF, GFF3], ids=["gtf", "gff3"])
+def test_gene_derives_introns_between_a_transcripts_exons(
+    tmp_path: Path, fai: Path, text: str
+) -> None:
+    output = _run_gene(tmp_path, text, fai)
+    chr1 = [row for row in bed_rows(output) if row[0] == "chr1"]
+    assert chr1 == [
+        ["chr1", "0", "100", "intergenic"],
+        ["chr1", "100", "200", "exon"],
+        ["chr1", "200", "300", "intron"],
+        ["chr1", "300", "400", "exon"],
+        ["chr1", "400", "1000", "intergenic"],
+    ]
+
+
+def test_gene_does_not_call_the_gap_between_two_genes_an_intron(tmp_path: Path, fai: Path) -> None:
+    """The gap between separate single-exon transcripts is intergenic. Deriving
+    introns from a chromosome-wide exon list instead gets this wrong, and it is
+    the difference between ~20% and ~42% intron on a compact genome."""
+    text = (
+        'chr1\tsrc\texon\t101\t200\t.\t+\t.\ttranscript_id "t1";\n'
+        'chr1\tsrc\texon\t301\t400\t.\t+\t.\ttranscript_id "t2";\n'
+    )
+    output = _run_gene(tmp_path, text, fai)
+    labels = {(row[1], row[2]): row[3] for row in bed_rows(output) if row[0] == "chr1"}
+    assert labels[("200", "300")] == "intergenic"
+
+
+def test_gene_prefers_exon_over_intron_where_transcripts_disagree(
+    tmp_path: Path, fai: Path
+) -> None:
+    """One transcript's intron overlapping another's exon must read as exon."""
+    text = (
+        'chr1\tsrc\texon\t101\t200\t.\t+\t.\ttranscript_id "t1";\n'
+        'chr1\tsrc\texon\t401\t500\t.\t+\t.\ttranscript_id "t1";\n'
+        'chr1\tsrc\texon\t251\t300\t.\t+\t.\ttranscript_id "t2";\n'
+    )
+    output = _run_gene(tmp_path, text, fai)
+    labels = {(row[1], row[2]): row[3] for row in bed_rows(output) if row[0] == "chr1"}
+    assert labels[("250", "300")] == "exon"
+    assert labels[("200", "250")] == "intron"
+
+
+def test_gene_tiles_every_sequence_including_unannotated_ones(tmp_path: Path, fai: Path) -> None:
+    output = _run_gene(tmp_path, GTF, fai)
+    covered: dict[str, int] = {}
+    for seqid, start, end, _label in bed_rows(output):
+        assert covered.setdefault(seqid, 0) == int(start), f"{seqid} is not contiguous"
+        covered[seqid] = int(end)
+    assert covered == read_fai(fai)
+
+
+def test_gene_merges_abutting_spans_of_the_same_label(tmp_path: Path, fai: Path) -> None:
+    """Overlapping exons must yield one record, not one per boundary."""
+    text = (
+        'chr1\tsrc\texon\t101\t300\t.\t+\t.\ttranscript_id "t1";\n'
+        'chr1\tsrc\texon\t201\t400\t.\t+\t.\ttranscript_id "t2";\n'
+    )
+    output = _run_gene(tmp_path, text, fai)
+    exons = [row for row in bed_rows(output) if row[3] == "exon"]
+    assert exons == [["chr1", "100", "400", "exon"]]
+
+
+def test_gene_reports_a_useful_error_when_nothing_matches(tmp_path: Path, fai: Path) -> None:
+    text = 'other\tsrc\texon\t101\t200\t.\t+\t.\ttranscript_id "t1";\n'
+    with pytest.raises(PrepError, match="--seqid-map"):
+        _run_gene(tmp_path, text, fai)
+
+
+# -- cytoband ---------------------------------------------------------
+
+CYTOBAND = "\n".join(
+    [
+        "chr1\t0\t1000\tp36.33\tgneg",
+        "chr1\t1000\t1500\tp36.32\tgpos25",
+        "chr1\t1500\t2000\tp33\tacen",
+        "chr2\t0\t2000\tq11.1\tgvar",
+        "chrUn_x\t0\t50\tp11\tgneg",
+    ]
+)
+
+
+def _run_cytoband(tmp_path: Path, fai: Path, **kwargs: object) -> tuple[PrepResult, Path]:
+    source = tmp_path / "cytoBand.txt"
+    source.write_text(CYTOBAND + "\n")
+    output = tmp_path / "cytoband.bed"
+    result = cytoband_prep.from_ucsc(
+        input_path=source,
+        lengths=fai,
+        output=output,
+        hierarchy=tmp_path / "cytoband.tsv",
+        **kwargs,  # type: ignore[arg-type]
+    )
+    return result, output
+
+
+def test_cytoband_labels_keep_their_chromosome(tmp_path: Path, fai: Path) -> None:
+    """Bare band names collide across chromosomes; ``1p36.33`` cannot."""
+    _, output = _run_cytoband(tmp_path, fai)
+    assert [row[3] for row in bed_rows(output)] == ["2q11.1", "1p36.33", "1p36.32", "1p33"]
+
+
+def test_cytoband_nests_sub_banded_and_singleton_bands_differently(
+    tmp_path: Path, fai: Path
+) -> None:
+    result, _ = _run_cytoband(tmp_path, fai)
+    edges = dict(line.split("\t") for line in (result.hierarchy or Path()).read_text().splitlines())
+    assert edges["1p36.33"] == "1p36"  # sub-banded: under its group
+    assert edges["1p36"] == "1"
+    assert edges["1p33"] == "1"  # singleton: straight under the chromosome
+    assert edges["1"] == "categorized"
+
+
+def test_cytoband_reports_unbanded_sequences_for_exclude_rather_than_labelling_them(
+    tmp_path: Path, fai: Path
+) -> None:
+    """The archive wrote chrM as a literal 'exclude' label; build has a real
+    exclude: list now, and a placeholder label would claim the sequence."""
+    result, output = _run_cytoband(tmp_path, fai)
+    assert "chrM" in result.exclude
+    assert all(row[0] != "chrM" for row in bed_rows(output))
+
+
+def test_cytoband_colors_come_from_the_stain_and_group_the_legend(
+    tmp_path: Path, fai: Path
+) -> None:
+    colors = tmp_path / "colors.tsv"
+    _run_cytoband(tmp_path, fai, colors=colors)
+    lines = colors.read_text().splitlines()
+    assert lines[0].endswith("legend_group")
+    rows = {parts[1]: (parts[2], parts[3]) for parts in (line.split("\t") for line in lines[1:])}
+    assert rows["1p36.33"] == (cytoband_prep.STAIN_COLORS["gneg"], "gneg")
+    assert rows["1p33"] == (cytoband_prep.STAIN_COLORS["acen"], "acen")
+    # Interior nodes are not bands and must not join a stain group.
+    assert rows["1"] == (cytoband_prep.INTERIOR_COLOR, cytoband_prep.INTERIOR_GROUP)
+
+
+def test_cytoband_flags_a_stain_it_has_no_colour_for(tmp_path: Path, fai: Path) -> None:
+    source = tmp_path / "cytoBand.txt"
+    source.write_text("chr1\t0\t1000\tp36.33\tglowing\n")
+    result = cytoband_prep.from_ucsc(
+        input_path=source,
+        lengths=fai,
+        output=tmp_path / "c.bed",
+        hierarchy=tmp_path / "c.tsv",
+        colors=tmp_path / "c_colors.tsv",
+    )
+    assert any("glowing" in note for note in result.notes)
+
+
+def test_cytoband_refuses_a_pattern_that_matches_nothing(tmp_path: Path, fai: Path) -> None:
+    with pytest.raises(PrepError, match="widen --primary-pattern"):
+        _run_cytoband(tmp_path, fai, primary_pattern=r"^nope$")
+
+
+# -- chromosome / satellite -------------------------------------------
+
+
+def test_fai_emits_one_whole_length_record_per_sequence_in_file_order(
+    tmp_path: Path, fai: Path
+) -> None:
+    output = tmp_path / "chromosome.bed"
+    result = structural_prep.from_fai(lengths=fai, output=output)
+    assert bed_rows(output) == [
+        ["chr2", "0", "2000", "chr2"],
+        ["chr1", "0", "1000", "chr1"],
+        ["chrM", "0", "100", "chrM"],
+    ]
+    assert result.background is None
+    assert result.hierarchy is None  # grouping is curation, not derivable
+
+
+def test_core_cluster_picks_the_densest_cluster_not_the_widest_extent() -> None:
+    """A stray distal monomer must not drag the centromere across the arm."""
+    bands = [(0, 10), (1_000_000, 1_010_000), (1_010_500, 1_020_000)]
+    assert structural_prep.core_cluster(bands, cluster_gap=500_000) == (1_000_000, 1_020_000)
+
+
+def test_merge_spans_bridges_only_gaps_within_the_limit() -> None:
+    assert structural_prep.merge_spans([(0, 10), (11, 20), (100, 110)], gap=10) == [
+        (0, 20),
+        (100, 110),
+    ]
+    assert structural_prep.merge_spans([(0, 10), (11, 20)], gap=0) == [(0, 10), (11, 20)]
+
+
+def test_satellite_splits_the_arms_around_the_core_and_tiles_fully(
+    tmp_path: Path, fai: Path
+) -> None:
+    source = tmp_path / "sat.gff3"
+    source.write_text("chr1\ttrf\tmonomer\t501\t600\t.\t+\t.\tID=m1\n")
+    output = tmp_path / "region.bed"
+    result = structural_prep.from_satellite(
+        input_path=source,
+        lengths=fai,
+        output=output,
+        hierarchy=tmp_path / "region.tsv",
+        satellite="CEN180",
+    )
+    chr1 = [row for row in bed_rows(output) if row[0] == "chr1"]
+    assert chr1 == [
+        ["chr1", "0", "500", "p_arm"],
+        ["chr1", "500", "600", "CEN180"],
+        ["chr1", "600", "1000", "q_arm"],
+    ]
+    # Sequences with no satellite are still covered, so the set tiles the genome.
+    assert [row for row in bed_rows(output) if row[0] == "chrM"] == [["chrM", "0", "100", "p_arm"]]
+    assert result.background is None
+
+
+def test_satellite_reads_bed_input_as_zero_based(tmp_path: Path, fai: Path) -> None:
+    """The coordinate convention follows the suffix; a BED must not be shifted."""
+    source = tmp_path / "sat.bed"
+    source.write_text("chr1\t500\t600\tmonomer\n")
+    output = tmp_path / "region.bed"
+    structural_prep.from_satellite(
+        input_path=source, lengths=fai, output=output, hierarchy=tmp_path / "region.tsv"
+    )
+    assert ["chr1", "500", "600", "satellite"] in bed_rows(output)
+
+
+# -- CLI wiring -------------------------------------------------------
+
+
+def test_stanza_goes_to_stdout_and_commentary_to_stderr(
+    tmp_path: Path, fai: Path, runner: CliRunner
+) -> None:
+    """So `prep-bed ... >> spec.yaml` captures the stanza and nothing else."""
+    result = runner.invoke(
+        main,
+        ["prep-bed", "fai", "--lengths", str(fai), "--output", str(tmp_path / "c.bed")],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert result.stdout.startswith("# add to your build spec:")
+    assert "feature_sets:\n  - name: chromosome" in result.stdout
+    assert "wrote" not in result.stdout
+
+
+def test_existing_outputs_are_not_clobbered_without_force(
+    tmp_path: Path, fai: Path, runner: CliRunner
+) -> None:
+    existing = tmp_path / "c.bed"
+    existing.write_text("precious\n")
+    args = ["prep-bed", "fai", "--lengths", str(fai), "--output", str(existing)]
+    result = runner.invoke(main, args)
+    assert result.exit_code != 0
+    assert "refusing to overwrite" in result.output
+    assert existing.read_text() == "precious\n"
+
+    assert runner.invoke(main, [*args, "--force"]).exit_code == 0
+    assert existing.read_text() != "precious\n"
+
+
+def test_every_format_subcommand_is_reachable(runner: CliRunner) -> None:
+    listing = runner.invoke(main, ["prep-bed", "--help"]).output
+    for leaf in ("repeatmasker", "edta", "gff-gene", "cytoband", "fai", "satellite"):
+        assert leaf in listing
+
+
+def test_a_bad_rename_prefix_is_a_clean_error_not_a_traceback(
+    tmp_path: Path, fai: Path, runner: CliRunner
+) -> None:
+    result = runner.invoke(
+        main,
+        [
+            "prep-bed",
+            "fai",
+            "--lengths",
+            str(fai),
+            "--output",
+            str(tmp_path / "c.bed"),
+            "--rename-prefix",
+            "missing-colon",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "OLD:NEW" in result.output
+    assert "Traceback" not in result.output

--- a/tests/test_prep_bed.py
+++ b/tests/test_prep_bed.py
@@ -165,13 +165,46 @@ def test_repeatmasker_bed_dialect_gives_the_same_labels(tmp_path: Path) -> None:
     assert from_out.read_text() == from_bed.read_text()
 
 
-def test_repeatmasker_labels_unknown_classes_rather_than_dropping_them(tmp_path: Path) -> None:
+def test_repeatmasker_labels_unmapped_classes_rather_than_dropping_them(tmp_path: Path) -> None:
     """Dropping them would leave those bases to the nonrepeat gap-fill, asserting
     the opposite of what the annotation says."""
     result, output = _run_rm(tmp_path, RM_OUT, "rm.out")
     labels = [row[3] for row in bed_rows(output)]
-    assert labels == ["LINE", "SINE", "Simple_repeat", "Unknown"]
+    assert labels == ["LINE", "SINE", "Simple_repeat", "other_repeat"]
     assert any("Novel_class" in note for note in result.notes)
+
+
+def test_an_unmapped_class_is_not_folded_into_repeatmaskers_own_unknown(
+    tmp_path: Path,
+) -> None:
+    """`Unknown` is a real RepeatMasker class meaning "could not classify this".
+    A class we have no leaf for is a different claim, and must not borrow it."""
+    text = RM_OUT + "  100  1.0 0.0 0.0  chr1  401 450 (550) + X  Unknown  1 50 (0) 5\n"
+    result, output = _run_rm(tmp_path, text, "rm.out")
+    labels = [row[3] for row in bed_rows(output)]
+    assert "Unknown" in labels  # the genuine class survives as itself
+    assert "other_repeat" in labels  # the unmapped one is kept separate
+    assert labels.count("Unknown") == 1
+    assert any("NOT RepeatMasker" in note for note in result.notes)
+
+
+def test_the_fallback_leaf_appears_only_when_it_is_used(tmp_path: Path) -> None:
+    """Otherwise every file would gain a node the reference tree does not have."""
+    clean = "\n".join(line for line in RM_OUT.splitlines() if "Novel_class" not in line)
+    _, _out = _run_rm(tmp_path / "clean", clean, "rm.out")
+    edges = (tmp_path / "clean" / "repeat.tsv").read_text()
+    assert "other_repeat" not in edges
+
+    _run_rm(tmp_path / "dirty", RM_OUT, "rm.out")
+    assert "other_repeat\trepeat" in (tmp_path / "dirty" / "repeat.tsv").read_text()
+
+
+def test_the_fallback_leaf_gets_a_colour_when_present(tmp_path: Path) -> None:
+    colors = tmp_path / "colors.tsv"
+    _run_rm(tmp_path, RM_OUT, "rm.out", colors=colors)
+    rows = {ln.split("\t")[1]: ln.split("\t")[2] for ln in colors.read_text().splitlines()[1:]}
+    assert rows["other_repeat"] == repeats_prep.RM_FALLBACK_COLOR
+    assert rows["other_repeat"] != rows["Unknown"]
 
 
 def test_repeatmasker_strips_the_uncertainty_marker(tmp_path: Path) -> None:
@@ -200,8 +233,11 @@ def test_repeatmasker_hierarchy_covers_every_leaf_it_can_emit(tmp_path: Path) ->
     """A leaf missing from the hierarchy fails the build, so check it here."""
     nodes = {child for child, _parent in repeats_prep.RM_HIERARCHY}
     assert set(repeats_prep.RM_CLASS_TO_LEAF.values()) <= nodes
-    assert repeats_prep.RM_FALLBACK_LEAF in nodes
     assert set(repeats_prep.RM_COLORS) == nodes
+    # The fallback is attached on demand, so it is deliberately NOT in the base
+    # tree -- but its parent must be.
+    assert repeats_prep.RM_FALLBACK_LEAF not in nodes
+    assert repeats_prep.RM_FALLBACK_PARENT in nodes
 
 
 # -- EDTA -------------------------------------------------------------

--- a/tests/test_prep_bed.py
+++ b/tests/test_prep_bed.py
@@ -250,6 +250,7 @@ chr1\tsrc\texon\t301\t400\t.\t+\t.\tID=e2;Parent=transcript:t1
 
 
 def _run_gene(tmp_path: Path, text: str, fai: Path, **kwargs: object) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
     source = tmp_path / "genes.gff3"
     source.write_text(text)
     output = tmp_path / "gene.bed"
@@ -268,6 +269,35 @@ def test_transcript_ids_reads_both_attribute_dialects() -> None:
     assert genes_prep.transcript_ids('transcript_id "t1"; gene_id "g1";') == ["t1"]
     assert genes_prep.transcript_ids("Parent=a,b") == ["a", "b"]
     assert genes_prep.transcript_ids("nothing_useful") == []
+
+
+def test_transcript_id_beats_parent_when_parent_is_the_gene() -> None:
+    """Liftoff-style output sets Parent to the GENE and names the transcript in
+    transcript_id. Preferring Parent there merges a gene's transcripts, and
+    introns derived from a merged exon list span the gaps between them."""
+    liftoff_gff3 = "transcript_id=AT1G01010.1;gene_id=AT1G01010;Parent=AT1G01010;ID=exon_1"
+    liftoff_gtf = 'transcript_id "AT1G01010.1"; gene_id "AT1G01010"; Parent "AT1G01010";'
+    assert genes_prep.transcript_ids(liftoff_gff3) == ["AT1G01010.1"]
+    assert genes_prep.transcript_ids(liftoff_gtf) == ["AT1G01010.1"]
+
+
+def test_the_two_published_syntaxes_of_one_annotation_agree(tmp_path: Path, fai: Path) -> None:
+    """The Col-CEN gene annotation is published with GTF-style attributes on
+    GitHub and GFF3-style on TAIR. Same content, so the same feature set."""
+    gtf_style = (
+        'chr1\tLiftoff\texon\t101\t200\t.\t+\t.\ttranscript_id "g1.1"; gene_id "g1"; Parent "g1";\n'
+        'chr1\tLiftoff\texon\t401\t500\t.\t+\t.\ttranscript_id "g1.2"; gene_id "g1"; Parent "g1";\n'
+    )
+    gff3_style = (
+        "chr1\tLiftoff\texon\t101\t200\t.\t+\t.\ttranscript_id=g1.1;gene_id=g1;Parent=g1\n"
+        "chr1\tLiftoff\texon\t401\t500\t.\t+\t.\ttranscript_id=g1.2;gene_id=g1;Parent=g1\n"
+    )
+    a = _run_gene(tmp_path / "a", gtf_style, fai)
+    b = _run_gene(tmp_path / "b", gff3_style, fai)
+    assert a.read_text() == b.read_text()
+    # Two single-exon transcripts of one gene: the gap is intergenic, not intron.
+    labels = {(r[1], r[2]): r[3] for r in bed_rows(a) if r[0] == "chr1"}
+    assert labels[("200", "400")] == "intergenic"
 
 
 @pytest.mark.parametrize("text", [GTF, GFF3], ids=["gtf", "gff3"])

--- a/tests/test_prep_bed.py
+++ b/tests/test_prep_bed.py
@@ -510,6 +510,84 @@ def test_satellite_splits_the_arms_around_the_core_and_tiles_fully(
     assert result.background is None
 
 
+def test_censat_label_drops_the_array_detail() -> None:
+    """CenSat qualifies each label with the arrays it contains; hundreds of
+    distinct values all mean the same feature."""
+    assert structural_prep.censat_label("gSat(TAR1)") == "gSat"
+    assert structural_prep.censat_label("hor(S1C10H1-B)") == "hor"
+    assert structural_prep.censat_label("ct") == "ct"
+
+
+def test_censat_splits_arms_at_the_ct_features(tmp_path: Path, fai: Path) -> None:
+    source = tmp_path / "censat.bed"
+    source.write_text(
+        'track name="x"\n'
+        "chr1\t100\t200\tgSat(TAR1)\n"  # a distal remnant, out on the p arm
+        "chr1\t400\t450\tct\n"
+        "chr1\t450\t550\tactive_hor(S1C1H1L)\n"
+        "chr1\t550\t600\tct\n"
+    )
+    output = tmp_path / "region.bed"
+    structural_prep.from_censat(
+        input_path=source, lengths=fai, output=output, hierarchy=tmp_path / "region.tsv"
+    )
+    assert [r for r in bed_rows(output) if r[0] == "chr1"] == [
+        ["chr1", "0", "100", "p_arm"],
+        ["chr1", "100", "200", "gSat"],  # remnant keeps its label
+        ["chr1", "200", "400", "p_arm"],
+        ["chr1", "400", "450", "ct"],
+        ["chr1", "450", "550", "active_hor"],
+        ["chr1", "550", "600", "ct"],
+        ["chr1", "600", "1000", "q_arm"],
+    ]
+
+
+def test_censat_coalesces_rows_that_share_a_label_once_detail_is_dropped(
+    tmp_path: Path, fai: Path
+) -> None:
+    """Two abutting arrays of the same feature are one region, not two."""
+    source = tmp_path / "censat.bed"
+    source.write_text("chr1\t100\t200\thor(S1C1H2-A)\nchr1\t200\t300\thor(S1C1H2-B)\n")
+    output = tmp_path / "region.bed"
+    structural_prep.from_censat(
+        input_path=source, lengths=fai, output=output, hierarchy=tmp_path / "region.tsv"
+    )
+    assert [r for r in bed_rows(output) if r[3] == "hor"] == [["chr1", "100", "300", "hor"]]
+
+
+def test_censat_reports_unannotated_sequences_instead_of_claiming_them(
+    tmp_path: Path, fai: Path
+) -> None:
+    source = tmp_path / "censat.bed"
+    source.write_text("chr1\t100\t200\tct\n")
+    output = tmp_path / "region.bed"
+    result = structural_prep.from_censat(
+        input_path=source, lengths=fai, output=output, hierarchy=tmp_path / "region.tsv"
+    )
+    assert "chrM" in result.exclude and "chr2" in result.exclude
+    assert all(row[0] == "chr1" for row in bed_rows(output))
+
+
+def test_censat_priorities_rank_the_three_branches(tmp_path: Path, fai: Path) -> None:
+    """Siblings must be all-equal or all-distinct for build to accept them."""
+    source = tmp_path / "censat.bed"
+    source.write_text("chr1\t100\t200\tct\n")
+    priority = tmp_path / "region.prio"
+    structural_prep.from_censat(
+        input_path=source,
+        lengths=fai,
+        output=tmp_path / "region.bed",
+        hierarchy=tmp_path / "region.tsv",
+        priority=priority,
+    )
+    rows = {
+        c: int(p)
+        for c, p, _parent in (ln.split("\t") for ln in priority.read_text().split("\n") if ln)
+    }
+    assert (rows["centromeric"], rows["rDNA"], rows["arm"]) == (1, 2, 3)
+    assert rows["p_arm"] == rows["q_arm"] == 1
+
+
 def test_satellite_reads_bed_input_as_zero_based(tmp_path: Path, fai: Path) -> None:
     """The coordinate convention follows the suffix; a BED must not be shifted."""
     source = tmp_path / "sat.bed"


### PR DESCRIPTION
`build` starts from a final labelled BED, and producing that BED was the last step with no command behind it — every dataset needed its own script. This adds `karyoscope prep-bed`, with one subcommand per **source format**:

| Subcommand | Input | Produces |
| --- | --- | --- |
| `repeatmasker` | RepeatMasker `.out` or the UCSC BED repackaging | `repeat` |
| `edta` | EDTA TE GFF3 | `repeat` |
| `gff-gene` | GFF3 or GTF gene models | `exon`/`intron`/`intergenic` |
| `cytoband` | UCSC `cytoBand.txt` or `cytoBandMapped` BED | `cytoband` |
| `fai` | samtools `.fai` | `chromosome` |
| `satellite` | centromeric satellite monomers | `region` |

Keying on the format rather than the output name is what keeps the options honest: RepeatMasker output and an EDTA GFF3 both yield a `repeat` set but share no parsing, so a single command would carry flags valid for only some inputs.

Each writes its BED and hierarchy and prints the matching `feature_sets:` stanza on **stdout**, with progress and warnings on stderr, so it can be appended straight to a build spec. Optional `--colors` reproduces the reference palettes and fills in `legend_group`, so a cytoband set arrives with its legend already collapsed to nine stain rows rather than needing the database hand-edited afterwards.

### Scope

`prep-bed` does **not** gap-fill, flatten overlaps, or drop sequences — `build` already owns `background:`, `flatten:` and `exclude:`, and duplicating them would mean two places to get them wrong. Sequences a set does not cover are reported for the spec's `exclude:` rather than given a placeholder `exclude` *label* (the older convention), because a label claims the sequence instead of leaving it uncovered. The one converter that tiles is `satellite`, because telling `p_arm` from `q_arm` needs the centromere position and a gap-fill has only one label.

### Validation

Re-derived the reference feature sets from their original inputs and diffed against what the bespoke scripts produced. Byte-identical:

| Converter | Source | Result |
| --- | --- | --- |
| `edta` | Col-CEN `EDTA.TEanno.gff3.gz` | BED + hierarchy identical (42,927 records) |
| `fai` | Col-CEN `.fai` | identical |
| `satellite` | `ColCEN_CEN180.gff3` | BED + hierarchy identical |
| `cytoband` | `hg38.cytoBand.txt.gz` | BED + hierarchy + priority identical (862 bands, 1,104 edges) |
| `repeatmasker` | `CHM13.RepeatMasker.bed` (971 MB) | identical, 4,636,653 records, all 15 class counts match |
| `gff-gene` | `CHM13.gtf.gz` | identical, 612,908 records |

The cytoband colours file is new output and reproduces the shipped CHM13 stain palette and group order exactly (`mixed → gneg → gpos25 → gpos50 → gpos75 → gpos100 → acen → gvar → stalk`).

### One reference does not reproduce, and it is the reference that is wrong

The *A. thaliana* Col-CEN `gene.bed` used to build that database labels **8,325 spans `intron` that lie inside no gene at all** — checked against the annotation's own `gene` records, 8,323 of them are gaps between *neighbouring genes*, which are intergenic. The rule that produces this derives introns from a chromosome-wide sorted exon list rather than per transcript.

| | intron | intergenic | exon |
|---|---|---|---|
| Arabidopsis reference | **42.0%** | 21.6% | 36.4% |
| this PR | **20.6%** | 43.0% | 36.4% |
| human CHM13 (identical to reference) | 48.8% | 46.5% | 4.8% |

42% intron is not plausible for a compact 135 Mb genome. Human is the control: the same code reproduces `CHM13_gen.bed` byte-for-byte, so this is a defect in how the Arabidopsis set was made, not a change in behaviour. **The Arabidopsis database needs regenerating.**

Introns are now derived from each transcript's own consecutive exons, and where transcripts disagree the more specific label wins (`exon` > `intron` > `intergenic`), so alternative splicing never double-labels a base.

### Tests

39 new tests; full suite 865 passed, 1 skipped. Pinned: coordinate conventions per dialect, the precedence rule, the between-genes case above, that unrecognised RepeatMasker classes are labelled rather than dropped, that the legend groups honour build's "same group ⇒ same colour" invariant, and that the stanza goes to stdout while commentary goes to stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)