### PR TITLE
fix(build): write colors.tsv in hierarchy order, reproducibly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`colors.tsv` row order is now reproducible, and follows the hierarchy.**
+  `build` wrote one row per node by iterating `Hierarchy.nodes()`, which returns
+  a **set** — so Python's per-run string hash randomisation reordered the file,
+  and rebuilding a database from byte-identical inputs produced a
+  byte-different `colors.tsv`. Row order is emitted in hierarchy order instead
+  (each root, then every child in edge order), which is also what makes legend
+  groups meaningful: they are ordered by first appearance in `colors.tsv`, so
+  for a cytoband set that ordering is now the Giemsa intensity progression
+  rather than whatever the hash seed produced. Colour *assignments* are
+  unchanged; only the order of the rows.
+
 ### Added
 - **`colors.tsv` gains an optional 4th column, `legend_group`, and `build`
   carries it through.** A feature set with hundreds of leaves in a handful of

--- a/src/karyoscope/core/build.py
+++ b/src/karyoscope/core/build.py
@@ -261,7 +261,9 @@ def _prepare_feature_set(
             + "\n  ".join(issues)
         )
 
-    nodes = hierarchy.nodes(fs.name)
+    # Ordered, not the node *set*: this list determines colors.tsv's row order,
+    # which must be reproducible across rebuilds and drives legend-group order.
+    nodes = hierarchy.nodes_in_order(fs.name)
 
     # -- colours --
     provided, provided_groups = _parse_set_colors(fs.colors) if fs.colors is not None else ({}, {})

--- a/src/karyoscope/core/io/emit.py
+++ b/src/karyoscope/core/io/emit.py
@@ -71,17 +71,21 @@ def assign_colors(
     4. Every other node (internal / root grouping node) is
        :data:`STRUCTURAL_COLOR`.
 
-    Returns ``{node: hex}`` covering all of ``nodes``.
+    Returns ``{node: hex}`` covering all of ``nodes``, **keyed in the order
+    ``nodes`` was given** — callers write ``colors.tsv`` straight from this, so
+    iterating a set here would make the file's row order vary between runs.
+    Pass :meth:`Hierarchy.nodes_in_order`, not :meth:`Hierarchy.nodes`.
     """
     provided = dict(provided or {})
-    node_set = set(nodes)
 
     auto_leaves = [leaf for leaf in leaves if leaf not in provided and leaf != background]
     palette = auto_palette(len(auto_leaves))
     leaf_colors = dict(zip(auto_leaves, palette, strict=True))
 
     out: dict[str, str] = {}
-    for node in node_set:
+    for node in nodes:
+        if node in out:
+            continue
         if node in provided:
             out[node] = provided[node]
         elif background is not None and node == background:

--- a/src/karyoscope/core/io/hierarchy.py
+++ b/src/karyoscope/core/io/hierarchy.py
@@ -114,6 +114,35 @@ class Hierarchy:
             out.add(row.parent)
         return out
 
+    def nodes_in_order(self, feature_set: str) -> list[str]:
+        """Return every node in ``feature_set`` in hierarchy order: roots, then
+        each child in edge order.
+
+        The ordered counterpart to :meth:`nodes`. Anything written out per node
+        must use this rather than iterating the set, or the row order varies
+        between runs — Python randomises string hashing, so a rebuild from
+        identical inputs produced a differently-ordered ``colors.tsv``. Row
+        order is also load-bearing: legend groups are ordered by first
+        appearance in ``colors.tsv``, so hierarchy order is what makes that
+        ordering meaningful (for cytoband, the Giemsa intensity progression)
+        instead of arbitrary.
+        """
+        rows = self.rows_in(feature_set)
+        children = {row.child for row in rows}
+        ordered: list[str] = []
+        seen: set[str] = set()
+        # Roots first: a parent that is never a child. Well-formed sets have
+        # exactly one, but this does not depend on that.
+        for row in rows:
+            if row.parent not in children and row.parent not in seen:
+                ordered.append(row.parent)
+                seen.add(row.parent)
+        for row in rows:
+            if row.child not in seen:
+                ordered.append(row.child)
+                seen.add(row.child)
+        return ordered
+
     def count_by_feature_set(self) -> dict[str, int]:
         """Return ``{feature_set: row_count}`` for every feature set."""
         counts: dict[str, int] = {}

--- a/tests/test_emit.py
+++ b/tests/test_emit.py
@@ -173,3 +173,43 @@ class TestBuildParseSetColors:
         colors, groups = build_mod._parse_set_colors(p)
         assert set(colors) == {"rA", "rB"}
         assert groups == {"rB": "sat"}
+
+
+def test_nodes_in_order_puts_the_root_first_then_children_in_edge_order() -> None:
+    """colors.tsv is written straight from this order, so it must be the
+    hierarchy's, not a set's."""
+    from karyoscope.core.io.hierarchy import Hierarchy, HierarchyRow
+
+    hier = Hierarchy(
+        rows=[
+            HierarchyRow("cytoband", "1", "categorized"),
+            HierarchyRow("cytoband", "1p36", "1"),
+            HierarchyRow("cytoband", "1p36.33", "1p36"),
+            HierarchyRow("cytoband", "1p33", "1"),
+        ]
+    )
+    assert hier.nodes_in_order("cytoband") == [
+        "categorized",
+        "1",
+        "1p36",
+        "1p36.33",
+        "1p33",
+    ]
+    assert set(hier.nodes_in_order("cytoband")) == hier.nodes("cytoband")
+
+
+def test_assign_colors_preserves_the_node_order_it_was_given() -> None:
+    """A rebuild from identical inputs must produce an identically-ordered
+    colors.tsv; iterating a set here made row order vary with the hash seed."""
+    from karyoscope.core.io import emit as emit_mod
+
+    nodes = ["categorized", "exon", "intron", "intergenic"]
+    colors = emit_mod.assign_colors(nodes=nodes, leaves=["exon", "intron", "intergenic"])
+    assert list(colors) == nodes
+
+
+def test_assign_colors_tolerates_a_repeated_node() -> None:
+    from karyoscope.core.io import emit as emit_mod
+
+    colors = emit_mod.assign_colors(nodes=["a", "b", "a"], leaves=["a", "b"])
+    assert list(colors) == ["a", "b"]


### PR DESCRIPTION
`build` emitted one `colors.tsv` row per node by iterating `Hierarchy.nodes()`, which returns a **set**. Python randomises string hashing per run, so **rebuilding a database from byte-identical inputs produced a byte-different `colors.tsv`** — same content, different row order.

Caught while regenerating the Arabidopsis database: `colors.tsv` was the only file besides the corrected feature set to change, and diffing it sorted showed the content was identical.

### Why the order matters

It isn't cosmetic. Legend groups are ordered by **first appearance in `colors.tsv`**, so an arbitrary row order makes the legend's group order arbitrary too. Emitting in hierarchy order — each root, then every child in edge order — is what makes it meaningful. For a cytoband set that ordering is the Giemsa intensity progression, and it happens to match the order the shipped cytoband database already has.

### Change

- Adds `Hierarchy.nodes_in_order()` alongside the existing set-returning `nodes()`, which stays for membership checks.
- `assign_colors` now preserves the node order it is given instead of iterating a set internally, and tolerates a repeated node.
- `build` passes the ordered list.

Colour *assignments* are unchanged — only the order of the rows. Verified stable across three `PYTHONHASHSEED` values, and confirmed on a real rebuild: with this fix, regenerating the Arabidopsis database changes only the one feature set that was actually corrected.

### Tests

Three added; full suite 829 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)