### PR TITLE
Audit fixes: temp-file placement, BAM conversion, error boundaries, docs accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sequence stays with the feature. Applies to `repeatmasker` and `edta`. The
   converters whose output already tiles declare no gap-fill and are unchanged.
 
+- **Genome-scale temp files are created next to their output, not in the
+  system tempdir.** The scaffold rewriters' spill directories (up to the whole
+  assembly with unscaffolded contigs kept), the BAM→FASTA conversion, and the
+  `hks smooth` intermediate TSV all previously landed in `/tmp` — on cluster
+  nodes often a small or RAM-backed filesystem. They now sit beside the output,
+  as annotate's smoothing pass already did.
+
+- **A BAM input to `annotate` (HKS backend) is converted to FASTA once**,
+  shared by every feature set's lookup, instead of once per feature set.
+
+### Fixed
+
+- **The `samtools | get_featureIDs` BAM pipeline can no longer deadlock on a
+  warning-heavy BAM.** samtools stderr was read only after `get_featureIDs`
+  finished; more than a pipe buffer's worth of warnings (malformed records
+  warn once each) blocked samtools mid-write and stalled the pipeline. stderr
+  now drains to a temp file.
+
 ### Documentation
+
+- **An accuracy pass across the command pages, README and CONTRIBUTING.**
+  `bin`'s `--threads 0` is documented as the CPUs the process may actually use
+  (SLURM allocation / affinity), not `os.cpu_count()`; `scaffold`'s output
+  filenames carry their `<input_stem>.<dbid>.` prefix; `version`'s tool list
+  includes `get_featureIDs` and HKS; `build`'s options table lists
+  `--flatten-order`; `annotate`'s HG002 runtime figure is attributed to the
+  KMC backend; the recipes file table lists all six supporting files; and
+  CONTRIBUTING's development setup uses `environment.yml`, which carries the
+  tools the ad-hoc conda command it replaced was missing (samtools and the
+  C++/Rust toolchains).
 
 - **`build`: background placement and the hierarchy root.** The gap-fill leaf
   sits at the root, so a k-mer it shares with a real feature resolves to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,16 +14,15 @@ This document covers the practical details. For community norms, please also rea
 
 ## Getting set up for development
 
-KaryoScope requires Python ≥3.10 and several external command-line tools (`KMC`, `bgzip`, `tabix`, `seqtk`). We recommend using a dedicated [conda](https://docs.conda.io/) (or [mamba](https://mamba.readthedocs.io/)) environment for everything, which lets you manage Python and the bioinformatics tools together.
+KaryoScope requires Python ≥3.10 and several external command-line tools (`KMC`, `bgzip`, `tabix`, `seqtk`, `samtools`, plus the C++ and Rust toolchains that build the `get_featureIDs` and `hks` binaries). The repository's [`environment.yml`](environment.yml) pins all of them; use it with [conda](https://docs.conda.io/) (or [mamba](https://mamba.readthedocs.io/)) so Python and the bioinformatics tools are managed together.
 
 ```bash
 git clone git@github.com:barthel-lab/KaryoScope.git
 cd KaryoScope
 
-# Create a dedicated environment with Python and the required external tools
-conda create -n karyoscope-dev -c conda-forge -c bioconda \
-    python=3.12 pip kmc htslib seqtk
-conda activate karyoscope-dev
+# Create the environment with Python and all required external tools
+conda env create -f environment.yml
+conda activate karyoscope
 
 # Install KaryoScope in editable mode with dev dependencies
 pip install -e ".[dev]"
@@ -35,6 +34,10 @@ pre-commit install
 # Build the bundled C++ helper (required for the annotate command and
 # its integration tests). Skip this if you're only doing Python work.
 make -C native/get_featureIDs
+
+# For `karyoscope build` and HKS-backend work, also build the `hks`
+# binary from a checkout of https://github.com/jnalanko/HKS:
+#   cargo install --path ../HKS --root "$CONDA_PREFIX"
 
 # Verify the install
 karyoscope --version

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## Overview
 
-KaryoScope is an alignment-free annotation tool that assigns each *k*-mer in a query assembly or sequencing read to a feature drawn from one or more user-defined hierarchical feature sets, producing a base-pair resolution annotation in a single pass. Because a feature set is simply any tiling of a reference with labelled regions, KaryoScope is extensible to arbitrary annotation sources, from satellite catalogs and repeat libraries to cytobands, FISH-probe coordinates, and structural-variant breakpoints.
+KaryoScope is an alignment-free annotation tool that assigns each *k*-mer in a query assembly or sequencing read to a feature drawn from one or more user-defined hierarchical feature sets, producing a base-pair resolution annotation in a single pass. Because a feature set is any tiling of a reference with labelled regions, KaryoScope is extensible to arbitrary annotation sources, from satellite catalogs and repeat libraries to cytobands, FISH-probe coordinates, and structural-variant breakpoints.
 
 A pre-built database for the human genome is distributed alongside the tool, derived from T2T-CHM13v2.0 with six feature sets covering chromosome of origin, satellite composition, interspersed repeats, subtelomeric structure, gene boundaries, and acrocentric-specific features. From these annotations, KaryoScope produces karyotype visualizations and cytogenetic reports without ever performing read alignment. Additional databases can be built for any reference genome or community-curated annotation source. [`karyoscope prep-bed`](docs/commands/prep-bed.md) converts the annotation into labelled feature-set BEDs and [`karyoscope build`](docs/commands/build.md) indexes them; [`docs/recipes/`](docs/recipes/) works both steps through for the human and *Arabidopsis* databases. Databases built this way can be published to, and installed from, the [KaryoScope registry](https://github.com/barthel-lab/KaryoScope-registry).
 
@@ -65,10 +65,10 @@ A pre-built database for the human genome is distributed alongside the tool, der
 | C++20 compiler | building the bundled `get_featureIDs` helper | GCC ≥ 11 or Clang ≥ 13 (Apple Clang) |
 | `bgzip`, `tabix` (htslib) | compressing and indexing BED output | 1.22.1 |
 | seqtk | telomere detection (`scaffold`, `centromeres`, `karyotype`) | 1.5 |
-| [`hks`](https://github.com/jnalanko/HKS) | building databases with `karyoscope build`, and annotating against HKS-backend databases (e.g. `HKS_human_CHM13_v2`) | 0.2.0 |
+| [`hks`](https://github.com/jnalanko/HKS) | building databases with `karyoscope build`, and annotating against HKS-backend databases (e.g. `HKS_human_CHM13_v2`) | 0.4.0 |
 | KMC | building a *KMC-backend* database (legacy — `karyoscope build` produces HKS databases). Not needed to *use* a pre-built KMC database; the bundled `get_featureIDs` helper queries its index directly | 3.2.x (vendored API 3.2.4) |
 | libcairo | rendering `--format pdf` / `--format png` | any recent release |
-| samtools | only for BAM input to `annotate` | 1.22.1 |
+| samtools | BAM input to `annotate`, and `karyoscope build` when the genome has no `.fai` index yet | 1.22.1 |
 
 **Hardware.** No non-standard hardware is required — KaryoScope runs on a standard CPU and has no GPU dependency. Resource needs scale with the input:
 
@@ -105,7 +105,7 @@ Measured on HG002 v1.1 against `HKS_human_CHM13_v2`. Restricting `--feature-set`
 
 > Installation via Bioconda is planned. For now, install from source.
 
-KaryoScope requires Python ≥3.10 and several external tools (`bgzip`, `tabix`, `seqtk`, `cairo` for PDF/PNG karyotype output, and `librsvg`/`rsvg-convert` for the SVG→PNG export used by `karyoplot` and `karyoscope-iscn zoom --png`). It also needs a *k*-mer backend query helper — see [k-mer index backends](#k-mer-index-backends) below. The simplest setup is a dedicated conda environment:
+KaryoScope requires Python ≥3.10 and several external tools (`bgzip`, `tabix`, `seqtk`, and `cairo` for PDF/PNG karyotype output). It also needs a *k*-mer backend query helper — see [k-mer index backends](#k-mer-index-backends) below. The simplest setup is a dedicated conda environment:
 
 ```bash
 git clone https://github.com/barthel-lab/KaryoScope.git

--- a/docs/commands/annotate.md
+++ b/docs/commands/annotate.md
@@ -52,11 +52,11 @@ For each feature set, `annotate` writes up to two BEDs:
 - Presmoothed (raw): `<input>.<dbid>.<feature_set>.presmoothed.bed[.gz]`
 - Smoothed (hierarchy-smoothed): `<input>.<dbid>.<feature_set>.smoothed.bed[.gz]`
 
-Each BED's 4th column is the human-readable feature name. k-mers absent from the index render as `novel`. The `.gz` suffix is present unless `--no-bgzip` is passed; `--no-bgzip` keeps BEDs as plain text for easy inspection.
+Each BED's 4th column is the human-readable feature name. k-mers absent from the index render as `novel`. The `.gz` suffix is present unless `--no-bgzip` is passed; `--no-bgzip` keeps BEDs as plain text.
 
 Smoothing promotes short noisy intervals (especially short `novel` runs flanked by specific features) to the lowest common ancestor of their flankers in the feature set's hierarchy.
 
-For human-scale inputs, use at least 16 threads. Memory to request depends on the backend and input shape. With the **HKS backend**, the peak is set by the index rather than the input — the shared base index plus one feature set's labeling at a time — so it is ~10 GB whether you annotate a single haplotype or a combined diploid assembly such as HG002 v1.1 (request ≥ 16 GB). The **KMC backend** peaks at ~30–35 GB (request ≥ 50 GB). HG002 runs in ~20–30 min at `-t 16`.
+For human-scale inputs, use at least 16 threads. Memory to request depends on the backend and input shape. With the **HKS backend**, the peak is set by the index rather than the input — the shared base index plus one feature set's labeling at a time — so it is ~10 GB whether you annotate a single haplotype or a combined diploid assembly such as HG002 v1.1 (request ≥ 16 GB). The **KMC backend** peaks at ~30–35 GB (request ≥ 50 GB); on it, HG002 runs in ~20–30 min at `-t 16`. For HKS-backend runtimes, see the README's [throughput figures](../../README.md#why-alignment-free).
 
 ## Progress output
 

--- a/docs/commands/bin.md
+++ b/docs/commands/bin.md
@@ -22,7 +22,7 @@ karyoscope bin -i INPUT -o OUTPUT -b BIN_SIZE [OPTIONS]
 | `--db TEXT` | Database id whose `hierarchy.tsv` defines the leaf-feature set. Default: the unique installed database if exactly one is installed and `--feature-set` is given. |
 | `--db-root DIRECTORY` | Override the database root directory (default: `$KARYOSCOPE_DB` or `~/.karyoscope/db/`). |
 | `--feature-set TEXT` | Feature set to use for leaf prioritisation. Required when `--db` is given (or implied). |
-| `-t, --threads INTEGER` | Per-sequence-chunk parallelism. `0` = auto (`os.cpu_count()`). `1` = single-threaded. Stdin/stdout I/O is always single-threaded regardless of this flag. **[default: 1]** |
+| `-t, --threads INTEGER` | Per-sequence-chunk parallelism. `0` = auto (the CPUs this process may actually use: a SLURM allocation or CPU affinity, not the machine's core count). `1` = single-threaded. Stdin/stdout I/O is always single-threaded regardless of this flag. **[default: 1]** |
 | `-h, --help` | Show this message and exit. |
 
 Passing `--db` without `--feature-set` is an error: the leaf set is per-feature-set, so one without the other is ambiguous. A bare invocation with no `--db`/`--feature-set` skips leaf prioritisation entirely.

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -22,7 +22,7 @@ Only two inputs are required — a genome and at least one annotation BED:
 | Input | Required | What it is |
 | --- | --- | --- |
 | **Genome FASTA** (`--sequence`) | **Yes** | The assembly your annotations are in coordinates of; plain or bgzipped. If a `.fai` is missing, `build` creates one with `samtools faidx`. |
-| **Feature-set BED** (`--feature-set NAME=BED`) | **Yes**, at least one | A BED whose **4th column is the feature label** — a leaf of this feature set's hierarchy. With no hierarchy file, each distinct label simply becomes its own leaf. Repeat the flag for more sets. Overlaps are allowed and gaps are filled automatically. |
+| **Feature-set BED** (`--feature-set NAME=BED`) | **Yes**, at least one | A BED whose **4th column is the feature label** — a leaf of this feature set's hierarchy. With no hierarchy file, each distinct label becomes its own leaf. Repeat the flag for more sets. Overlaps are allowed and gaps are filled automatically. |
 | Hierarchy (`--hierarchy NAME=PATH`) | No | `child<tab>parent` edge list. Without one, every leaf becomes a child of the root `categorized` (a flat star). See [Hierarchy](#hierarchy). |
 | Priorities (`--priority NAME=PATH`) | No | Resolves which label wins a k-mer claimed by several. In its 3-column `child priority parent` form it **also supplies the hierarchy**, so one file covers both. See [Priorities](#priorities). |
 | Colours (`--colors NAME=PATH`) | No | `feature<tab>color`, or the full `feature_set<tab>feature<tab>color`, with an optional 4th `legend_group` column. Without one, a distinct palette is generated per leaf. See [Colours](#colours). |
@@ -260,6 +260,7 @@ else.
 | `--priority NAME=PATH` | Priority file for a feature set ([Priorities](#priorities)); enables priority mode. Repeatable. |
 | `--colors NAME=PATH` | Colours file for a feature set: `feature<tab>color`, or the full `feature_set<tab>feature<tab>color`, optionally with a 4th `legend_group` column ([Colours](#colours)). Repeatable. |
 | `--flatten` | Pre-flatten overlapping BED regions to one label per base ([Priorities](#priorities)). |
+| `--flatten-order NAME=PATH` | Flatten order file for a feature set; implies `--flatten` for that set ([Priorities](#priorities)). Repeatable. |
 | `--variable-k` | Build a variable-k index, queryable at any k ≤ s ([Fixed-k and variable-k](#fixed-k-and-variable-k)). Not combinable with `--priority`. |
 | `--spec FILE` | Build-spec YAML (alternative to `--id`/`--sequence`/`--feature-set`). |
 | `--db-version TEXT` | Database version, semver (default `1.0.0`). |

--- a/docs/commands/remap-bed.md
+++ b/docs/commands/remap-bed.md
@@ -35,7 +35,7 @@ A BED contig that is *absent* from the map is not an error: the map only lists c
 
 Two-database flow — layout from `KS_human_CHM13_v2`, plot a cytoband feature set:
 
-```
+```bash
 karyoscope scaffold -i hap1=hap1.fa.gz --db KS_human_CHM13_v2 --mode bed
 karyoscope annotate -i hap1.fa.gz --db KS_human_CHM13_cytoband
 karyoscope remap-bed \

--- a/docs/commands/scaffold.md
+++ b/docs/commands/scaffold.md
@@ -52,8 +52,8 @@ karyoscope scaffold -i hap1.fa -i hap2.fa --combine-chromosomes -o results/
 
 ## Output
 
-- `scaffold_map.tsv` — the authoritative 8-column map (`new_name`, `original_name`, `input_file`, `hap`, `chromosome`, `flipped`, `length`, `stats`).
-- `scaffold_stats.tsv` — legacy 2-column stats, kept for back-compat.
+- `<input_stem>.<dbid>.scaffold_map.tsv` — the authoritative 8-column map (`new_name`, `original_name`, `input_file`, `hap`, `chromosome`, `flipped`, `length`, `stats`).
+- `<input_stem>.<dbid>.scaffold_stats.tsv` — legacy 2-column stats, kept for back-compat.
 - `--mode bed` / `both`: per-feature-set `<input_stem>.<dbid>.<feature_set>.smoothed.scaffolded.bed[.gz]`.
 - `--mode fasta` (default) / `both`: `<input_stem>.<dbid>.scaffolded.fa[.gz]`.
 - Encoded contig name format: `<chrom>_<hap>_<contig>[_rc]`, where the `_rc` suffix marks a reverse-complemented contig.

--- a/docs/commands/version.md
+++ b/docs/commands/version.md
@@ -10,7 +10,7 @@ karyoscope version
 
 ## Description
 
-Prints the KaryoScope version, the Python interpreter and platform, the default database root and how many databases are installed, the versions of the Python dependencies, and whether the external tools (KMC, bgzip, tabix, seqtk) are found on PATH. If you only need the version string, `karyoscope --version` / `-V` prints just that. Please include this output in bug reports.
+Prints the KaryoScope version, the Python interpreter and platform, the default database root and how many databases are installed, the versions of the Python dependencies, and whether the external tools (KMC, `get_featureIDs`, HKS, bgzip, tabix, seqtk) are found on PATH. If you only need the version string, `karyoscope --version` / `-V` prints just that. Please include this output in bug reports.
 
 ## Example output
 
@@ -32,6 +32,8 @@ Python dependencies:
 
 External tools:
   KMC: not found on PATH
+  get_featureIDs: K-mer feature analysis tool (at /path/to/get_featureIDs)
+  HKS: Running hks version 0.4.0 (at /path/to/hks)
   bgzip: bgzip (htslib) 1.22.1 (at /path/to/bgzip)
   tabix: tabix (htslib) 1.22.1 (at /path/to/tabix)
   seqtk: ... (at /path/to/seqtk)

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -45,6 +45,8 @@ This is why every input here is pinned by checksum rather than by name.
 | `chm13v2_chromosome.hierarchy.txt` | which human chromosomes are metacentric / submetacentric / acrocentric / sex |
 | `colcen_chromosome.hierarchy.txt` | which Col-CEN sequences are nuclear |
 | `chm13v2_repeat.priority.txt` | the published order in which repeat classes win an overlap |
+| `chm13v2_repeat.order.txt` | which repeat class each base goes to when annotations overlap (the `flatten_order:` for the repeat set) |
+| `chm13v2_gene.priority.txt` | how `exon`, `intron` and `intergenic` rank when a k-mer is claimed by more than one |
 | `chm13v2_refseq_to_chr.tsv` | RefSeq accession → chromosome name |
 
 Every other hierarchy and priority file in these recipes is written by `prep-bed` as it converts, so there is nothing to supply.

--- a/src/karyoscope/cli.py
+++ b/src/karyoscope/cli.py
@@ -1,6 +1,6 @@
 """Top-level command-line interface for KaryoScope.
 
-This module wires the eight v0.1 subcommands into a single ``karyoscope``
+This module wires the subcommands into a single ``karyoscope``
 entry point. Each subcommand lives in its own module under
 ``karyoscope.commands`` so that they can grow independently.
 
@@ -195,7 +195,8 @@ def main(ctx: click.Context, verbose: int, quiet: bool) -> None:
     ctx.ensure_object(dict)["quiet"] = quiet
 
 
-# Register subcommands. The order here determines the order in `--help`.
+# Register subcommands. `--help` lists them alphabetically
+# (``list_commands`` sorts); the order here is not significant.
 
 
 if __name__ == "__main__":

--- a/src/karyoscope/commands/_options.py
+++ b/src/karyoscope/commands/_options.py
@@ -10,6 +10,25 @@ import click
 logger = logging.getLogger(__name__)
 
 
+def parse_named_path(value: str) -> tuple[str | None, Path]:
+    """Parse ``NAME=PATH`` or bare ``PATH``.
+
+    Returns ``(None, Path(value))`` when no ``=`` is present.
+    """
+    if "=" in value:
+        name, _, path = value.partition("=")
+        name = name.strip()
+        if not name:
+            raise click.BadParameter(f"empty name in {value!r}; use NAME=PATH or just PATH")
+        return name, Path(path)
+    return None, Path(value)
+
+
+def split_comma(value: str) -> list[str]:
+    """Split a comma-separated string into stripped non-empty tokens."""
+    return [tok.strip() for tok in value.split(",") if tok.strip()]
+
+
 def resolve_db_root_flag(
     db_root: Path | None,
     legacy_db: Path | None,

--- a/src/karyoscope/commands/annotate.py
+++ b/src/karyoscope/commands/annotate.py
@@ -38,14 +38,8 @@ import click
 from karyoscope import paths
 from karyoscope import progress as _progress
 from karyoscope.core.annotate import annotate
-from karyoscope.core.external import ExternalToolError, ToolNotFoundError
 from karyoscope.exceptions import (
-    DatabaseLayoutError,
-    DatabaseNotFoundError,
-    InsufficientDiskSpaceError,
     KaryoscopeError,
-    ManifestError,
-    MissingDependencyError,
 )
 
 logger = logging.getLogger(__name__)
@@ -231,16 +225,7 @@ def cmd(
             check_space=not no_space_check,
             progress=_progress.from_context(),
         )
-    except (
-        DatabaseNotFoundError,
-        DatabaseLayoutError,
-        ManifestError,
-        ToolNotFoundError,
-        ExternalToolError,
-        InsufficientDiskSpaceError,
-        MissingDependencyError,
-        KaryoscopeError,
-    ) as e:
+    except KaryoscopeError as e:
         raise click.ClickException(str(e)) from e
 
     click.echo("Wrote:")

--- a/src/karyoscope/commands/bin_cmd.py
+++ b/src/karyoscope/commands/bin_cmd.py
@@ -35,10 +35,7 @@ from karyoscope.core.bin import bin_features, leaves_for
 from karyoscope.core.io.hierarchy import parse_hierarchy
 from karyoscope.exceptions import (
     BinError,
-    DatabaseLayoutError,
-    DatabaseNotFoundError,
     KaryoscopeError,
-    ManifestError,
 )
 from karyoscope.manifest import validate_database_layout
 
@@ -148,12 +145,7 @@ def cmd(
                     manifest.hierarchy,
                 )
                 leaf_set = None
-        except (
-            DatabaseNotFoundError,
-            DatabaseLayoutError,
-            ManifestError,
-            KaryoscopeError,
-        ) as e:
+        except KaryoscopeError as e:
             raise click.ClickException(str(e)) from e
     elif db_id is not None:
         raise click.UsageError("--db requires --feature-set; pass both or neither")

--- a/src/karyoscope/commands/build.py
+++ b/src/karyoscope/commands/build.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import click
 
 from karyoscope import paths
-from karyoscope.commands.scaffold import _parse_named_path
+from karyoscope.commands._options import parse_named_path
 from karyoscope.core.build import BuildResult, build_database
 from karyoscope.core.buildspec import BuildSpec
 from karyoscope.core.external import ExternalToolError, ToolNotFoundError
@@ -37,7 +37,7 @@ def _named_path_map(values: tuple[str, ...], flag: str) -> dict[str, Path]:
     """Parse repeated ``NAME=PATH`` options into ``{name: Path}``."""
     out: dict[str, Path] = {}
     for raw in values:
-        name, path = _parse_named_path(raw)
+        name, path = parse_named_path(raw)
         if name is None:
             raise click.UsageError(f"{flag} requires NAME=PATH form (got {raw!r})")
         if name in out:

--- a/src/karyoscope/commands/build.py
+++ b/src/karyoscope/commands/build.py
@@ -22,12 +22,9 @@ from karyoscope import paths
 from karyoscope.commands._options import parse_named_path
 from karyoscope.core.build import BuildResult, build_database
 from karyoscope.core.buildspec import BuildSpec
-from karyoscope.core.external import ExternalToolError, ToolNotFoundError
 from karyoscope.exceptions import (
     BuildError,
-    DatabaseLayoutError,
     KaryoscopeError,
-    ManifestError,
 )
 
 logger = logging.getLogger(__name__)
@@ -260,14 +257,7 @@ def cmd(
             force=force,
             keep_intermediates=keep_intermediates,
         )
-    except (
-        BuildError,
-        ToolNotFoundError,
-        ExternalToolError,
-        DatabaseLayoutError,
-        ManifestError,
-        KaryoscopeError,
-    ) as e:
+    except KaryoscopeError as e:
         raise click.ClickException(str(e)) from e
 
     _report(result)

--- a/src/karyoscope/commands/centromeres.py
+++ b/src/karyoscope/commands/centromeres.py
@@ -27,16 +27,10 @@ from karyoscope.core.centromeres import (
     DEFAULT_FINE_BIN_SIZE,
     centromeres_run,
 )
-from karyoscope.core.external import ExternalToolError, ToolNotFoundError
 from karyoscope.core.scaffold import DEFAULT_HUMAN_ACROCENTRICS
 from karyoscope.core.scaffold_run import InputSpec
 from karyoscope.exceptions import (
-    CentromereError,
-    DatabaseLayoutError,
-    DatabaseNotFoundError,
     KaryoscopeError,
-    ManifestError,
-    ScaffoldError,
 )
 
 logger = logging.getLogger(__name__)
@@ -257,16 +251,7 @@ def cmd(
             auto=auto,
             output_dir=output_dir,
         )
-    except (
-        CentromereError,
-        ScaffoldError,
-        DatabaseNotFoundError,
-        DatabaseLayoutError,
-        ManifestError,
-        ToolNotFoundError,
-        ExternalToolError,
-        KaryoscopeError,
-    ) as e:
+    except KaryoscopeError as e:
         raise click.ClickException(str(e)) from e
 
     click.echo("Wrote:")

--- a/src/karyoscope/commands/centromeres.py
+++ b/src/karyoscope/commands/centromeres.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import click
 
 from karyoscope import paths
-from karyoscope.commands.scaffold import _parse_named_path, _split_comma
+from karyoscope.commands._options import parse_named_path, split_comma
 from karyoscope.core.centromeres import (
     DEFAULT_COARSE_BIN_SIZE,
     DEFAULT_FINE_BIN_SIZE,
@@ -192,10 +192,10 @@ def cmd(
         karyoscope centromeres -i CHM13.fa.gz --fine-bin-size 0
     """
     # --- parse named-pair options -----------------------------------
-    parsed_inputs: list[tuple[str | None, Path]] = [_parse_named_path(raw) for raw in inputs_raw]
+    parsed_inputs: list[tuple[str | None, Path]] = [parse_named_path(raw) for raw in inputs_raw]
     parsed_telos: dict[str, Path] = {}
     for raw in telo_raw:
-        name, path = _parse_named_path(raw)
+        name, path = parse_named_path(raw)
         if name is None:
             raise click.UsageError(f"--telo requires NAME=PATH form (got {raw!r})")
         if name in parsed_telos:
@@ -220,7 +220,7 @@ def cmd(
     if acrocentrics_raw:
         flattened: list[str] = []
         for entry in acrocentrics_raw:
-            flattened.extend(_split_comma(entry))
+            flattened.extend(split_comma(entry))
         if not flattened:
             raise click.UsageError("--acrocentric was given but produced no chromosome names")
         acrocentrics = set(flattened)

--- a/src/karyoscope/commands/download.py
+++ b/src/karyoscope/commands/download.py
@@ -25,15 +25,8 @@ from karyoscope import installed as _installed
 from karyoscope import registry as _registry
 from karyoscope.commands._options import resolve_db_root_flag
 from karyoscope.exceptions import (
-    ChecksumError,
-    DatabaseLayoutError,
     DatabaseNotFoundError,
-    FetchError,
-    IncompatibleVersionError,
-    InsufficientDiskSpaceError,
     KaryoscopeError,
-    ManifestError,
-    RegistryError,
 )
 
 # --- Formatting helpers -----------------------------------------------------
@@ -470,16 +463,6 @@ def cmd(
             show_progress=not quiet,
             check_space=not no_space_check,
         )
-    except (
-        RegistryError,
-        ManifestError,
-        DatabaseNotFoundError,
-        DatabaseLayoutError,
-        ChecksumError,
-        FetchError,
-        IncompatibleVersionError,
-        InsufficientDiskSpaceError,
-        KaryoscopeError,
-    ) as e:
+    except KaryoscopeError as e:
         # Convert known KaryoScope errors to clean user-facing messages.
         raise click.ClickException(str(e)) from e

--- a/src/karyoscope/commands/info.py
+++ b/src/karyoscope/commands/info.py
@@ -489,10 +489,5 @@ def cmd(target: str | None, db_root_arg: Path | None, db_alias: Path | None) -> 
             return
 
         _show_database(db_root, target)
-    except (
-        DatabaseNotFoundError,
-        DatabaseLayoutError,
-        ManifestError,
-        KaryoscopeError,
-    ) as e:
+    except KaryoscopeError as e:
         raise click.ClickException(str(e)) from e

--- a/src/karyoscope/commands/karyotype.py
+++ b/src/karyoscope/commands/karyotype.py
@@ -29,7 +29,7 @@ import click
 
 from karyoscope import paths, preflight
 from karyoscope import progress as _progress
-from karyoscope.commands.scaffold import _parse_named_path, _split_comma
+from karyoscope.commands._options import parse_named_path, split_comma
 from karyoscope.core.external import ExternalToolError, ToolNotFoundError
 from karyoscope.core.karyotype_run import karyotype_run
 from karyoscope.core.scaffold import DEFAULT_HUMAN_ACROCENTRICS
@@ -400,10 +400,10 @@ def cmd(
                               --sex male --feature-set region
     """
     # --- parse named-pair options -----------------------------------
-    parsed_inputs: list[tuple[str | None, Path]] = [_parse_named_path(raw) for raw in inputs_raw]
+    parsed_inputs: list[tuple[str | None, Path]] = [parse_named_path(raw) for raw in inputs_raw]
     parsed_telos: dict[str, Path] = {}
     for raw in telo_raw:
-        name, path = _parse_named_path(raw)
+        name, path = parse_named_path(raw)
         if name is None:
             raise click.UsageError(f"--telo requires NAME=PATH form (got {raw!r})")
         if name in parsed_telos:
@@ -428,7 +428,7 @@ def cmd(
     if acrocentrics_raw:
         flattened: list[str] = []
         for entry in acrocentrics_raw:
-            flattened.extend(_split_comma(entry))
+            flattened.extend(split_comma(entry))
         if not flattened:
             raise click.UsageError("--acrocentric was given but produced no chromosome names")
         acrocentrics = set(flattened)

--- a/src/karyoscope/commands/karyotype.py
+++ b/src/karyoscope/commands/karyotype.py
@@ -30,18 +30,11 @@ import click
 from karyoscope import paths, preflight
 from karyoscope import progress as _progress
 from karyoscope.commands._options import parse_named_path, split_comma
-from karyoscope.core.external import ExternalToolError, ToolNotFoundError
 from karyoscope.core.karyotype_run import karyotype_run
 from karyoscope.core.scaffold import DEFAULT_HUMAN_ACROCENTRICS
 from karyoscope.core.scaffold_run import InputSpec
 from karyoscope.exceptions import (
-    CentromereError,
-    DatabaseLayoutError,
-    DatabaseNotFoundError,
     KaryoscopeError,
-    KaryotypeError,
-    ManifestError,
-    ScaffoldError,
 )
 
 logger = logging.getLogger(__name__)
@@ -516,17 +509,7 @@ def cmd(
             colors_path=colors_path,
             seed_human_chromosomes=not no_human_chroms,
         )
-    except (
-        KaryotypeError,
-        CentromereError,
-        ScaffoldError,
-        DatabaseNotFoundError,
-        DatabaseLayoutError,
-        ManifestError,
-        ToolNotFoundError,
-        ExternalToolError,
-        KaryoscopeError,
-    ) as e:
+    except KaryoscopeError as e:
         raise click.ClickException(str(e)) from e
 
     click.echo("Wrote:")

--- a/src/karyoscope/commands/prep_bed.py
+++ b/src/karyoscope/commands/prep_bed.py
@@ -238,7 +238,7 @@ def edta(
 
     \b
     No colours are written: there is no established palette for the EDTA
-    vocabulary, so build's automatic assignment beats an invented one.
+    vocabulary, so colours are left to build's automatic assignment.
     """
     _run(
         repeats_prep.from_edta,

--- a/src/karyoscope/commands/scaffold.py
+++ b/src/karyoscope/commands/scaffold.py
@@ -34,6 +34,7 @@ import click
 
 from karyoscope import paths
 from karyoscope import progress as _progress
+from karyoscope.commands._options import parse_named_path, split_comma
 from karyoscope.core.external import ExternalToolError, ToolNotFoundError
 from karyoscope.core.scaffold import DEFAULT_HUMAN_ACROCENTRICS
 from karyoscope.core.scaffold_run import InputSpec, scaffold_run
@@ -46,25 +47,6 @@ from karyoscope.exceptions import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _parse_named_path(value: str) -> tuple[str | None, Path]:
-    """Parse ``NAME=PATH`` or bare ``PATH``.
-
-    Returns ``(None, Path(value))`` when no ``=`` is present.
-    """
-    if "=" in value:
-        name, _, path = value.partition("=")
-        name = name.strip()
-        if not name:
-            raise click.BadParameter(f"empty name in {value!r}; use NAME=PATH or just PATH")
-        return name, Path(path)
-    return None, Path(value)
-
-
-def _split_comma(value: str) -> list[str]:
-    """Split a comma-separated string into stripped non-empty tokens."""
-    return [tok.strip() for tok in value.split(",") if tok.strip()]
 
 
 @click.command(
@@ -266,11 +248,11 @@ def cmd(
     # --- parse named-pair options -----------------------------------
     parsed_inputs: list[tuple[str | None, Path]] = []
     for raw in inputs_raw:
-        parsed_inputs.append(_parse_named_path(raw))
+        parsed_inputs.append(parse_named_path(raw))
 
     parsed_telos: dict[str, Path] = {}
     for raw in telo_raw:
-        name, path = _parse_named_path(raw)
+        name, path = parse_named_path(raw)
         if name is None:
             raise click.UsageError(
                 f"--telo requires NAME=PATH form (got {raw!r}); the name should match an --input"
@@ -301,7 +283,7 @@ def cmd(
     if acrocentrics_raw:
         flattened: list[str] = []
         for entry in acrocentrics_raw:
-            flattened.extend(_split_comma(entry))
+            flattened.extend(split_comma(entry))
         if not flattened:
             raise click.UsageError("--acrocentric was given but produced no chromosome names")
         acrocentrics = set(flattened)

--- a/src/karyoscope/commands/scaffold.py
+++ b/src/karyoscope/commands/scaffold.py
@@ -35,15 +35,10 @@ import click
 from karyoscope import paths
 from karyoscope import progress as _progress
 from karyoscope.commands._options import parse_named_path, split_comma
-from karyoscope.core.external import ExternalToolError, ToolNotFoundError
 from karyoscope.core.scaffold import DEFAULT_HUMAN_ACROCENTRICS
 from karyoscope.core.scaffold_run import InputSpec, scaffold_run
 from karyoscope.exceptions import (
-    DatabaseLayoutError,
-    DatabaseNotFoundError,
     KaryoscopeError,
-    ManifestError,
-    ScaffoldError,
 )
 
 logger = logging.getLogger(__name__)
@@ -337,15 +332,7 @@ def cmd(
             auto=auto,
             output_dir=output_dir,
         )
-    except (
-        ScaffoldError,
-        DatabaseNotFoundError,
-        DatabaseLayoutError,
-        ManifestError,
-        ToolNotFoundError,
-        ExternalToolError,
-        KaryoscopeError,
-    ) as e:
+    except KaryoscopeError as e:
         raise click.ClickException(str(e)) from e
 
     # --- summarise on stdout ----------------------------------------

--- a/src/karyoscope/commands/version.py
+++ b/src/karyoscope/commands/version.py
@@ -18,6 +18,7 @@ import click
 
 from karyoscope import preflight
 from karyoscope._version import __version__
+from karyoscope.core.external import run_tool
 from karyoscope.paths import default_db_root, installed_databases
 
 #: External tools KaryoScope shells out to. Each entry is
@@ -73,13 +74,7 @@ def _external_tool_version(executable: str, version_flag: str) -> tuple[str | No
 
     cmd = [path, version_flag] if version_flag else [path]
     try:
-        proc = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=5,
-            check=False,
-        )
+        proc = run_tool(cmd, check=False, capture=True, timeout=5)
     except (subprocess.TimeoutExpired, OSError):
         return path, "(could not determine version)"
 

--- a/src/karyoscope/core/annotate.py
+++ b/src/karyoscope/core/annotate.py
@@ -51,6 +51,7 @@ from karyoscope.core.io.hierarchy import (
     validate_hierarchy,
 )
 from karyoscope.core.io.hks import (
+    convert_bam_to_fasta,
     convert_hks_tsv_to_bed,
     run_hks_lookup,
     run_hks_smooth,
@@ -1042,57 +1043,74 @@ def _run_hks_backend(
     # which map to karyotype chromosomes).
     is_reads = _is_reads_input(input_path)
 
+    # A BAM is converted to FASTA once, up front: run_hks_lookup would
+    # otherwise re-run samtools fasta for every feature set.
+    query_path = input_path
+    tmp_fasta: Path | None = None
+    if input_path.suffix.lower() == ".bam":
+        logger.info(
+            "converting BAM %s to FASTA once for %d feature set(s)",
+            input_path.name,
+            len(requested),
+        )
+        tmp_fasta = convert_bam_to_fasta(input_path, output_dir, capture=True)
+        query_path = tmp_fasta
+
     t_hks_start = time.perf_counter()
     tracker = progress.track(requested)
-    for fs in requested:
-        t_fs = time.perf_counter()
-        fs_file = db_dir / f"{manifest.index.basename}.{fs}.hksf"
-        hierarchy_file = db_dir / f"{manifest.index.basename}.{fs}.hierarchy.txt"
-        raw_tsv = output_dir / f"{prefix}.{fs}.lookup_raw.tmp.tsv"
+    try:
+        for fs in requested:
+            t_fs = time.perf_counter()
+            fs_file = db_dir / f"{manifest.index.basename}.{fs}.hksf"
+            hierarchy_file = db_dir / f"{manifest.index.basename}.{fs}.hierarchy.txt"
+            raw_tsv = output_dir / f"{prefix}.{fs}.lookup_raw.tmp.tsv"
 
-        logger.info(
-            "running hks lookup for feature set %r on %s (threads=%d)",
-            fs,
-            input_path.name,
-            threads,
-        )
-        run_hks_lookup(
-            base_path=base_path,
-            feature_set_file=fs_file,
-            k=k,
-            input_path=input_path,
-            output_path=raw_tsv,
-            threads=threads,
-            report_query_names=not is_reads,
-            capture=True,
-        )
-        if not raw_tsv.is_file():
-            raise KaryoscopeError(f"hks lookup did not produce expected output at {raw_tsv}")
+            logger.info(
+                "running hks lookup for feature set %r on %s (threads=%d)",
+                fs,
+                input_path.name,
+                threads,
+            )
+            run_hks_lookup(
+                base_path=base_path,
+                feature_set_file=fs_file,
+                k=k,
+                input_path=query_path,
+                output_path=raw_tsv,
+                threads=threads,
+                report_query_names=not is_reads,
+                capture=True,
+            )
+            if not raw_tsv.is_file():
+                raise KaryoscopeError(f"hks lookup did not produce expected output at {raw_tsv}")
 
-        try:
-            if keep_presmoothed:
-                convert_hks_tsv_to_bed(raw_tsv, presmoothed_paths[fs])
-
-            if smooth:
-                t_smo = time.perf_counter()
-                logger.info("running hks smooth for feature set %r", fs)
-                run_hks_smooth(
-                    hierarchy_file=hierarchy_file,
-                    input_path=raw_tsv,
-                    output_path=smoothed_paths[fs],
-                    threads=threads,
-                    capture=True,
-                )
-                logger.info("smoothed feature set %r in %.1fs", fs, time.perf_counter() - t_smo)
-        finally:
             try:
-                raw_tsv.unlink()
-            except OSError as exc:
-                logger.warning("could not remove temp lookup TSV %s: %s", raw_tsv, exc)
-        # Reported here rather than per sub-step: one line per feature set
-        # is the granularity a user waiting on the run actually needs, and
-        # HKS processes them strictly in sequence so the counter is honest.
-        tracker.step(fs, time.perf_counter() - t_fs)
+                if keep_presmoothed:
+                    convert_hks_tsv_to_bed(raw_tsv, presmoothed_paths[fs])
+
+                if smooth:
+                    t_smo = time.perf_counter()
+                    logger.info("running hks smooth for feature set %r", fs)
+                    run_hks_smooth(
+                        hierarchy_file=hierarchy_file,
+                        input_path=raw_tsv,
+                        output_path=smoothed_paths[fs],
+                        threads=threads,
+                        capture=True,
+                    )
+                    logger.info("smoothed feature set %r in %.1fs", fs, time.perf_counter() - t_smo)
+            finally:
+                try:
+                    raw_tsv.unlink()
+                except OSError as exc:
+                    logger.warning("could not remove temp lookup TSV %s: %s", raw_tsv, exc)
+            # Reported here rather than per sub-step: one line per feature set
+            # is the granularity a user waiting on the run actually needs, and
+            # HKS processes them strictly in sequence so the counter is honest.
+            tracker.step(fs, time.perf_counter() - t_fs)
+    finally:
+        if tmp_fasta is not None:
+            tmp_fasta.unlink(missing_ok=True)
 
     logger.info(
         "hks backend complete in %.1fs (%d feature set(s))",

--- a/src/karyoscope/core/annotate.py
+++ b/src/karyoscope/core/annotate.py
@@ -44,7 +44,7 @@ from karyoscope import cpus as _cpus
 from karyoscope import diskspace, preflight
 from karyoscope import installed as _installed
 from karyoscope.core.external import require_tool, run_tool
-from karyoscope.core.io.features import Features, parse_features, render_feature
+from karyoscope.core.io.features import NOVEL_NAME, Features, parse_features, render_feature
 from karyoscope.core.io.hierarchy import (
     Hierarchy,
     parse_hierarchy,
@@ -448,6 +448,14 @@ def _split_combined_bed(
     pending: dict[str, tuple[str, int, int, str] | None] = {fs: None for fs in feature_sets}
     handles: dict[str, TextIO] = {fs: output_paths[fs].open("w") for fs in feature_sets}
 
+    # Flat per-set {id: name} tables, seeded with the id-0 "novel"
+    # sentinel: this loop runs once per record per feature set over a
+    # combined BED with hundreds of millions of records, so the per-hit
+    # cost must be one dict lookup, not render_feature's validation and
+    # nested lookups. render_feature stays as the miss path, so an
+    # unknown id raises the same FeaturesError as before.
+    lookups = [(fs, {0: NOVEL_NAME, **features.names_for_set(fs)}) for fs in feature_sets]
+
     def flush(fs: str) -> None:
         rec = pending[fs]
         if rec is None:
@@ -459,8 +467,10 @@ def _split_combined_bed(
     try:
         with combined_bed.open() as f:
             for seq_name, start, end, fid in _iter_bed_records(f):
-                for fs in feature_sets:
-                    name = render_feature(fid, fs, features)
+                for fs, id_to_name in lookups:
+                    name = id_to_name.get(fid)
+                    if name is None:
+                        name = render_feature(fid, fs, features)
                     rec = pending[fs]
                     if (
                         rec is not None

--- a/src/karyoscope/core/annotate.py
+++ b/src/karyoscope/core/annotate.py
@@ -43,7 +43,7 @@ from typing import TextIO
 from karyoscope import cpus as _cpus
 from karyoscope import diskspace, preflight
 from karyoscope import installed as _installed
-from karyoscope.core.external import require_tool, run_tool
+from karyoscope.core.io.bgzip import bgzip_file
 from karyoscope.core.io.features import NOVEL_NAME, Features, parse_features, render_feature
 from karyoscope.core.io.hierarchy import (
     Hierarchy,
@@ -970,47 +970,6 @@ def _human_bytes(n: int) -> str:
     return f"{n / 1024**2:.1f} MB"
 
 
-def _bgzip_file(path: Path, threads: int = 1) -> Path:
-    """Compress ``path`` in-place with ``bgzip``, returning the new path.
-
-    ``bgzip`` removes the source file by default (matches gzip's behaviour).
-    Returns ``Path(str(path) + ".gz")``. Logs per-file start + completion
-    at INFO so a long bgzip pass (12 files for a 6-feature-set human
-    database) doesn't look like the pipeline has hung.
-
-    ``threads`` is forwarded as ``bgzip -@``; the htslib bgzip compresses
-    a single file in parallel when given more than one thread. We
-    process files sequentially within the bgzip pass, so passing the
-    user's full ``--threads`` here is the right call (no contention
-    with concurrent file compressions). ``threads=1`` (the default)
-    omits ``-@`` entirely for cleanest subprocess invocation.
-    """
-    bgzip = require_tool(
-        "bgzip",
-        install_hint="Install htslib (`conda install -c bioconda htslib`), "
-        "or rerun with --no-bgzip to skip compression.",
-    )
-    orig_size = path.stat().st_size
-    logger.info("bgzipping %s (%s, threads=%d)", path.name, _human_bytes(orig_size), threads)
-    t0 = time.perf_counter()
-    cmd = [bgzip, "-f"]
-    if threads > 1:
-        cmd.extend(["-@", str(threads)])
-    cmd.append(str(path))
-    run_tool(cmd)
-    out_path = Path(str(path) + ".gz")
-    out_size = out_path.stat().st_size if out_path.is_file() else 0
-    dt = time.perf_counter() - t0
-    logger.info(
-        "bgzipped %s (%s -> %s) in %.1fs",
-        out_path.name,
-        _human_bytes(orig_size),
-        _human_bytes(out_size),
-        dt,
-    )
-    return out_path
-
-
 # --- HKS backend ------------------------------------------------------
 
 
@@ -1512,9 +1471,9 @@ def annotate(
         t_bgzip_start = time.perf_counter()
         for fs in requested:
             if fs in presmoothed_paths:
-                presmoothed_paths[fs] = _bgzip_file(presmoothed_paths[fs], threads=threads)
+                presmoothed_paths[fs] = bgzip_file(presmoothed_paths[fs], threads=threads)
             if fs in smoothed_paths:
-                smoothed_paths[fs] = _bgzip_file(smoothed_paths[fs], threads=threads)
+                smoothed_paths[fs] = bgzip_file(smoothed_paths[fs], threads=threads)
         logger.info("bgzip pass complete in %.1fs", time.perf_counter() - t_bgzip_start)
         # Worth its own line: compressing 12 BEDs of a human diploid run
         # takes minutes, and it happens after the last feature-set line, so

--- a/src/karyoscope/core/centromeres.py
+++ b/src/karyoscope/core/centromeres.py
@@ -36,8 +36,9 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from karyoscope.core.annotate import _bgzip_file, resolve_database
+from karyoscope.core.annotate import resolve_database
 from karyoscope.core.bin import bin_features, leaves_for
+from karyoscope.core.io.bgzip import bgzip_file
 from karyoscope.core.io.hierarchy import parse_hierarchy
 from karyoscope.core.io.scaffold_map import MapRow, read_map
 from karyoscope.core.scaffold import (
@@ -538,7 +539,7 @@ def centromeres_run(
         with plain.open("w") as h:
             for contig, (cstart, cend) in ranges.items():
                 h.write(f"{contig}\t{cstart}\t{cend}\n")
-        final = _bgzip_file(plain, threads=threads) if bgzip else plain
+        final = bgzip_file(plain, threads=threads) if bgzip else plain
 
         results[spec.path.name] = CentromereResult(
             input_path=spec.path,

--- a/src/karyoscope/core/external.py
+++ b/src/karyoscope/core/external.py
@@ -108,8 +108,15 @@ def run_tool(
     cwd: Path | None = None,
     env: Mapping[str, str] | None = None,
     input_text: str | None = None,
+    timeout: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run an external command and return its :class:`CompletedProcess`.
+
+    Memory note: with ``check=True`` (the default) stdout/stderr are
+    fully buffered in memory even when ``capture`` is False, so the
+    error message can include stderr. Do not route a tool's
+    unbounded-size data output through stdout here — have the tool
+    write to a file (every current heavy tool does).
 
     Behavior:
 
@@ -141,6 +148,9 @@ def run_tool(
         should merge with :data:`os.environ` first.
     input_text
         Optional string to pipe to the subprocess's stdin.
+    timeout
+        Seconds before the subprocess is killed. On expiry,
+        :class:`subprocess.TimeoutExpired` propagates to the caller.
     """
     cmd_list = [str(c) for c in cmd]
     logger.debug("running: %s", " ".join(cmd_list))
@@ -158,6 +168,7 @@ def run_tool(
         env=dict(env) if env is not None else None,
         input=input_text,
         text=True,
+        timeout=timeout,
     )
 
     if check and result.returncode != 0:

--- a/src/karyoscope/core/io/bgzip.py
+++ b/src/karyoscope/core/io/bgzip.py
@@ -1,0 +1,57 @@
+"""In-place ``bgzip`` compression of output files.
+
+Shared by every pipeline stage that compresses its BED/FASTA outputs
+(``annotate``, ``scaffold``, ``centromeres``, ``karyotype``).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+
+from karyoscope.core.external import require_tool, run_tool
+from karyoscope.diskspace import format_bytes
+
+logger = logging.getLogger(__name__)
+
+
+def bgzip_file(path: Path, threads: int = 1) -> Path:
+    """Compress ``path`` in-place with ``bgzip``, returning the new path.
+
+    ``bgzip`` removes the source file by default (matches gzip's behaviour).
+    Returns ``Path(str(path) + ".gz")``. Logs per-file start + completion
+    at INFO so a long bgzip pass (12 files for a 6-feature-set human
+    database) doesn't look like the pipeline has hung.
+
+    ``threads`` is forwarded as ``bgzip -@``; the htslib bgzip compresses
+    a single file in parallel when given more than one thread. We
+    process files sequentially within the bgzip pass, so passing the
+    user's full ``--threads`` here is the right call (no contention
+    with concurrent file compressions). ``threads=1`` (the default)
+    omits ``-@`` entirely for cleanest subprocess invocation.
+    """
+    bgzip = require_tool(
+        "bgzip",
+        install_hint="Install htslib (`conda install -c bioconda htslib`), "
+        "or rerun with --no-bgzip to skip compression.",
+    )
+    orig_size = path.stat().st_size
+    logger.info("bgzipping %s (%s, threads=%d)", path.name, format_bytes(orig_size), threads)
+    t0 = time.perf_counter()
+    cmd = [bgzip, "-f"]
+    if threads > 1:
+        cmd.extend(["-@", str(threads)])
+    cmd.append(str(path))
+    run_tool(cmd)
+    out_path = Path(str(path) + ".gz")
+    out_size = out_path.stat().st_size if out_path.is_file() else 0
+    dt = time.perf_counter() - t0
+    logger.info(
+        "bgzipped %s (%s -> %s) in %.1fs",
+        out_path.name,
+        format_bytes(orig_size),
+        format_bytes(out_size),
+        dt,
+    )
+    return out_path

--- a/src/karyoscope/core/io/features.py
+++ b/src/karyoscope/core/io/features.py
@@ -88,6 +88,26 @@ class Features:
             return None
         return row.get(feature_set)
 
+    def names_for_set(self, feature_set: str) -> dict[int, str]:
+        """Project the table onto one feature set as a flat ``{id: name}`` dict.
+
+        For per-record hot loops: after this one-time projection, a
+        record costs a single dict lookup instead of
+        :meth:`feature_in_set`'s membership validation plus two nested
+        lookups. ``0`` is not in the result (it is implicitly
+        ``"novel"``, as everywhere).
+
+        Raises
+        ------
+        FeaturesError
+            If ``feature_set`` is not one of the file's columns.
+        """
+        if feature_set not in self.feature_sets:
+            raise FeaturesError(
+                f"unknown feature set {feature_set!r}; valid sets are {self.feature_sets!r}"
+            )
+        return {fid: row[feature_set] for fid, row in self.table.items()}
+
 
 def render_feature(
     feature_id: int,

--- a/src/karyoscope/core/io/hks.py
+++ b/src/karyoscope/core/io/hks.py
@@ -230,7 +230,6 @@ def run_hks_lookup(
 
     if input_path.suffix.lower() == ".bam":
         return _run_hks_lookup_from_bam(
-            binary=binary,
             base_path=base_path,
             feature_set_file=feature_set_file,
             k=k,
@@ -269,22 +268,14 @@ def run_hks_lookup(
     return output_path
 
 
-def _run_hks_lookup_from_bam(
-    *,
-    binary: str,
-    base_path: Path,
-    feature_set_file: Path,
-    k: int,
-    bam_path: Path,
-    output_path: Path,
-    threads: int,
-    report_query_names: bool = True,
-    capture: bool,
-) -> Path:
-    """Convert a BAM to FASTA in a temp file and run HKS lookup on it.
+def convert_bam_to_fasta(bam_path: Path, dest_dir: Path, *, capture: bool = False) -> Path:
+    """Convert a BAM to a temporary FASTA via ``samtools fasta``.
 
-    HKS requires a seekable file path, so we materialise the samtools
-    output to a temporary FASTA rather than streaming via a named pipe.
+    HKS requires a seekable file path, so the samtools output is
+    materialised rather than streamed via a named pipe. The FASTA is
+    created in ``dest_dir`` — it is input-sized, so it belongs on the
+    output's filesystem, not the system tempdir. The caller owns the
+    returned file and must delete it.
     """
     samtools = require_tool(
         "samtools",
@@ -296,20 +287,18 @@ def _run_hks_lookup_from_bam(
         ),
     )
 
-    # Next to the output, not the system tempdir: the FASTA is input-sized
-    # (whole genome or read set), and /tmp on cluster nodes is often small
-    # or RAM-backed.
-    with tempfile.NamedTemporaryFile(suffix=".fasta", delete=False, dir=output_path.parent) as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".fasta", delete=False, dir=dest_dir) as tmp:
         tmp_fasta = Path(tmp.name)
 
     try:
         logger.debug("converting BAM to FASTA: %s -> %s", bam_path, tmp_fasta)
-        samtools_result = subprocess.run(
-            [samtools, "fasta", str(bam_path)],
-            stdout=tmp_fasta.open("wb"),
-            stderr=subprocess.PIPE if capture else None,
-            check=False,
-        )
+        with tmp_fasta.open("wb") as out:
+            samtools_result = subprocess.run(
+                [samtools, "fasta", str(bam_path)],
+                stdout=out,
+                stderr=subprocess.PIPE if capture else None,
+                check=False,
+            )
         if samtools_result.returncode != 0:
             stderr = samtools_result.stderr.decode() if samtools_result.stderr else ""
             raise ExternalToolError(
@@ -317,6 +306,31 @@ def _run_hks_lookup_from_bam(
                 returncode=samtools_result.returncode,
                 stderr=stderr,
             )
+    except BaseException:
+        tmp_fasta.unlink(missing_ok=True)
+        raise
+    return tmp_fasta
+
+
+def _run_hks_lookup_from_bam(
+    *,
+    base_path: Path,
+    feature_set_file: Path,
+    k: int,
+    bam_path: Path,
+    output_path: Path,
+    threads: int,
+    report_query_names: bool = True,
+    capture: bool,
+) -> Path:
+    """Convert a BAM to FASTA in a temp file and run HKS lookup on it.
+
+    One conversion per call: a caller querying several feature sets
+    against the same BAM should convert once with
+    :func:`convert_bam_to_fasta` and pass the FASTA instead.
+    """
+    tmp_fasta = convert_bam_to_fasta(bam_path, output_path.parent, capture=capture)
+    try:
         return run_hks_lookup(
             base_path=base_path,
             feature_set_file=feature_set_file,
@@ -328,8 +342,7 @@ def _run_hks_lookup_from_bam(
             capture=capture,
         )
     finally:
-        if tmp_fasta.exists():
-            tmp_fasta.unlink()
+        tmp_fasta.unlink(missing_ok=True)
 
 
 def run_hks_smooth(

--- a/src/karyoscope/core/io/hks.py
+++ b/src/karyoscope/core/io/hks.py
@@ -296,7 +296,10 @@ def _run_hks_lookup_from_bam(
         ),
     )
 
-    with tempfile.NamedTemporaryFile(suffix=".fasta", delete=False) as tmp:
+    # Next to the output, not the system tempdir: the FASTA is input-sized
+    # (whole genome or read set), and /tmp on cluster nodes is often small
+    # or RAM-backed.
+    with tempfile.NamedTemporaryFile(suffix=".fasta", delete=False, dir=output_path.parent) as tmp:
         tmp_fasta = Path(tmp.name)
 
     try:
@@ -374,7 +377,10 @@ def run_hks_smooth(
 
     n_threads = threads if threads > 0 else 4
 
-    with tempfile.NamedTemporaryFile(suffix=".tsv", delete=False) as tmp:
+    # Next to the output, not the system tempdir: the smoothed TSV is the
+    # size of the lookup TSV (GBs for an assembly, tens of GBs for reads),
+    # and /tmp on cluster nodes is often small or RAM-backed.
+    with tempfile.NamedTemporaryFile(suffix=".tsv", delete=False, dir=output_path.parent) as tmp:
         smooth_tsv = Path(tmp.name)
 
     try:

--- a/src/karyoscope/core/io/kmc.py
+++ b/src/karyoscope/core/io/kmc.py
@@ -32,6 +32,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 from karyoscope._version import __version__
@@ -476,27 +477,34 @@ def _run_get_featureids_piped_from_bam(
     ]
     logger.debug("piping: %s | %s", " ".join(samtools_cmd), " ".join(getfid_cmd))
 
-    samtools_proc = subprocess.Popen(
-        samtools_cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-    try:
-        getfid_proc = subprocess.run(
-            getfid_cmd,
-            stdin=samtools_proc.stdout,
-            capture_output=True,
+    # samtools stderr goes to a temp file, not a pipe: nothing drains a
+    # pipe until get_featureIDs finishes, so a warning-heavy BAM (one
+    # line per malformed record) could fill the ~64 KB pipe buffer,
+    # block samtools mid-write, stall its stdout, and deadlock the
+    # whole pipeline. A file has no such limit.
+    with tempfile.TemporaryFile(mode="w+", encoding="utf-8", errors="replace") as errf:
+        samtools_proc = subprocess.Popen(
+            samtools_cmd,
+            stdout=subprocess.PIPE,
+            stderr=errf,
             text=True,
-            check=False,
         )
-    finally:
-        # Closing the read end before wait() lets samtools see SIGPIPE
-        # cleanly if get_featureIDs exited early.
-        if samtools_proc.stdout is not None:
-            samtools_proc.stdout.close()
-    samtools_returncode = samtools_proc.wait()
-    samtools_stderr = samtools_proc.stderr.read() if samtools_proc.stderr is not None else ""
+        try:
+            getfid_proc = subprocess.run(
+                getfid_cmd,
+                stdin=samtools_proc.stdout,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        finally:
+            # Closing the read end before wait() lets samtools see SIGPIPE
+            # cleanly if get_featureIDs exited early.
+            if samtools_proc.stdout is not None:
+                samtools_proc.stdout.close()
+        samtools_returncode = samtools_proc.wait()
+        errf.seek(0)
+        samtools_stderr = errf.read()
 
     # Order matters: downstream failure (get_featureIDs) is the more
     # actionable error to surface first. Both paths route through

--- a/src/karyoscope/core/karyotype_run.py
+++ b/src/karyoscope/core/karyotype_run.py
@@ -38,7 +38,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
-from karyoscope.core.annotate import _bgzip_file, annotate, resolve_database
+from karyoscope.core.annotate import annotate, resolve_database
 from karyoscope.core.bin import bin_features, leaves_for
 from karyoscope.core.centromeres import (
     DEFAULT_COARSE_BIN_SIZE,
@@ -47,6 +47,7 @@ from karyoscope.core.centromeres import (
     centromeres_run,
     find_centromere_ranges,
 )
+from karyoscope.core.io.bgzip import bgzip_file
 from karyoscope.core.io.colors import (
     colors_for_set,
     parse_colors_and_groups,
@@ -601,7 +602,7 @@ def _ensure_combined_centromeres(
         for contig, (cstart, cend) in ranges.items():
             h.write(f"{contig}\t{cstart}\t{cend}\n")
     if bgzip:
-        _bgzip_file(plain, threads=threads)
+        bgzip_file(plain, threads=threads)
     return dict(ranges)
 
 

--- a/src/karyoscope/core/scaffold.py
+++ b/src/karyoscope/core/scaffold.py
@@ -657,6 +657,18 @@ def _open_bed_out(path: Path, *, gzip_out: bool) -> IO[str]:
 # buffered to reverse it, an un-flipped one streams straight through.
 
 
+def _spill_root(output_path: Path) -> str | None:
+    """Where spill temp dirs go: next to the output, not the system tempdir.
+
+    The system tempdir is often small or RAM-backed on cluster nodes,
+    while a spill is the size of the input; the output's filesystem is
+    the one provisioned for data that size. ``None`` (the tempfile
+    default) only when the output has no existing parent to sit next to.
+    """
+    parent = Path(output_path).parent
+    return str(parent) if parent.is_dir() else None
+
+
 class _SpilledContigs:
     """Per-contig temp files for the contigs a scaffold map places.
 
@@ -692,7 +704,9 @@ class _SpilledContigs:
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
 
-def _spill_needed_contigs(input_path: Path, needed: set[str]) -> _SpilledContigs:
+def _spill_needed_contigs(
+    input_path: Path, needed: set[str], *, tmp_root: str | None = None
+) -> _SpilledContigs:
     """Stream ``input_path`` once, spilling each needed contig to a temp file.
 
     Contigs absent from ``needed`` are validated and skipped (never
@@ -700,8 +714,10 @@ def _spill_needed_contigs(input_path: Path, needed: set[str]) -> _SpilledContigs
     line number, matching the previous whole-file loader's behaviour.
     Each spilled line is ``start\\tend\\trest`` so the reader can round-
     trip the record without re-splitting the original name column.
+    ``tmp_root`` is where the spill directory is created (see
+    :func:`_spill_root`).
     """
-    tmpdir = Path(tempfile.mkdtemp(prefix="ks_scaffold_"))
+    tmpdir = Path(tempfile.mkdtemp(prefix="ks_scaffold_", dir=tmp_root))
     handles: dict[str, IO[str]] = {}
     paths: dict[str, Path] = {}
     try:
@@ -820,7 +836,7 @@ def _rewrite_bed_spill(
 ) -> None:
     """Gzip / stdin path: spill placed contigs to temp files, read in map order."""
     with (
-        _spill_needed_contigs(input_path, needed) as spilled,
+        _spill_needed_contigs(input_path, needed, tmp_root=_spill_root(output_path)) as spilled,
         _open_bed_out(output_path, gzip_out=gzip_out) as out,
     ):
         for row in map_rows:
@@ -1148,7 +1164,9 @@ class _SpilledSeqs:
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
 
-def _spill_fasta_seqs(input_path: Path, needed: set[str] | None) -> _SpilledSeqs:
+def _spill_fasta_seqs(
+    input_path: Path, needed: set[str] | None, *, tmp_root: str | None = None
+) -> _SpilledSeqs:
     """Stream ``input_path`` once, spilling wanted contigs to temp files.
 
     ``needed=None`` spills every contig (used when unscaffolded contigs
@@ -1156,9 +1174,10 @@ def _spill_fasta_seqs(input_path: Path, needed: set[str] | None) -> _SpilledSeqs
     :func:`karyoscope.core.io.fasta.read_fasta_lengths` exactly: the name
     is the first whitespace token of the header, blank lines are
     skipped, CR/LF are stripped, and a repeated header keeps its last
-    occurrence (the temp file is truncated and rewritten).
+    occurrence (the temp file is truncated and rewritten). ``tmp_root``
+    is where the spill directory is created (see :func:`_spill_root`).
     """
-    tmpdir = Path(tempfile.mkdtemp(prefix="ks_scaffold_fa_"))
+    tmpdir = Path(tempfile.mkdtemp(prefix="ks_scaffold_fa_", dir=tmp_root))
     paths: dict[str, Path] = {}
     cur_fh: IO[str] | None = None
     try:
@@ -1241,7 +1260,7 @@ def rewrite_fasta(
     needed = None if keep_unscaffolded else {row.original_name for row in map_rows}
     placed: set[str] = set()
     with (
-        _spill_fasta_seqs(input_path, needed) as spilled,
+        _spill_fasta_seqs(input_path, needed, tmp_root=_spill_root(output_path)) as spilled,
         _open_bed_out(output_path, gzip_out=gzip_out) as out,
     ):
         for row in map_rows:
@@ -1650,7 +1669,7 @@ def write_combined_fasta(
     placed: set[str] = set()
     leftovers: list[tuple[str, int]] = []
     with (
-        _spill_fasta_seqs(input_path, needed) as spilled,
+        _spill_fasta_seqs(input_path, needed, tmp_root=_spill_root(output_path)) as spilled,
         _open_bed_out(output_path, gzip_out=gzip_out) as out,
     ):
         for obj in objects:
@@ -1749,7 +1768,7 @@ def rewrite_bed_combined(
 
     needed = {comp.row.original_name for obj in objects for comp in obj.components}
     with (
-        _spill_needed_contigs(input_path, needed) as spilled,
+        _spill_needed_contigs(input_path, needed, tmp_root=_spill_root(output_path)) as spilled,
         _open_bed_out(output_path, gzip_out=gzip_out) as out,
     ):
         for obj in objects:

--- a/src/karyoscope/core/scaffold_run.py
+++ b/src/karyoscope/core/scaffold_run.py
@@ -44,7 +44,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from karyoscope.core.annotate import _bgzip_file, annotate, resolve_database
+from karyoscope.core.annotate import annotate, resolve_database
 from karyoscope.core.bin import bin_features, leaves_for
 from karyoscope.core.hap_inference import (
     assign_per_input_labels,
@@ -52,6 +52,7 @@ from karyoscope.core.hap_inference import (
     read_fasta_contig_names,
 )
 from karyoscope.core.io.agp import write_agp
+from karyoscope.core.io.bgzip import bgzip_file
 from karyoscope.core.io.fasta import read_fasta_lengths
 from karyoscope.core.io.hierarchy import parse_hierarchy
 from karyoscope.core.io.scaffold_map import MapRow, write_legacy_stats, write_map
@@ -439,7 +440,7 @@ def _write_combined_outputs(
             t_rb = time.perf_counter()
             rewrite_bed_combined(src, out_plain, objects=layout, gzip_out=False)
             logger.info("wrote %s in %.1fs", out_plain.name, time.perf_counter() - t_rb)
-            scaffolded_beds[fs] = _bgzip_file(out_plain, threads=threads) if bgzip else out_plain
+            scaffolded_beds[fs] = bgzip_file(out_plain, threads=threads) if bgzip else out_plain
 
     # Combined FASTA.
     fasta_plain = r.out_dir / f"{r.stem}.{db_id}.scaffolded.{_COMBINED_TAG}.fa"
@@ -454,7 +455,7 @@ def _write_combined_outputs(
         gzip_out=False,
     )
     logger.info("wrote %s in %.1fs", fasta_plain.name, time.perf_counter() - t_rf)
-    scaffolded_fasta = _bgzip_file(fasta_plain, threads=threads) if bgzip else fasta_plain
+    scaffolded_fasta = bgzip_file(fasta_plain, threads=threads) if bgzip else fasta_plain
 
     # AGP: complete description of the FASTA, including kept leftovers.
     agp_path = r.out_dir / f"{r.stem}.{db_id}.scaffolded.{_COMBINED_TAG}.agp"
@@ -793,7 +794,7 @@ def scaffold_run(
                 t_rb = time.perf_counter()
                 rewrite_bed(src, out_plain, map_rows=per_input_rows, gzip_out=False)
                 logger.info("wrote %s in %.1fs", out_plain.name, time.perf_counter() - t_rb)
-                out_final = _bgzip_file(out_plain, threads=threads) if bgzip else out_plain
+                out_final = bgzip_file(out_plain, threads=threads) if bgzip else out_plain
                 scaffolded_beds[fs] = out_final
         elif mode in ("bed", "both") and not write_scaffolded_beds:
             # write_scaffolded_beds=False: caller has opted out of the
@@ -827,7 +828,7 @@ def scaffold_run(
                 gzip_out=False,
             )
             logger.info("wrote %s in %.1fs", fasta_plain.name, time.perf_counter() - t_rf)
-            scaffolded_fasta = _bgzip_file(fasta_plain, threads=threads) if bgzip else fasta_plain
+            scaffolded_fasta = bgzip_file(fasta_plain, threads=threads) if bgzip else fasta_plain
 
         results[r.spec.path.name] = ScaffoldResult(
             input_path=r.spec.path,

--- a/src/karyoscope/core/smooth.py
+++ b/src/karyoscope/core/smooth.py
@@ -121,6 +121,7 @@ class HierarchyIndex:
     parent_of: dict[str, str]
     root: str
     _ancestor_cache: dict[str, list[str]] = field(default_factory=dict)
+    _ancestor_set_cache: dict[str, frozenset[str]] = field(default_factory=dict)
     _lca_cache: dict[tuple[str, str], str | None] = field(default_factory=dict)
 
     @classmethod
@@ -169,8 +170,15 @@ class HierarchyIndex:
         """Return True if ``potential_ancestor`` is on the path from ``node`` to root.
 
         A node is considered its own ancestor (matches the archive).
+        Checked against a memoised frozenset of the ancestor path: this
+        runs in the innermost smoothing scans, once per interval
+        comparison across the whole genome.
         """
-        return potential_ancestor in self.get_ancestors(node)
+        cached = self._ancestor_set_cache.get(node)
+        if cached is None:
+            cached = frozenset(self.get_ancestors(node))
+            self._ancestor_set_cache[node] = cached
+        return potential_ancestor in cached
 
     def get_lca(self, node1: str, node2: str) -> str | None:
         """Return the lowest common ancestor of ``node1`` and ``node2``.

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -13,7 +13,13 @@ import threading
 from pathlib import Path
 from types import SimpleNamespace
 
-from karyoscope.core.annotate import _detect_worker_death, _quiet_worker_pipe_errors
+from karyoscope.core.annotate import (
+    _derive_input_basename,
+    _detect_worker_death,
+    _quiet_worker_pipe_errors,
+    _split_combined_bed,
+)
+from karyoscope.core.io.features import parse_features
 from karyoscope.core.io.kmc import (
     clear_combined_marker,
     combined_bed_is_complete,
@@ -250,3 +256,199 @@ def test_resolve_query_k_variable_rejects_above_max() -> None:
 def test_resolve_query_k_rejects_below_one() -> None:
     with pytest.raises(KaryoscopeError, match=">= 1"):
         _resolve_query_k(_manifest(31, "variable", 31), 0, "db")
+
+
+def _read_bed(path: Path) -> list[tuple[str, int, int, str]]:
+    """Read a plain BED and return parsed records."""
+    out: list[tuple[str, int, int, str]] = []
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        seq, start, end, name = line.split("\t")
+        out.append((seq, int(start), int(end), name))
+    return out
+
+
+# --- _derive_input_basename (pure function, no binary needed) ---------
+
+
+def test_derive_basename_strips_known_extensions() -> None:
+    assert _derive_input_basename(Path("foo.fa.gz")) == "foo"
+    assert _derive_input_basename(Path("path/to/bar.fasta")) == "bar"
+    assert _derive_input_basename(Path("baz.fna.gz")) == "baz"
+    assert _derive_input_basename(Path("BAR.FA.GZ")) == "BAR"  # case-insensitive
+    assert _derive_input_basename(Path("name_only")) == "name_only"
+    # Falls back to .stem for unknown extensions
+    assert _derive_input_basename(Path("foo.unknown")) == "foo"
+
+
+# --- _split_combined_bed (unit test with hand-crafted data) -----------
+
+
+def test_split_combined_bed_translates_and_merges(tmp_path: Path, unpacked_dummy_db: Path) -> None:
+    """The splitter should translate ids and merge adjacent same-name runs."""
+    # Hand-crafted combined BED using REAL feature ids from the dummy db
+    # (features.tsv has rows 1->chr1/rA, 2->chr1/rB, 3->chr2/rC).
+    combined = tmp_path / "combined.bed"
+    combined.write_text(
+        # Adjacent rows mapping to different region ids but same chromosome
+        # should merge in the chromosome BED but not in the region BED.
+        "seqA\t0\t10\t1\n"  # chr1, rA
+        "seqA\t10\t20\t2\n"  # chr1, rB
+        "seqA\t20\t30\t3\n"  # chr2, rC
+        # A 'novel' run (feature_id 0):
+        "seqA\t30\t40\t0\n"  # novel
+        # New sequence: starts a new run regardless of label
+        "seqB\t0\t15\t1\n"  # chr1, rA
+    )
+    features = parse_features(unpacked_dummy_db / "features.tsv")
+
+    out_paths = {
+        "chromosome": tmp_path / "chrom.bed",
+        "region": tmp_path / "region.bed",
+    }
+    _split_combined_bed(combined, ["chromosome", "region"], features, out_paths)
+
+    chrom = _read_bed(out_paths["chromosome"])
+    region = _read_bed(out_paths["region"])
+
+    # Chromosome BED: rows 0-20 both map to chr1 and merge; 20-30 is chr2;
+    # 30-40 is novel; seqB starts a fresh run at chr1.
+    assert chrom == [
+        ("seqA", 0, 20, "chr1"),
+        ("seqA", 20, 30, "chr2"),
+        ("seqA", 30, 40, "novel"),
+        ("seqB", 0, 15, "chr1"),
+    ]
+
+    # Region BED: each row stays distinct (different region per row).
+    assert region == [
+        ("seqA", 0, 10, "rA"),
+        ("seqA", 10, 20, "rB"),
+        ("seqA", 20, 30, "rC"),
+        ("seqA", 30, 40, "novel"),
+        ("seqB", 0, 15, "rA"),
+    ]
+
+
+def test_split_combined_bed_raises_on_unknown_feature_id(
+    tmp_path: Path, unpacked_dummy_db: Path
+) -> None:
+    """A featureID present in the BED but absent from features.tsv is an error.
+
+    This usually signals a mismatch between the KMC index and
+    features.tsv (different builds, or a stale features file). We
+    refuse to silently emit a placeholder string because 'Unknown' can
+    be a legitimate feature name in real databases (e.g., the repeats
+    set).
+    """
+    from karyoscope.core.io.features import FeaturesError
+
+    combined = tmp_path / "combined.bed"
+    # featureID 999 has no row in the dummy db's features.tsv (which
+    # only has rows for ids 1, 2, 3).
+    combined.write_text("seqA\t0\t10\t999\n")
+    features = parse_features(unpacked_dummy_db / "features.tsv")
+
+    out_paths = {"chromosome": tmp_path / "chrom.bed"}
+    with pytest.raises(FeaturesError, match="feature id 999 is not in features"):
+        _split_combined_bed(combined, ["chromosome"], features, out_paths)
+
+
+# --- _run_hks_backend BAM handling (stubbed backend calls) -----------
+
+
+def test_run_hks_backend_converts_bam_once_for_all_feature_sets(tmp_path, monkeypatch) -> None:
+    """A BAM input is converted to FASTA once, shared by every lookup, then removed."""
+    from karyoscope.core import annotate as ann
+
+    convert_calls: list[Path] = []
+    lookup_inputs: list[tuple[Path, bool]] = []
+
+    def fake_convert(bam_path: Path, dest_dir: Path, *, capture: bool = False) -> Path:
+        fasta = Path(dest_dir) / "converted.tmp.fasta"
+        fasta.write_text(">r1\nACGT\n")
+        convert_calls.append(fasta)
+        return fasta
+
+    def fake_lookup(
+        *,
+        base_path,
+        feature_set_file,
+        k,
+        input_path,
+        output_path,
+        threads,
+        report_query_names,
+        capture,
+    ):
+        lookup_inputs.append((input_path, report_query_names))
+        output_path.write_text("hdr\n1\t0\t4\tchr1\n")
+        return output_path
+
+    monkeypatch.setattr(ann, "convert_bam_to_fasta", fake_convert)
+    monkeypatch.setattr(ann, "run_hks_lookup", fake_lookup)
+    monkeypatch.setattr(ann, "convert_hks_tsv_to_bed", lambda tsv, bed: bed.write_text("x"))
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    requested = ["chromosome", "region", "gene"]
+    ann._run_hks_backend(
+        manifest=SimpleNamespace(index=SimpleNamespace(basename="db")),
+        db_dir=tmp_path,
+        input_path=tmp_path / "reads.bam",
+        prefix="reads.db",
+        output_dir=out_dir,
+        requested=requested,
+        smooth=False,
+        keep_presmoothed=True,
+        presmoothed_paths={fs: out_dir / f"{fs}.bed" for fs in requested},
+        smoothed_paths={},
+        threads=1,
+        k=31,
+    )
+
+    assert len(convert_calls) == 1
+    fasta = convert_calls[0]
+    # Every feature set queried the one converted FASTA, as a reads input
+    # (integer query ranks, not names).
+    assert [inp for inp, _ in lookup_inputs] == [fasta] * len(requested)
+    assert all(rq is False for _, rq in lookup_inputs)
+    # The temp FASTA is removed once the loop finishes.
+    assert not fasta.exists()
+
+
+def test_run_hks_backend_removes_bam_fasta_on_lookup_failure(tmp_path, monkeypatch) -> None:
+    """The converted FASTA does not outlive a failing lookup."""
+    from karyoscope.core import annotate as ann
+    from karyoscope.exceptions import KaryoscopeError
+
+    def fake_convert(bam_path: Path, dest_dir: Path, *, capture: bool = False) -> Path:
+        fasta = Path(dest_dir) / "converted.tmp.fasta"
+        fasta.write_text(">r1\nACGT\n")
+        return fasta
+
+    def failing_lookup(**kwargs):
+        raise KaryoscopeError("lookup exploded")
+
+    monkeypatch.setattr(ann, "convert_bam_to_fasta", fake_convert)
+    monkeypatch.setattr(ann, "run_hks_lookup", failing_lookup)
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    with pytest.raises(KaryoscopeError, match="lookup exploded"):
+        ann._run_hks_backend(
+            manifest=SimpleNamespace(index=SimpleNamespace(basename="db")),
+            db_dir=tmp_path,
+            input_path=tmp_path / "reads.bam",
+            prefix="reads.db",
+            output_dir=out_dir,
+            requested=["chromosome"],
+            smooth=False,
+            keep_presmoothed=True,
+            presmoothed_paths={"chromosome": out_dir / "chromosome.bed"},
+            smoothed_paths={},
+            threads=1,
+            k=31,
+        )
+    assert not (out_dir / "converted.tmp.fasta").exists()

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -327,6 +327,7 @@ class TestCLI:
 # --- threaded path produces byte-identical output -------------------
 
 
+@pytest.mark.slow
 class TestBinFeaturesThreaded:
     """``bin_features(threads=N)`` should byte-for-byte match
     ``bin_features(threads=1)`` regardless of N.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,23 +6,14 @@ import pytest
 from click.testing import CliRunner
 
 from karyoscope import __version__
-from karyoscope.cli import main
+from karyoscope.cli import _LAZY_COMMANDS, main
 
 
 def test_top_level_help_lists_all_commands(cli_runner: CliRunner) -> None:
     """`karyoscope --help` should mention every registered subcommand."""
     result = cli_runner.invoke(main, ["--help"])
     assert result.exit_code == 0
-    for cmd_name in (
-        "download",
-        "annotate",
-        "scaffold",
-        "bin",
-        "centromeres",
-        "karyotype",
-        "info",
-        "version",
-    ):
+    for cmd_name in _LAZY_COMMANDS:
         assert cmd_name in result.output, f"`{cmd_name}` missing from --help output"
 
 
@@ -33,19 +24,7 @@ def test_version_flag(cli_runner: CliRunner) -> None:
     assert __version__ in result.output
 
 
-@pytest.mark.parametrize(
-    "subcommand",
-    [
-        "download",
-        "annotate",
-        "scaffold",
-        "bin",
-        "centromeres",
-        "karyotype",
-        "info",
-        "version",
-    ],
-)
+@pytest.mark.parametrize("subcommand", sorted(_LAZY_COMMANDS))
 def test_subcommand_help_succeeds(cli_runner: CliRunner, subcommand: str) -> None:
     """Each subcommand should respond to --help without error."""
     result = cli_runner.invoke(main, [subcommand, "--help"])

--- a/tests/test_command_annotate.py
+++ b/tests/test_command_annotate.py
@@ -13,8 +13,6 @@ import pytest
 from click.testing import CliRunner
 
 from karyoscope.cli import main
-from karyoscope.core.annotate import _derive_input_basename, _split_combined_bed
-from karyoscope.core.io.features import parse_features
 from karyoscope.core.io.kmc import combined_bed_is_complete, write_combined_marker
 
 pytestmark = pytest.mark.integration
@@ -67,92 +65,6 @@ def _read_bed(path: Path) -> list[tuple[str, int, int, str]]:
         seq, start, end, name = line.split("\t")
         out.append((seq, int(start), int(end), name))
     return out
-
-
-# --- _derive_input_basename (pure function, no binary needed) ---------
-
-
-def test_derive_basename_strips_known_extensions() -> None:
-    assert _derive_input_basename(Path("foo.fa.gz")) == "foo"
-    assert _derive_input_basename(Path("path/to/bar.fasta")) == "bar"
-    assert _derive_input_basename(Path("baz.fna.gz")) == "baz"
-    assert _derive_input_basename(Path("BAR.FA.GZ")) == "BAR"  # case-insensitive
-    assert _derive_input_basename(Path("name_only")) == "name_only"
-    # Falls back to .stem for unknown extensions
-    assert _derive_input_basename(Path("foo.unknown")) == "foo"
-
-
-# --- _split_combined_bed (unit test with hand-crafted data) -----------
-
-
-def test_split_combined_bed_translates_and_merges(tmp_path: Path, unpacked_dummy_db: Path) -> None:
-    """The splitter should translate ids and merge adjacent same-name runs."""
-    # Hand-crafted combined BED using REAL feature ids from the dummy db
-    # (features.tsv has rows 1->chr1/rA, 2->chr1/rB, 3->chr2/rC).
-    combined = tmp_path / "combined.bed"
-    combined.write_text(
-        # Adjacent rows mapping to different region ids but same chromosome
-        # should merge in the chromosome BED but not in the region BED.
-        "seqA\t0\t10\t1\n"  # chr1, rA
-        "seqA\t10\t20\t2\n"  # chr1, rB
-        "seqA\t20\t30\t3\n"  # chr2, rC
-        # A 'novel' run (feature_id 0):
-        "seqA\t30\t40\t0\n"  # novel
-        # New sequence: starts a new run regardless of label
-        "seqB\t0\t15\t1\n"  # chr1, rA
-    )
-    features = parse_features(unpacked_dummy_db / "features.tsv")
-
-    out_paths = {
-        "chromosome": tmp_path / "chrom.bed",
-        "region": tmp_path / "region.bed",
-    }
-    _split_combined_bed(combined, ["chromosome", "region"], features, out_paths)
-
-    chrom = _read_bed(out_paths["chromosome"])
-    region = _read_bed(out_paths["region"])
-
-    # Chromosome BED: rows 0-20 both map to chr1 and merge; 20-30 is chr2;
-    # 30-40 is novel; seqB starts a fresh run at chr1.
-    assert chrom == [
-        ("seqA", 0, 20, "chr1"),
-        ("seqA", 20, 30, "chr2"),
-        ("seqA", 30, 40, "novel"),
-        ("seqB", 0, 15, "chr1"),
-    ]
-
-    # Region BED: each row stays distinct (different region per row).
-    assert region == [
-        ("seqA", 0, 10, "rA"),
-        ("seqA", 10, 20, "rB"),
-        ("seqA", 20, 30, "rC"),
-        ("seqA", 30, 40, "novel"),
-        ("seqB", 0, 15, "rA"),
-    ]
-
-
-def test_split_combined_bed_raises_on_unknown_feature_id(
-    tmp_path: Path, unpacked_dummy_db: Path
-) -> None:
-    """A featureID present in the BED but absent from features.tsv is an error.
-
-    This usually signals a mismatch between the KMC index and
-    features.tsv (different builds, or a stale features file). We
-    refuse to silently emit a placeholder string because 'Unknown' can
-    be a legitimate feature name in real databases (e.g., the repeats
-    set).
-    """
-    from karyoscope.core.io.features import FeaturesError
-
-    combined = tmp_path / "combined.bed"
-    # featureID 999 has no row in the dummy db's features.tsv (which
-    # only has rows for ids 1, 2, 3).
-    combined.write_text("seqA\t0\t10\t999\n")
-    features = parse_features(unpacked_dummy_db / "features.tsv")
-
-    out_paths = {"chromosome": tmp_path / "chrom.bed"}
-    with pytest.raises(FeaturesError, match="feature id 999 is not in features"):
-        _split_combined_bed(combined, ["chromosome"], features, out_paths)
 
 
 # --- end-to-end CLI ---------------------------------------------------

--- a/tests/test_command_scaffold.py
+++ b/tests/test_command_scaffold.py
@@ -19,7 +19,7 @@ import pytest
 from click.testing import CliRunner
 
 from karyoscope.cli import main
-from karyoscope.commands.scaffold import _parse_named_path
+from karyoscope.commands._options import parse_named_path
 from karyoscope.core.io.scaffold_map import read_map
 
 # --- CLI parsing (no external tools) --------------------------------
@@ -27,12 +27,12 @@ from karyoscope.core.io.scaffold_map import read_map
 
 class TestParseNamedPath:
     def test_name_and_path(self) -> None:
-        name, path = _parse_named_path("hap1=foo.fa")
+        name, path = parse_named_path("hap1=foo.fa")
         assert name == "hap1"
         assert path == Path("foo.fa")
 
     def test_bare_path(self) -> None:
-        name, path = _parse_named_path("foo.fa")
+        name, path = parse_named_path("foo.fa")
         assert name is None
         assert path == Path("foo.fa")
 
@@ -40,7 +40,7 @@ class TestParseNamedPath:
         import click as _click
 
         with pytest.raises(_click.BadParameter):
-            _parse_named_path("=foo.fa")
+            parse_named_path("=foo.fa")
 
 
 class TestCliSurface:

--- a/tests/test_hks.py
+++ b/tests/test_hks.py
@@ -328,6 +328,7 @@ def test_convert_handles_a_line_longer_than_a_block(tmp_path: Path) -> None:
     assert bed.read_text() == _reference_convert(tsv_text)
 
 
+@pytest.mark.slow
 def test_convert_is_byte_identical_on_pseudorandom_records(tmp_path: Path) -> None:
     """Fuzz the label mix and line lengths against the oracle."""
     import random
@@ -346,3 +347,50 @@ def test_convert_is_byte_identical_on_pseudorandom_records(tmp_path: Path) -> No
         bed = tmp_path / f"out_{block}.bed"
         convert_hks_tsv_to_bed(tsv, bed, block_bytes=block)
         assert bed.read_text() == expected, f"mismatch at block_bytes={block}"
+
+
+# --- convert_bam_to_fasta (stubbed samtools) -------------------------
+
+
+def test_convert_bam_to_fasta_runs_samtools_into_dest_dir(tmp_path, monkeypatch) -> None:
+    """The conversion runs `samtools fasta <bam>` with stdout in dest_dir."""
+    from types import SimpleNamespace
+
+    from karyoscope.core.io import hks as hks_mod
+
+    seen: dict[str, object] = {}
+
+    def fake_run(cmd, stdout=None, stderr=None, check=False):
+        seen["cmd"] = cmd
+        stdout.write(b">r1\nACGT\n")
+        return SimpleNamespace(returncode=0, stderr=None)
+
+    monkeypatch.setattr(hks_mod, "require_tool", lambda name, **kw: "samtools-stub")
+    monkeypatch.setattr(hks_mod.subprocess, "run", fake_run)
+
+    bam = tmp_path / "reads.bam"
+    fasta = hks_mod.convert_bam_to_fasta(bam, tmp_path)
+    try:
+        assert seen["cmd"] == ["samtools-stub", "fasta", str(bam)]
+        assert fasta.parent == tmp_path
+        assert fasta.read_text() == ">r1\nACGT\n"
+    finally:
+        fasta.unlink(missing_ok=True)
+
+
+def test_convert_bam_to_fasta_failure_raises_and_cleans_up(tmp_path, monkeypatch) -> None:
+    """A non-zero samtools exit raises ExternalToolError and removes the temp FASTA."""
+    from types import SimpleNamespace
+
+    from karyoscope.core.external import ExternalToolError
+    from karyoscope.core.io import hks as hks_mod
+
+    def fake_run(cmd, stdout=None, stderr=None, check=False):
+        return SimpleNamespace(returncode=1, stderr=b"boom")
+
+    monkeypatch.setattr(hks_mod, "require_tool", lambda name, **kw: "samtools-stub")
+    monkeypatch.setattr(hks_mod.subprocess, "run", fake_run)
+
+    with pytest.raises(ExternalToolError, match="boom"):
+        hks_mod.convert_bam_to_fasta(tmp_path / "reads.bam", tmp_path, capture=True)
+    assert list(tmp_path.glob("*.fasta")) == []

--- a/tests/test_smooth.py
+++ b/tests/test_smooth.py
@@ -118,12 +118,9 @@ def test_index_lca_none_for_disjoint_nodes(region_index: HierarchyIndex) -> None
 
 
 def test_index_caches_results(region_index: HierarchyIndex) -> None:
-    """get_ancestors / get_lca memoise — second call hits the cache."""
-    region_index.get_ancestors("rA")
-    region_index.get_lca("rA", "rB")
-    # Caches are populated
-    assert "rA" in region_index._ancestor_cache
-    assert any("rA" in k for k in region_index._lca_cache)
+    """get_ancestors memoises: repeated calls return the same object."""
+    assert region_index.get_ancestors("rA") is region_index.get_ancestors("rA")
+    assert region_index.get_lca("rA", "rB") == region_index.get_lca("rA", "rB")
 
 
 def test_index_rejects_multiple_roots() -> None:


### PR DESCRIPTION
Fixes from a four-axis audit (architecture / tests / docs / runtime+memory) of the codebase. Eleven commits, grouped:

**Performance / correctness**
- Genome-scale temp files (scaffold spill dirs, BAM→FASTA, `hks smooth` TSV) are created next to the output instead of the system tempdir, which on cluster nodes is often small or RAM-backed. Same treatment annotate's smoothing pass already had.
- A BAM input to `annotate` (HKS backend) is converted to FASTA once, not once per feature set.
- `_split_combined_bed` uses flat per-set `{id: name}` dicts instead of `render_feature` per record; `is_ancestor` memoises a frozenset. Unknown ids still raise the same `FeaturesError`.
- The `samtools | get_featureIDs` pipeline drains samtools stderr to a file, closing a deadlock window on warning-heavy BAMs.

**Refactors**
- Shared CLI parsing helpers move from the scaffold command module to `commands/_options.py`.
- Every command's 8-class exception tuple collapses to `except KaryoscopeError` (each tuple was exactly equivalent; the lists had drifted). −100 lines.
- `_bgzip_file` becomes `core/io/bgzip.py:bgzip_file` (it was shared infrastructure trapped under a private name in `core/annotate.py`).
- `run_tool` gains `timeout=`; `version.py` stops bypassing it with raw `subprocess.run`.

**Docs** — accuracy pass: `bin` `--threads 0` semantics, scaffold output filename prefixes, `version`'s missing HKS/get_featureIDs rows, `build`'s `--flatten-order` table row, KMC attribution on annotate's HG002 figure, README samtools scope + stale references, recipes file table, CONTRIBUTING now uses `environment.yml`.

**Tests** — `test_cli` parametrizes over `_LAZY_COMMANDS` (was checking 8 of 12 commands); pure tests moved out of the integration-marked module into the default pass; first unit coverage of the BAM input path (conversion command, placement, cleanup, convert-once); `slow` marker is now used.

Verified: 938 unit + 45 integration tests pass locally, ruff lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)