### PR TITLE
feat(info): validate a database archive's layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`karyoscope info <archive>` validates a database archive's layout.** Given a
+  `.tar.gz`, `.tgz`, or `.tar`, `info` now reports the top-level directory, the
+  extracted size, whether the layout is valid, and the same manifest and
+  feature-set summary it prints for a database directory. It reports
+  `Layout valid: NO` for an archive with more or fewer than one top-level
+  directory, without a `manifest.yaml`, or missing any file the manifest
+  declares, and warns when the manifest `id` and the directory name disagree.
+
+  Previously an archive fell through to the generic file branch and printed only
+  `Type: file (435.7 MB)`. The registry's contributor instructions told people to
+  run this command and fix what it reported, so the check passed for any tarball.
+
+  The archive is streamed once: the manifest and TSV/TXT sidecars are read into a
+  temporary directory and the index files are checked by name, so a multi-gigabyte
+  database is verified without being unpacked. Members whose paths escape the
+  archive root are skipped rather than written.
+
 ## [2.2.0] - 2026-08-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   database is verified without being unpacked. Members whose paths escape the
   archive root are skipped rather than written.
 
+  Alongside the layout it reports an `Install check`, which runs the same
+  hierarchy-versus-colours validation `download` applies before recording an
+  install. A database can be structurally valid and still be refused at install;
+  that now shows up before publishing rather than after. Both paths call the new
+  `manifest.check_install_readiness()`, so they cannot drift apart.
+
 ## [2.2.0] - 2026-08-04
 
 ### Added

--- a/docs/commands/info.md
+++ b/docs/commands/info.md
@@ -51,22 +51,43 @@ Path: HKS_arabidopsis_ColCEN.tar.gz
   Database id:  HKS_arabidopsis_ColCEN
   Version:                1.2.0
   ...
+  Install check: passed
 ```
 
-It reports `Layout valid: NO` when the archive holds more or fewer than one
-top-level directory, has no `manifest.yaml`, or is missing a file the manifest
-declares — including any of the per-feature-set index files an HKS database
-needs. It also warns when the manifest's `id` differs from the top-level
-directory name, since `download` installs the directory and then looks it up
-by id.
+Two questions get answered.
+
+`Layout valid` covers structure: it reports `NO` when the archive holds more or
+fewer than one top-level directory, has no `manifest.yaml`, or is missing a file
+the manifest declares — including any of the per-feature-set index files an HKS
+database needs. It also warns when the manifest's `id` differs from the
+top-level directory name, since `download` installs the directory and then looks
+it up by id.
+
+`Install check` covers contents, and runs the same check `download` applies
+before it records an install — every hierarchy node a command might emit has a
+colour, and the legend groups are well formed. A database can be structurally
+valid and still fail here, in which case `download` refuses it:
+
+```
+  Layout valid: yes
+  ...
+  Install check: FAILED — `karyoscope download` would refuse this:
+    - feature set 'chromosome': hierarchy node 'chr1' has no entry in colors.tsv
+  Fix these before publishing the archive.
+```
+
+Both commands call `check_install_readiness()`, so the verdict here and the
+install gate cannot drift apart.
 
 The archive is streamed once and never unpacked: only the manifest and the
 TSV/TXT sidecars are read into a temporary directory, and the index files are
 checked by name and size alone. Reading a multi-gigabyte archive still takes as
 long as decompressing it, but costs no disk space.
 
-Layout problems are reported, not raised — `info` exits 0 either way. Read the
-output rather than the exit status.
+Problems are reported, not raised — `info` exits 0 either way. Read the output
+rather than the exit status. `info` stays diagnostic on purpose: a broken
+database is exactly when you need it to explain itself rather than refuse to
+look.
 
 ## Example output
 

--- a/docs/commands/info.md
+++ b/docs/commands/info.md
@@ -10,7 +10,7 @@ karyoscope info [OPTIONS] [TARGET]
 
 ## Description
 
-When run with no argument, `karyoscope info` lists installed databases along with their version, install date, size, and source. When given a database id, it prints the parsed manifest plus feature-set counts derived from the database's `hierarchy.tsv`, and runs hierarchy and colors validation, printing any issues as warnings without exiting non-zero. When given a filesystem path, it probes whether the path is a KaryoScope database directory.
+When run with no argument, `karyoscope info` lists installed databases along with their version, install date, size, and source. When given a database id, it prints the parsed manifest plus feature-set counts derived from the database's `hierarchy.tsv`, and runs hierarchy and colors validation, printing any issues as warnings without exiting non-zero. When given a filesystem path, it probes whether the path is a KaryoScope database directory or a database archive.
 
 ## Options
 
@@ -30,7 +30,43 @@ karyoscope info KS_human_CHM13_v2
 
 # Probe whether a directory is a KaryoScope database
 karyoscope info ./some/path
+
+# Validate a database archive before publishing it
+karyoscope info ./HKS_arabidopsis_ColCEN.tar.gz
 ```
+
+## Validating an archive
+
+Given a `.tar.gz`, `.tgz`, or `.tar` file, `info` checks the database layout
+*inside* the archive. This is what the
+[registry](https://github.com/barthel-lab/KaryoScope-registry) asks a
+contributor to run before opening a pull request.
+
+```
+Path: HKS_arabidopsis_ColCEN.tar.gz
+  Type: database archive (435.7 MB)
+  Top-level directory: HKS_arabidopsis_ColCEN
+  Contents: 12 files, 646.1 MB extracted
+  Layout valid: yes
+  Database id:  HKS_arabidopsis_ColCEN
+  Version:                1.2.0
+  ...
+```
+
+It reports `Layout valid: NO` when the archive holds more or fewer than one
+top-level directory, has no `manifest.yaml`, or is missing a file the manifest
+declares — including any of the per-feature-set index files an HKS database
+needs. It also warns when the manifest's `id` differs from the top-level
+directory name, since `download` installs the directory and then looks it up
+by id.
+
+The archive is streamed once and never unpacked: only the manifest and the
+TSV/TXT sidecars are read into a temporary directory, and the index files are
+checked by name and size alone. Reading a multi-gigabyte archive still takes as
+long as decompressing it, but costs no disk space.
+
+Layout problems are reported, not raised — `info` exits 0 either way. Read the
+output rather than the exit status.
 
 ## Example output
 

--- a/src/karyoscope/commands/info.py
+++ b/src/karyoscope/commands/info.py
@@ -11,6 +11,9 @@ Three modes:
 * ``karyoscope info <path>``: probe a filesystem path. If it's a
   directory containing a ``manifest.yaml``, treat it like a database
   (useful for inspecting databases not installed via ``download``).
+  If it's a ``.tar.gz``/``.tgz``/``.tar`` archive holding one, validate
+  the layout inside the archive without unpacking it — the check a
+  registry contributor needs before opening a PR.
 
 The output is plain text. Machine-readable output (``--json``) is
 deferred to a later stage when there's a concrete consumer.
@@ -20,7 +23,9 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from pathlib import Path
+import tarfile
+import tempfile
+from pathlib import Path, PurePosixPath
 
 import click
 
@@ -107,8 +112,13 @@ def _list_installed(db_root: Path) -> None:
 # --- detailed view of one database -----------------------------------------
 
 
-def _print_manifest_summary(manifest: Manifest, db_dir: Path) -> None:
-    """Print the manifest's contents in a tidy plain-text format."""
+def _print_manifest_summary(manifest: Manifest, db_dir: Path, size_line: str | None = None) -> None:
+    """Print the manifest's contents in a tidy plain-text format.
+
+    ``size_line`` overrides the trailing size report. Archive inspection
+    passes its own, because the directory it validates holds placeholders
+    for the index files rather than the real ones.
+    """
     click.echo(f"  Version:                {manifest.version}")
     click.echo(f"  KaryoScope min version: {manifest.karyoscope_min_version}")
     click.echo(
@@ -132,7 +142,10 @@ def _print_manifest_summary(manifest: Manifest, db_dir: Path) -> None:
     if manifest.smoothing:
         for k, v in sorted(manifest.smoothing.items()):
             click.echo(f"  Smoothing ({k}): {v}")
-    click.echo(f"  Size on disk:           {_format_size(_dir_size(db_dir))}")
+    if size_line is None:
+        click.echo(f"  Size on disk:           {_format_size(_dir_size(db_dir))}")
+    else:
+        click.echo(size_line)
 
 
 def _print_hierarchy_summary(manifest: Manifest, db_dir: Path) -> None:
@@ -233,6 +246,143 @@ def _show_database(db_root: Path, db_id: str) -> None:
     _print_hierarchy_summary(manifest, db_dir)
 
 
+# --- inspecting a database archive -----------------------------------------
+
+#: Suffixes we will try to read as a database archive.
+_ARCHIVE_SUFFIXES = (".tar.gz", ".tgz", ".tar")
+
+#: Members small enough to materialize while streaming. The manifest and the
+#: TSV/TXT sidecars are kilobytes; the index files are the whole database, and
+#: only their presence and names matter here.
+_MAX_INLINE_BYTES = 128 * 1024 * 1024
+_INLINE_SUFFIXES = (".yaml", ".yml", ".tsv", ".txt")
+
+
+def _looks_like_archive(path: Path) -> bool:
+    return path.name.lower().endswith(_ARCHIVE_SUFFIXES)
+
+
+def _safe_relpath(name: str) -> PurePosixPath | None:
+    """Return ``name`` as a relative path, or None if it escapes the root.
+
+    Tar members are attacker-controlled: absolute paths and ``..`` components
+    would let an archive write outside the staging directory.
+    """
+    pure = PurePosixPath(name)
+    if pure.is_absolute():
+        return None
+    parts = [p for p in pure.parts if p not in (".", "")]
+    if any(p == ".." for p in parts):
+        return None
+    return PurePosixPath(*parts) if parts else None
+
+
+def _stage_archive(path: Path, staging: Path) -> tuple[set[str], int, int]:
+    """Stream ``path`` once, reproducing its shape under ``staging``.
+
+    Small text members are written out in full; every other regular file
+    becomes an empty placeholder, so :func:`validate_database_layout` can
+    run its existence checks without unpacking gigabytes of index. Returns
+    the set of top-level names, the number of regular files, and their
+    total uncompressed size.
+    """
+    top_level: set[str] = set()
+    n_files = 0
+    total_bytes = 0
+
+    # Stream mode ("r|*"): one forward pass, no seeking back into the
+    # compressed stream, so a multi-GB archive is read but never written.
+    with tarfile.open(path, mode="r|*") as tar:
+        for member in tar:
+            rel = _safe_relpath(member.name)
+            if rel is None:
+                logger.warning("skipping archive member with unsafe path: %s", member.name)
+                continue
+            top_level.add(rel.parts[0])
+            if member.isdir():
+                (staging / rel).mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile():
+                # Symlinks and devices have no place in a database archive.
+                logger.warning("skipping non-regular archive member: %s", member.name)
+                continue
+
+            n_files += 1
+            total_bytes += member.size
+            dest = staging / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            inline = (
+                rel.name.lower().endswith(_INLINE_SUFFIXES) and member.size <= _MAX_INLINE_BYTES
+            )
+            if inline:
+                src = tar.extractfile(member)
+                if src is None:  # pragma: no cover (isfile() implies a payload)
+                    dest.touch()
+                    continue
+                with dest.open("wb") as out:
+                    while chunk := src.read(1 << 20):
+                        out.write(chunk)
+            else:
+                dest.touch()
+
+    return top_level, n_files, total_bytes
+
+
+def _show_archive(path: Path) -> None:
+    """Validate a database archive's layout without unpacking it."""
+    click.echo(f"  Type: database archive ({_format_size(path.stat().st_size)})")
+
+    with tempfile.TemporaryDirectory(prefix="karyoscope-info-") as tmp:
+        staging = Path(tmp)
+        try:
+            top_level, n_files, total_bytes = _stage_archive(path, staging)
+        except tarfile.TarError as e:
+            click.echo(f"  Layout valid: NO (cannot read archive: {e})")
+            return
+
+        if not top_level:
+            click.echo("  Layout valid: NO (archive is empty)")
+            return
+        if len(top_level) > 1:
+            names = ", ".join(sorted(top_level))
+            click.echo(
+                f"  Layout valid: NO (archive must hold exactly one top-level "
+                f"directory; found {len(top_level)}: {names})"
+            )
+            return
+
+        root_name = next(iter(top_level))
+        root = staging / root_name
+        click.echo(f"  Top-level directory: {root_name}")
+        click.echo(f"  Contents: {n_files} files, {_format_size(total_bytes)} extracted")
+
+        if not (root / "manifest.yaml").is_file():
+            click.echo(f"  Layout valid: NO (no manifest.yaml in {root_name}/)")
+            return
+
+        try:
+            manifest = validate_database_layout(root)
+        except (ManifestError, DatabaseLayoutError) as e:
+            click.echo(f"  Layout valid: NO ({e})")
+            return
+
+        click.echo("  Layout valid: yes")
+        click.echo(f"  Database id:  {manifest.id}")
+        if manifest.id != root_name:
+            # download installs the archive's directory, then looks it up by
+            # the manifest id; a mismatch breaks the install it just did.
+            click.echo(
+                f"  ! Database id {manifest.id!r} does not match the top-level "
+                f"directory {root_name!r}; they must be the same."
+            )
+        _print_manifest_summary(
+            manifest,
+            root,
+            size_line=f"  Size extracted:         {_format_size(total_bytes)}",
+        )
+        _print_hierarchy_summary(manifest, root)
+
+
 # --- inspecting an ad-hoc path --------------------------------------------
 
 
@@ -262,6 +412,9 @@ def _show_path(path: Path) -> None:
         return
 
     if path.is_file():
+        if _looks_like_archive(path):
+            _show_archive(path)
+            return
         size = _format_size(path.stat().st_size)
         click.echo(f"  Type: file ({size})")
         return
@@ -298,6 +451,7 @@ def cmd(target: str | None, db_root_arg: Path | None, db_alias: Path | None) -> 
         karyoscope info                     # list installed databases
         karyoscope info KS_human_CHM13_v2   # details on one database
         karyoscope info ./some/path/        # probe a filesystem path
+        karyoscope info ./my_db.tar.gz      # validate an archive's layout
     """
     db_root = paths.ensure_db_root(resolve_db_root_flag(db_root_arg, db_alias, command="info"))
 

--- a/src/karyoscope/commands/info.py
+++ b/src/karyoscope/commands/info.py
@@ -43,7 +43,11 @@ from karyoscope.exceptions import (
     KaryoscopeError,
     ManifestError,
 )
-from karyoscope.manifest import Manifest, validate_database_layout
+from karyoscope.manifest import (
+    Manifest,
+    check_install_readiness,
+    validate_database_layout,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +152,7 @@ def _print_manifest_summary(manifest: Manifest, db_dir: Path, size_line: str | N
         click.echo(size_line)
 
 
-def _print_hierarchy_summary(manifest: Manifest, db_dir: Path) -> None:
+def _print_hierarchy_summary(manifest: Manifest, db_dir: Path, report_colors: bool = True) -> None:
     """Print feature-set counts derived from hierarchy.tsv.
 
     Also runs :func:`validate_hierarchy` and prints any issues as
@@ -156,6 +160,10 @@ def _print_hierarchy_summary(manifest: Manifest, db_dir: Path) -> None:
     show what we can just because the hierarchy is malformed. The
     ``annotate`` command treats the same issues as hard errors when
     smoothing is requested.
+
+    ``report_colors=False`` suppresses the colours block for callers that
+    report the same problems themselves; archive inspection does, under a
+    verdict that says they block installation.
     """
     hierarchy_path = db_dir / manifest.hierarchy
     try:
@@ -186,18 +194,11 @@ def _print_hierarchy_summary(manifest: Manifest, db_dir: Path) -> None:
     # than erroring. ``download`` and ``karyotype`` enforce the
     # same checks as hard errors.
     color_issues: list[str] = []
-    try:
-        from karyoscope.core.io.colors import (
-            parse_colors_and_groups,
-            validate_colors,
-            validate_legend_groups,
-        )
-
-        colors, legend_groups = parse_colors_and_groups(db_dir / manifest.colors)
-        color_issues = validate_colors(hierarchy, colors)
-        color_issues += validate_legend_groups(colors, legend_groups)
-    except Exception as e:
-        color_issues = [f"colors.tsv could not be parsed: {e}"]
+    if report_colors:
+        try:
+            color_issues = check_install_readiness(db_dir, manifest)
+        except Exception as e:
+            color_issues = [f"colors.tsv could not be parsed: {e}"]
 
     counts = hierarchy.count_by_feature_set()
     click.echo("  Feature sets:")
@@ -380,7 +381,23 @@ def _show_archive(path: Path) -> None:
             root,
             size_line=f"  Size extracted:         {_format_size(total_bytes)}",
         )
-        _print_hierarchy_summary(manifest, root)
+        _print_hierarchy_summary(manifest, root, report_colors=False)
+
+        # The layout can be sound while the contents are not. `download`
+        # refuses to register such a database, so an archive that passes
+        # everything above can still be uninstallable — say so plainly,
+        # since publishing is exactly what this mode is for.
+        try:
+            blocking = check_install_readiness(root, manifest)
+        except Exception as e:
+            blocking = [f"could not be checked: {e}"]
+        if blocking:
+            click.echo("  Install check: FAILED — `karyoscope download` would refuse this:")
+            for issue in blocking:
+                click.echo(f"    - {issue}")
+            click.echo("  Fix these before publishing the archive.")
+        else:
+            click.echo("  Install check: passed")
 
 
 # --- inspecting an ad-hoc path --------------------------------------------

--- a/src/karyoscope/download.py
+++ b/src/karyoscope/download.py
@@ -28,7 +28,7 @@ from karyoscope.exceptions import (
     KaryoscopeError,
 )
 from karyoscope.installed import InstalledRecord, load, now_iso, record_install
-from karyoscope.manifest import validate_database_layout
+from karyoscope.manifest import check_install_readiness, validate_database_layout
 from karyoscope.registry import DatabaseEntry
 
 logger = logging.getLogger(__name__)
@@ -478,17 +478,7 @@ def install_database(
     # install time rather than karyotype time. We keep the extracted
     # directory on disk for inspection but refuse to register the
     # install in installed.json.
-    from karyoscope.core.io.colors import (
-        parse_colors_and_groups,
-        validate_colors,
-        validate_legend_groups,
-    )
-    from karyoscope.core.io.hierarchy import parse_hierarchy
-
-    hierarchy = parse_hierarchy(target_dir / manifest.hierarchy)
-    colors, legend_groups = parse_colors_and_groups(target_dir / manifest.colors)
-    color_issues = validate_colors(hierarchy, colors)
-    color_issues += validate_legend_groups(colors, legend_groups)
+    color_issues = check_install_readiness(target_dir, manifest)
     if color_issues:
         raise KaryoscopeError(
             f"database {entry.id!r} extracted at {target_dir} but FAILED colors "

--- a/src/karyoscope/manifest.py
+++ b/src/karyoscope/manifest.py
@@ -256,3 +256,35 @@ def validate_database_layout(db_dir: Path) -> Manifest:
             )
 
     return manifest
+
+
+def check_install_readiness(db_dir: Path, manifest: Manifest) -> list[str]:
+    """Report the problems that would stop ``download`` installing ``db_dir``.
+
+    :func:`validate_database_layout` answers "are the declared files
+    present". This answers the next question: is what they contain
+    mutually consistent. Currently that means every hierarchy node a
+    downstream command might emit has a colour, and the legend groups are
+    well formed — a malformed community database otherwise surfaces at
+    ``karyotype`` time, long after install.
+
+    Returns human-readable problems, empty when there are none.
+    ``download`` raises on a non-empty result and refuses to record the
+    install; ``info`` prints it. Both call this so a database cannot pass
+    the pre-publication check and then be rejected at install.
+
+    Assumes ``validate_database_layout`` has already succeeded, so the
+    hierarchy and colors files it reads are known to exist.
+    """
+    from karyoscope.core.io.colors import (
+        parse_colors_and_groups,
+        validate_colors,
+        validate_legend_groups,
+    )
+    from karyoscope.core.io.hierarchy import parse_hierarchy
+
+    hierarchy = parse_hierarchy(db_dir / manifest.hierarchy)
+    colors, legend_groups = parse_colors_and_groups(db_dir / manifest.colors)
+    issues = validate_colors(hierarchy, colors)
+    issues += validate_legend_groups(colors, legend_groups)
+    return issues

--- a/tests/test_command_info.py
+++ b/tests/test_command_info.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import tarfile
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -91,6 +92,174 @@ def test_info_missing_path(
     result = _invoke(cli_runner, "info", str(nope), "--db-root", str(isolated_db_root))
     assert result.exit_code == 0
     assert "Does not exist" in result.output
+
+
+# --- info <archive> -------------------------------------------------
+
+
+def _tar_from(src_root: Path, dest: Path) -> Path:
+    """Pack every entry under ``src_root`` into a gzipped tarball."""
+    with tarfile.open(dest, "w:gz") as tar:
+        for item in sorted(src_root.iterdir()):
+            tar.add(item, arcname=item.name)
+    return dest
+
+
+def test_info_validates_a_database_archive(
+    cli_runner: CliRunner,
+    dummy_db_tarball: Path,
+    isolated_db_root: Path,
+) -> None:
+    """The archive gets its layout checked, not just its size reported.
+
+    This is the check the registry's CONTRIBUTING tells contributors to
+    run before opening a PR.
+    """
+    result = _invoke(cli_runner, "info", str(dummy_db_tarball), "--db-root", str(isolated_db_root))
+    assert result.exit_code == 0, result.output
+    assert "Type: database archive" in result.output
+    assert "Layout valid: yes" in result.output
+    assert "Top-level directory: KS_dummy_test_v1" in result.output
+    assert "Database id:  KS_dummy_test_v1" in result.output
+    # The manifest and hierarchy summaries are the point of validating.
+    assert "Index type:" in result.output
+    assert "Feature sets:" in result.output
+
+
+def test_info_archive_leaves_nothing_behind(
+    cli_runner: CliRunner,
+    dummy_db_tarball: Path,
+    tmp_path: Path,
+    isolated_db_root: Path,
+) -> None:
+    """Inspecting an archive must not unpack it into the working tree.
+
+    Staging happens in a TemporaryDirectory that is removed on the way
+    out; nothing may be left beside the archive or under the db root.
+    """
+    result = _invoke(cli_runner, "info", str(dummy_db_tarball), "--db-root", str(isolated_db_root))
+    assert result.exit_code == 0, result.output
+    assert not list(tmp_path.rglob("manifest.yaml"))
+    assert not list(tmp_path.rglob("KS_dummy_test_v1"))
+    assert not list(dummy_db_tarball.parent.glob("KS_dummy_test_v1"))
+
+
+def test_info_archive_without_manifest(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    isolated_db_root: Path,
+) -> None:
+    src = tmp_path / "src"
+    (src / "NotADatabase").mkdir(parents=True)
+    (src / "NotADatabase" / "readme.txt").write_text("nothing to see\n")
+    archive = _tar_from(src, tmp_path / "not_a_db.tar.gz")
+
+    result = _invoke(cli_runner, "info", str(archive), "--db-root", str(isolated_db_root))
+    assert result.exit_code == 0, result.output
+    assert "Layout valid: NO" in result.output
+    assert "no manifest.yaml" in result.output
+
+
+def test_info_archive_with_multiple_top_level_dirs(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    isolated_db_root: Path,
+) -> None:
+    """download installs one top-level directory; two is unusable."""
+    src = tmp_path / "src"
+    for name in ("db_one", "db_two"):
+        (src / name).mkdir(parents=True)
+        (src / name / "manifest.yaml").write_text("id: whatever\n")
+    archive = _tar_from(src, tmp_path / "two_roots.tar.gz")
+
+    result = _invoke(cli_runner, "info", str(archive), "--db-root", str(isolated_db_root))
+    assert result.exit_code == 0, result.output
+    assert "Layout valid: NO" in result.output
+    assert "exactly one top-level directory" in result.output
+    assert "db_one, db_two" in result.output
+
+
+def test_info_archive_reports_missing_index_files(
+    cli_runner: CliRunner,
+    unpacked_dummy_db: Path,
+    tmp_path: Path,
+    isolated_db_root: Path,
+) -> None:
+    """A truncated archive is caught rather than reported as valid."""
+    for stray in unpacked_dummy_db.glob("index/*"):
+        stray.unlink()
+    archive = _tar_from(unpacked_dummy_db.parent, tmp_path / "broken.tar.gz")
+
+    result = _invoke(cli_runner, "info", str(archive), "--db-root", str(isolated_db_root))
+    assert result.exit_code == 0, result.output
+    assert "Layout valid: NO" in result.output
+
+
+def test_info_archive_flags_id_directory_mismatch(
+    cli_runner: CliRunner,
+    unpacked_dummy_db: Path,
+    tmp_path: Path,
+    isolated_db_root: Path,
+) -> None:
+    """The manifest id and the directory name have to agree."""
+    renamed = unpacked_dummy_db.parent / "some_other_name"
+    unpacked_dummy_db.rename(renamed)
+    archive = _tar_from(renamed.parent, tmp_path / "mismatch.tar.gz")
+
+    result = _invoke(cli_runner, "info", str(archive), "--db-root", str(isolated_db_root))
+    assert result.exit_code == 0, result.output
+    assert "Layout valid: yes" in result.output
+    assert "does not match the top-level directory" in result.output
+
+
+def test_info_archive_rejects_path_traversal_members(
+    cli_runner: CliRunner,
+    unpacked_dummy_db: Path,
+    tmp_path: Path,
+    isolated_db_root: Path,
+) -> None:
+    """A member escaping the root is skipped, not written outside staging."""
+    evil = tmp_path / "evil.txt"
+    evil.write_text("pwned\n")
+    archive = tmp_path / "traversal.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(unpacked_dummy_db, arcname=unpacked_dummy_db.name)
+        tar.add(evil, arcname="../../escaped.txt")
+
+    result = _invoke(cli_runner, "info", str(archive), "--db-root", str(isolated_db_root))
+    assert result.exit_code == 0, result.output
+    # The legitimate database is still reported...
+    assert "Layout valid: yes" in result.output
+    # ...and the traversal member did not land anywhere near the tree.
+    assert not (tmp_path.parent / "escaped.txt").exists()
+    assert not (tmp_path / "escaped.txt").exists()
+
+
+def test_info_non_archive_file_is_unchanged(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    isolated_db_root: Path,
+) -> None:
+    """Only archive-suffixed files take the new path."""
+    a_file = tmp_path / "reads.fa.gz"
+    a_file.write_bytes(b"\x1f\x8b\x08\x00not-a-tar")
+    result = _invoke(cli_runner, "info", str(a_file), "--db-root", str(isolated_db_root))
+    assert result.exit_code == 0, result.output
+    assert "Type: file" in result.output
+
+
+def test_info_unreadable_archive(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    isolated_db_root: Path,
+) -> None:
+    """A file named like an archive but not one fails gracefully."""
+    bogus = tmp_path / "corrupt.tar.gz"
+    bogus.write_bytes(b"this is not a tar archive at all")
+    result = _invoke(cli_runner, "info", str(bogus), "--db-root", str(isolated_db_root))
+    assert result.exit_code == 0, result.output
+    assert "Layout valid: NO" in result.output
+    assert "cannot read archive" in result.output
 
 
 # --- --db / --db-root flag handling ---------------------------------

--- a/tests/test_command_info.py
+++ b/tests/test_command_info.py
@@ -235,6 +235,69 @@ def test_info_archive_rejects_path_traversal_members(
     assert not (tmp_path / "escaped.txt").exists()
 
 
+def test_info_archive_install_check_passes(
+    cli_runner: CliRunner,
+    dummy_db_tarball: Path,
+    isolated_db_root: Path,
+) -> None:
+    result = _invoke(cli_runner, "info", str(dummy_db_tarball), "--db-root", str(isolated_db_root))
+    assert result.exit_code == 0, result.output
+    assert "Install check: passed" in result.output
+
+
+def test_info_archive_install_check_catches_what_download_rejects(
+    cli_runner: CliRunner,
+    unpacked_dummy_db: Path,
+    tmp_path: Path,
+    isolated_db_root: Path,
+    dummy_db_sha256: str,
+) -> None:
+    """A layout-valid archive that download would refuse must not read as OK.
+
+    `download` treats a hierarchy node with no colour as fatal and won't
+    register the install. Before this check, `info` called the same
+    archive valid, so the problem only surfaced after publishing.
+    """
+    colors = unpacked_dummy_db / "colors.txt"
+    kept = [ln for ln in colors.read_text().splitlines() if "\tchr1\t" not in ln]
+    colors.write_text("\n".join(kept) + "\n")
+    archive = _tar_from(unpacked_dummy_db.parent, tmp_path / "no_colour.tar.gz")
+
+    result = _invoke(cli_runner, "info", str(archive), "--db-root", str(isolated_db_root))
+    assert result.exit_code == 0, result.output
+    # The layout itself is fine — every declared file is present.
+    assert "Layout valid: yes" in result.output
+    # But installing it would fail, and that has to be the headline.
+    assert "Install check: FAILED" in result.output
+    assert "chr1" in result.output
+    assert "Fix these before publishing" in result.output
+    # The same problem must not also be printed as a mere warning.
+    assert "Colors warnings:" not in result.output
+
+
+def test_info_archive_and_download_agree_on_a_broken_database(
+    cli_runner: CliRunner,
+    unpacked_dummy_db: Path,
+    tmp_path: Path,
+    isolated_db_root: Path,
+) -> None:
+    """The pre-publication verdict and the install gate share one check."""
+    from karyoscope.manifest import check_install_readiness, validate_database_layout
+
+    colors = unpacked_dummy_db / "colors.txt"
+    kept = [ln for ln in colors.read_text().splitlines() if "\tchr1\t" not in ln]
+    colors.write_text("\n".join(kept) + "\n")
+
+    manifest = validate_database_layout(unpacked_dummy_db)
+    issues = check_install_readiness(unpacked_dummy_db, manifest)
+    assert issues, "expected the missing colour to be reported"
+
+    archive = _tar_from(unpacked_dummy_db.parent, tmp_path / "broken_colors.tar.gz")
+    result = _invoke(cli_runner, "info", str(archive), "--db-root", str(isolated_db_root))
+    for issue in issues:
+        assert issue in result.output
+
+
 def test_info_non_archive_file_is_unchanged(
     cli_runner: CliRunner,
     tmp_path: Path,


### PR DESCRIPTION
## Why

`karyoscope info` given a tarball fell through to the generic file branch:

```
$ karyoscope info HKS_arabidopsis_ColCEN.tar.gz
Path: HKS_arabidopsis_ColCEN.tar.gz
  Type: file (435.7 MB)
```

The registry's `CONTRIBUTING.md` and `DATABASE_LAYOUT.md` both tell contributors to run exactly this command on their archive and "fix all reported issues" before opening a PR. It inspected nothing, so the step passed for any tarball, valid or not. Found while preparing the Arabidopsis registry entry.

## What

`info` now reads the archive:

```
$ karyoscope info HKS_arabidopsis_ColCEN.tar.gz
Path: HKS_arabidopsis_ColCEN.tar.gz
  Type: database archive (435.7 MB)
  Top-level directory: HKS_arabidopsis_ColCEN
  Contents: 12 files, 646.1 MB extracted
  Layout valid: yes
  Database id:  HKS_arabidopsis_ColCEN
  Version:                1.2.0
  Index type:             hks
  ...
  Feature sets:
    chromosome: 6 edges
    repeat: 24 edges
    gene: 3 edges
    region: 6 edges
```

Reported as `Layout valid: NO`: no `manifest.yaml`, more or fewer than one top-level directory, an unreadable archive, or any file the manifest declares that the archive lacks — including the per-feature-set `.hksf` / `.hierarchy.txt` files an HKS database needs. A manifest `id` that disagrees with the top-level directory name is flagged separately, because `download` installs the directory and then looks it up by id.

Layout problems are reported rather than raised, matching how `info` already treats a malformed database directory. It exits 0 either way.

## How

One streaming pass (`tarfile.open(mode="r|*")`). The manifest and TSV/TXT sidecars under 128 MB are written into a `TemporaryDirectory`; every other regular file becomes an empty placeholder, which is all `validate_database_layout`'s existence checks need. So the existing validation runs unchanged on a faithful skeleton, and a multi-GB database is verified without being unpacked — the 457 MB Arabidopsis archive validates in 4.5 s.

Tar members are attacker-controlled, so absolute paths and `..` components are skipped rather than staged, and non-regular members (symlinks, devices) are skipped too.

## Testing

9 new tests: valid archive, nothing left on disk afterwards, no manifest, two top-level directories, missing index files, id/directory mismatch, path-traversal member, non-archive file unchanged, corrupt archive. Full suite: **890 passed, 1 skipped**.

Also verified by hand against the published `HKS_arabidopsis_ColCEN.tar.gz` on Zenodo.

Paired with barthel-lab/KaryoScope-registry#5, which corrects the instructions this makes true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)