### PR TITLE
ci: stop merges cancelling each other's runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,14 @@ on:
   pull_request:
     branches: [main]
 
-# Cancel superseded runs on the same PR/branch
+# Supersede earlier runs of the same PR, but never one merge's run with the
+# next merge's. Keying on github.ref put every push to main in one group, so
+# merging PRs back to back cancelled the earlier merge commit's run and left
+# it with no CI at all. Keying on the PR number when there is one, and the
+# commit sha otherwise, gives each main commit a group of its own: merges
+# neither cancel nor queue behind each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## The bug

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

`github.ref` is `refs/heads/main` for *every* push to main, so all merge commits shared one concurrency group. Merging PRs back to back cancelled the previous merge's run:

- `063131d` (#28) — no completed CI
- `8c01e65` (#29) — no completed CI

It also made the README badge read as failing, because the badge renders `cancelled` as not passing. It went green again only once #30's run finished. #31 got a clean run purely because it was merged on its own.

## The fix

Key the group on the PR number when there is one, and the commit sha otherwise:

```yaml
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
```

PR runs still supersede themselves when you push again — that is the behaviour the setting is for, and it is unchanged. Every push to main now lands in a group of its own, so merges neither cancel nor queue behind one another.

## Why not the conditional

The other obvious fix is `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`. It stops the cancellation, but leaves every main push in a single group — so they serialize instead, and three quick merges get their CI one after another. Grouping by sha avoids both failure modes.

## Note on merging

This does not retroactively give #28 and #29 runs. If you want CI recorded against current main, the standard step of re-running the suite on merged main before tagging still covers it.

Verified the workflow YAML parses and the triggers and job list are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)