### PR TITLE
prep-bed pave: an HPV database from PaVE reference genomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`karyoscope prep-bed pave` — a papillomavirus `gene` feature set from PaVE
+  genome records.** Leaves are the ORFs — `E6`, `E7`, `E1`, `E2`, the
+  genus-specific `E5_*`, `E10`, `L2`, `L1` — plus the `URR`, grouped `early` and
+  `late`.
+
+  The spliced transcripts `E1^E4`, `E8^E2` and `E6*` are excluded: they lie
+  wholly inside the ORFs they are spliced from — 100% of their bases across
+  PaVE's 224 human reference genomes — so a ranking that prefers the primary ORF
+  leaves them holding no sequence. The `E1BS` and `E2BS` binding motifs are
+  excluded as 12–20 bp, shorter than any usable k. A feature name with no leaf
+  raises rather than being dropped to the gap-fill.
+
+  The reading frames overlap, so `--priority` writes a ranking in genome order
+  rather than the set being flattened: 10.2% of bases carry more than one
+  annotated feature, 1.2% once the spliced transcripts are dropped. A feature
+  spanning the origin of a circular genome becomes two records with one label.
+
+  A PaVE record also carries the genome sequence and the ICTV lineage, so
+  `--fasta` writes the FASTA for `build`'s `sequence:` and `--taxonomy` writes
+  the genus → species → type hierarchy for a `type` set whose BED comes from
+  `prep-bed fai`.
+
+- **A recipe for an HPV database, `docs/recipes/hpv-pave.md`.** 224 genomes,
+  1.68 Mb, a 2 s build and a 10.5 MB database with `type` and `gene` sets. Both
+  the input records and every derived file are pinned by checksum, and the
+  download script ships in `docs/recipes/files/`.
+
 - **`karyoscope prep-bed asat` — a per-array alpha-satellite feature set from a
   CenSat annotation.** Where `prep-bed censat` collapses CenSat onto its 14
   broad classes, `asat` reads the same file per array: `hor_1_5(S1C1/5/19H1L)`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 > ℹ️ **KaryoScope follows [semantic versioning](https://semver.org); v1.0.0 is the first stable release.** The command-line interface is stable: deprecations ship with warnings and a back-compatible transition, and any breaking change will come with a major-version bump. The project is being prepared for journal submission, and new features continue to land between releases — see the [CHANGELOG](CHANGELOG.md) and [releases](https://github.com/barthel-lab/KaryoScope/releases).
 
-> 🚀 **New in v2.2.0.** [`karyoscope prep-bed`](docs/commands/prep-bed.md) converts source annotations — RepeatMasker, EDTA, GFF3/GTF gene models, CenSat, satellite catalogs, a plain `.fai` — into the feature-set BEDs [`karyoscope build`](docs/commands/build.md) consumes, so building a database no longer needs a script per dataset. [`docs/recipes/`](docs/recipes/) rebuilds the shipped human and *Arabidopsis* databases end to end, from download URL to built index. [`examples/karyotypes/`](examples/karyotypes/) collects reference karyotype plots for six assemblies to compare your own output against. Legends can now be collapsed with a `legend_group` column. See the [CHANGELOG](CHANGELOG.md).
+> 🚀 **New in v2.2.0.** [`karyoscope prep-bed`](docs/commands/prep-bed.md) converts source annotations — RepeatMasker, EDTA, GFF3/GTF gene models, UCSC cytoband tables, CenSat, satellite catalogs, a plain `.fai` — into the feature-set BEDs [`karyoscope build`](docs/commands/build.md) consumes, so building a database no longer needs a script per dataset. [`docs/recipes/`](docs/recipes/) rebuilds the shipped human and *Arabidopsis* databases end to end, from download URL to built index. [`examples/karyotypes/`](examples/karyotypes/) collects reference karyotype plots for six assemblies to compare your own output against. Legends can now be collapsed with a `legend_group` column. See the [CHANGELOG](CHANGELOG.md).
 
 ---
 
@@ -35,7 +35,7 @@ A pre-built database for the human genome is distributed alongside the tool, der
 
 ### Why alignment-free?
 
-- **Pangenome-scale throughput.** On the [HKS](https://github.com/jnalanko/HKS) *k*-mer indexing backend, one `annotate` run covering all six feature sets finishes a complete human haplotype in **~7–9 minutes at a ~10 GB memory peak**, at 16 threads — scaling to cohorts of hundreds of phased assemblies. The original KMC backend does the same work in ~17–22 minutes at ~30–35 GB, so HKS is roughly 2.5–3× faster on about a third of the RAM. (Measured at 16 threads on T2T-CHM13v2.0, HG008N and HG008T, as a single sequential run of the whole pipeline — assignment plus smoothing for every feature set.)
+- **Pangenome-scale throughput.** On the [HKS](https://github.com/jnalanko/HKS) *k*-mer indexing backend, one `annotate` run covering all six feature sets finishes a complete human haplotype in **~7–9 minutes at a ~10 GB memory peak**, at 16 threads — scaling to cohorts of hundreds of phased assemblies. The original KMC backend does the same work in ~17–22 minutes at ~30–35 GB, so HKS is roughly 2.5–3× faster on about a third of the RAM. (Measured at 16 threads on T2T-CHM13v2.0, HG008N and HG008T, as a single sequential run of the whole pipeline — assignment plus smoothing for every feature set. See [System requirements](#system-requirements) for the machine.)
 - **Base-pair resolution across the entire genome.** Performs well in the satellite-dense centromeres, subtelomeres, and acrocentric short arms where alignment-based pipelines suffer from reference bias and ambiguous mappings.
 - **Multiple feature classes in a single pass.** The same *k*-mer can carry labels across feature sets simultaneously, so a single position can be annotated as belonging to a specific chromosome, satellite family, repeat class, and gene at once.
 - **Extensible.** Any annotation that tiles a reference of interest can serve as a feature set.
@@ -70,7 +70,7 @@ A pre-built database for the human genome is distributed alongside the tool, der
 | libcairo | rendering `--format pdf` / `--format png` | any recent release |
 | samtools | only for BAM input to `annotate` | 1.22.1 |
 
-**Hardware.** No non-standard hardware is required — KaryoScope runs on a standard CPU and has no GPU dependency. Resource needs scale with the input:
+**Hardware.** No non-standard hardware is required — KaryoScope runs on a standard CPU and has no GPU dependency. Every runtime and memory figure in this README was measured on a cluster node with two Intel Xeon Gold 6342 CPUs (Ice Lake, 2.80 GHz, 24 cores each, SMT disabled) and 503 GiB RAM, running the job on 16 threads. Resource needs scale with the input:
 
 - **Demo and small inputs:** run on any laptop in seconds (see [Demo](#demo)).
 - **Human whole-genome inputs (HKS backend, recommended):** `annotate`'s peak is set by the index, not by the input. It holds the shared base index (6.0 GiB) plus one feature set's labeling at a time (the largest is 3.0 GiB), so the peak is **~10 GB whatever you annotate** — a single haplotype and a combined diploid assembly measure the same. **Request ≥ 16 GB.** A single haplotype's six-feature-set run takes **~7–9 minutes** at 16 threads; a combined diploid is roughly twice that. Measured on T2T-CHM13v2.0, HG008N, HG008T and HG002 v1.1. See [Disk space](#disk-space) for storage.
@@ -306,7 +306,7 @@ Beyond the per-command pages:
 
 | Where | What |
 |---|---|
-| [`docs/recipes/`](docs/recipes/) | Rebuild the shipped human and *Arabidopsis* databases from published sources — every download URL and checksum, the `prep-bed` command for each feature set, and the build spec. |
+| [`docs/recipes/`](docs/recipes/) | Rebuild the shipped human and *Arabidopsis* databases from published sources, and build an HPV database from [PaVE](https://pave.niaid.nih.gov/) reference genomes — every download URL and checksum, the `prep-bed` command for each feature set, and the build spec. |
 | [`examples/karyotypes/`](examples/karyotypes/) | Reference karyotype plots for six assemblies (CHM13, HG002, an HG008 tumour/normal pair, an HPRC population sample, and *Arabidopsis*), with notes on what each shows and the commands that produced them. |
 
 ## Databases
@@ -322,9 +322,9 @@ karyoscope download --list           # download and on-disk size for each
 karyoscope download --info <ID>      # ...plus the free space needed to install
 ```
 
-You can also build your own database from a genome and per-feature-set BED annotations with [`karyoscope build`](docs/commands/build.md). `build` starts from a final labelled BED; [`karyoscope prep-bed`](docs/commands/prep-bed.md) produces one from the formats annotation usually arrives in — RepeatMasker and EDTA tables, GFF3/GTF gene models, UCSC cytoband tables, satellite catalogs, and a plain `.fai` — and prints the build-spec stanza to go with it.
+You can also build your own database from a genome and per-feature-set BED annotations with [`karyoscope build`](docs/commands/build.md). `build` starts from a final labelled BED; [`karyoscope prep-bed`](docs/commands/prep-bed.md) produces one from the formats annotation usually arrives in — RepeatMasker and EDTA tables, GFF3/GTF gene models, UCSC cytoband tables, CenSat and satellite catalogs, PaVE genome records, and a plain `.fai` — and prints the build-spec stanza to go with it.
 
-For complete worked examples — every download URL, checksum, conversion and build spec — see [docs/recipes/](docs/recipes/), which rebuilds the human CHM13v2 and *Arabidopsis* Col-CEN databases from published sources.
+For complete worked examples — every download URL, checksum, conversion and build spec — see [docs/recipes/](docs/recipes/), which rebuilds the human CHM13v2 and *Arabidopsis* Col-CEN databases from published sources and builds an HPV database from PaVE reference genomes.
 
 ## Pre-computed annotations
 

--- a/docs/commands/prep-bed.md
+++ b/docs/commands/prep-bed.md
@@ -61,9 +61,9 @@ Annotation seqids often differ from the assembly's. Two options, on every subcom
 
 `--hierarchy` is written wherever the source format implies one. `--colors` and `--priority` are optional and produced only when you name an output path.
 
-Colours are emitted only where an established KaryoScope palette exists — `repeatmasker`, `gff-gene` and `cytoband`. For those, the palette reproduces the shipped reference databases. For `edta` there is no such convention, so no colours are written and `build` assigns them.
+Colours are emitted only where an established KaryoScope palette exists — `repeatmasker`, `gff-gene`, `cytoband`, `asat` and `pave`. For `repeatmasker`, `gff-gene` and `cytoband`, the palette reproduces the shipped reference databases; `asat` colours by suprachromosomal family, and `pave` colours early genes cool, late genes warm and the URR grey. For `edta` there is no such convention, so no colours are written and `build` assigns them.
 
-Where a set has many leaves in few colours, the colours file also fills in `legend_group` (the optional 4th column) so the legend collapses. `cytoband` groups by Giemsa stain, turning several hundred bands into nine legend rows; `repeatmasker` groups the five RNA leaves, which share one colour. See [`build`'s legend section](build.md#grouping-the-legend).
+Where a set has many leaves in few colours, the colours file also fills in `legend_group` (the optional 4th column) so the legend collapses. `cytoband` groups by Giemsa stain, turning several hundred bands into nine legend rows; `asat` groups arrays by suprachromosomal family, also nine rows; `repeatmasker` groups the five RNA leaves, which share one colour; `pave` groups the E5 variants into one row. See [`build`'s legend section](build.md#grouping-the-legend).
 
 ## Options
 
@@ -88,6 +88,8 @@ Format-specific options of note:
 | `cytoband` | `--primary-pattern REGEX` | Which seqids carry banding (default `^chr([0-9]+\|X\|Y)$`). |
 | `censat` | `--priority PATH` | Priority file ranking centromeric over rDNA over arm. |
 | `asat` | `--class CLASS` | α-satellite class to include: `active_hor`, `hor`, `dhor`, `mon`. Repeatable; default all four. |
+| `asat` | `--priority PATH` | Priority file ranking `alpha_hor` over `dhor` over `mon`, with the background named explicitly. |
+| `asat` | `--background LABEL` | Gap-fill label named in the stanza and the priority file (default `background`). |
 | `satellite` | `--satellite LABEL` | Leaf label for the bands, e.g. `CEN180` or `aSat`. |
 | `satellite` | `--merge-gap N` | Merge monomers within N bases into one band (default 10). |
 | `satellite` | `--cluster-gap N` | Gap for clustering bands into the centromere core (default 500000). |

--- a/docs/commands/prep-bed.md
+++ b/docs/commands/prep-bed.md
@@ -13,6 +13,7 @@ karyoscope prep-bed fai          --lengths FAI --output BED [OPTIONS]
 karyoscope prep-bed censat       --input FILE --lengths FAI --output BED --hierarchy TSV [OPTIONS]
 karyoscope prep-bed asat         --input FILE --output BED --hierarchy TSV [OPTIONS]
 karyoscope prep-bed satellite    --input FILE --lengths FAI --output BED --hierarchy TSV [OPTIONS]
+karyoscope prep-bed pave         --input FILE --output BED --hierarchy TSV [OPTIONS]
 ```
 
 ## Description
@@ -30,6 +31,7 @@ There is one subcommand **per source format**, not per feature set. Unrelated fo
 | `fai` | samtools `.fai` | `chromosome`: one leaf per sequence |
 | `censat` | CenSat annotation BED | `region`: CenSat features plus `p_arm`/`q_arm` |
 | `satellite` | centromeric satellite monomers (GFF or BED) | `region`: satellite bands plus `p_arm`/`q_arm` |
+| `pave` | PaVE genome records (JSON) | `gene`: one leaf per papillomavirus ORF, plus the URR |
 
 Each subcommand writes its BED (and, where the format implies one, a hierarchy) and prints the matching build-spec stanza. **The stanza goes to stdout and everything else to stderr**, so you can append it straight to a spec:
 
@@ -89,6 +91,10 @@ Format-specific options of note:
 | `satellite` | `--satellite LABEL` | Leaf label for the bands, e.g. `CEN180` or `aSat`. |
 | `satellite` | `--merge-gap N` | Merge monomers within N bases into one band (default 10). |
 | `satellite` | `--cluster-gap N` | Gap for clustering bands into the centromere core (default 500000). |
+| `pave` | `--priority PATH` | Priority file ranking the ORFs in genome order. |
+| `pave` | `--fasta PATH` | Also write the genome sequences the records carry. |
+| `pave` | `--taxonomy PATH` | Also write the ICTV lineage as a hierarchy, for a `type` set. |
+| `pave` | `--background LABEL` | Gap-fill label named in the stanza (default `intergenic`). |
 
 Run `karyoscope prep-bed SUBCOMMAND --help` for the full list.
 
@@ -169,6 +175,20 @@ One whole-length record per sequence, labelled with its own name, in the `.fai`'
 
 Keep non-karyotype sequences out with `build`'s `exclude:`, not by filtering here, so every feature set agrees about what exists.
 
+### `pave`
+
+Reads the JSON that [PaVE](https://pave.niaid.nih.gov/)'s `/api/genome/{id}` endpoint returns — a JSON array of them, a single one, or an object wrapping them under `data`. A summary from the `/api/genome` list endpoint carries no sequence or coordinates and is rejected by name.
+
+Leaves are the ORFs — `E6`, `E7`, `E1`, `E2`, `E5` (as the genus-specific `E5_ALPHA`, `E5_BETA`, `E5_GAMMA`, `E5_DELTA` and `E5_OTHER`), `E10`, `L2`, `L1` — plus the `URR`, grouped `early` and `late`. A feature name with no leaf raises rather than being dropped, which would hand its bases to the gap-fill.
+
+Two kinds of feature are excluded. The spliced transcripts `E1^E4`, `E8^E2` and `E6*` lie wholly inside the ORFs they are spliced from — across PaVE's 224 human reference genomes, 100% of their bases — so under a ranking that prefers the primary ORF they hold no sequence. The `E1BS` and `E2BS` binding motifs are 12–20 bp, shorter than any usable k.
+
+Papillomavirus genomes are circular, and a feature spanning the origin arrives as two locations (`7157..7906` and `1..103`). Both become BED records with the same label. The k-mers that cross the junction are not present in a linear FASTA.
+
+The reading frames overlap, so the set is built in priority mode rather than flattened: 10.2% of bases carry more than one annotated feature, and 1.2% once the spliced transcripts are dropped. `--priority` writes the ranking in genome order, which resolves each observed overlap toward the earlier ORF — `E6` over `E7`, `E7` over `E1`, `E1` over `E2`, `L2` over `L1`, and `E10` over `URR` through `early` outranking it.
+
+A record also carries the genome sequence and the ICTV lineage, so `--fasta` writes the FASTA for `build`'s `sequence:` (bgzip and index it) and `--taxonomy` writes the family → genus → species → type hierarchy for a `type` feature set whose BED comes from `fai`. Taxon names have their spaces replaced with underscores, since hierarchy files are whitespace-separated. The constant `Papillomaviridae` level is dropped.
+
 ## Examples
 
 ```bash
@@ -193,6 +213,11 @@ karyoscope prep-bed satellite --input ColCEN_CEN180.gff3 --lengths ColCEN.fa.gz.
 # A per-array alpha-satellite set from the same CenSat file the region set uses
 karyoscope prep-bed asat --input chm13v2.0.cenSatv2.1.bed \
     --output asat.bed --hierarchy asat.tsv
+
+# A papillomavirus gene set, plus the FASTA and taxonomy from the same records
+karyoscope prep-bed pave --input pave_human_ref.json \
+    --output gene.bed --hierarchy gene.tsv --priority gene.priority.txt \
+    --fasta HPV.fasta --taxonomy type.hierarchy.txt
 
 # Then build from the assembled spec
 karyoscope build --spec build.yaml

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -6,6 +6,7 @@ Complete, runnable recipes for rebuilding KaryoScope databases from published so
 | --- | --- | --- |
 | [human-chm13v2.md](human-chm13v2.md) | `HKS_human_CHM13_v2` | `chromosome`, `region`, `repeat`, `gene` |
 | [arabidopsis-colcen.md](arabidopsis-colcen.md) | `HKS_arabidopsis_ColCEN` | `chromosome`, `region`, `repeat`, `gene` |
+| [hpv-pave.md](hpv-pave.md) | `HKS_hpv_PaVE` | `type`, `gene` |
 
 Each recipe gives the exact download URL for every input, a checksum to verify it, the [`prep-bed`](../commands/prep-bed.md) command that converts it, and the [`build`](../commands/build.md) spec that assembles the result.
 
@@ -38,7 +39,7 @@ This is why every input here is pinned by checksum rather than by name.
 
 ## Supporting files
 
-[`files/`](files/) holds the few inputs that nothing derives, because they encode curation or a naming convention rather than data:
+[`files/`](files/) holds the few files a recipe needs that nothing derives — curation, a naming convention, or a download that has no single URL:
 
 | File | Used by |
 | --- | --- |
@@ -46,9 +47,12 @@ This is why every input here is pinned by checksum rather than by name.
 | `colcen_chromosome.hierarchy.txt` | which Col-CEN sequences are nuclear |
 | `chm13v2_repeat.priority.txt` | the published order in which repeat classes win an overlap |
 | `chm13v2_refseq_to_chr.tsv` | RefSeq accession → chromosome name |
+| `fetch_pave_human_ref.py` | walks PaVE's per-genome API into the one JSON input the HPV recipe converts |
 
 Every other hierarchy and priority file in these recipes is written by `prep-bed` as it converts, so there is nothing to supply.
 
 ## A note on exact reproduction
 
-These recipes rebuild the feature sets, and the BEDs they produce are byte-identical to the ones the shipped databases were built from — with one deliberate exception, described in each recipe: the shipped BEDs label the mitochondrion with a literal `exclude` *label*, a convention that predates `build`'s `exclude:` list. The recipes use `exclude:`. A label claims the sequence for the feature set; `exclude:` leaves it uncovered, so it reads as `none` everywhere.
+Where a recipe rebuilds a shipped database, the BEDs it produces are byte-identical to the ones that database was built from — with one deliberate exception, described in each recipe: the shipped BEDs label the mitochondrion with a literal `exclude` *label*, a convention that predates `build`'s `exclude:` list. The recipes use `exclude:`. A label claims the sequence for the feature set; `exclude:` leaves it uncovered, so it reads as `none` everywhere.
+
+The HPV recipe builds a database that is not shipped, so it pins its inputs and outputs by checksum instead.

--- a/docs/recipes/arabidopsis-colcen.md
+++ b/docs/recipes/arabidopsis-colcen.md
@@ -196,3 +196,4 @@ karyoscope karyotype -i Col-CEN_v1.2=Col-CEN_v1.2.fasta.gz \
 - [`karyoscope prep-bed`](../commands/prep-bed.md)
 - [`karyoscope build`](../commands/build.md)
 - [Recipe: human CHM13v2](human-chm13v2.md)
+- [Recipe: HPV from PaVE](hpv-pave.md)

--- a/docs/recipes/files/fetch_pave_human_ref.py
+++ b/docs/recipes/files/fetch_pave_human_ref.py
@@ -1,0 +1,45 @@
+"""Fetch PaVE's human reference papillomavirus genomes into one JSON array.
+
+PaVE serves one record per genome from ``/api/genome/{id}``, and that record
+carries the sequence, the ORF coordinates and the ICTV lineage. There is no
+bulk endpoint that returns all three, so this walks the reference list and
+writes ``pave_human_ref.json`` — the single input to
+``karyoscope prep-bed pave``.
+
+Records are sorted by locus id and serialised with fixed formatting, so two
+runs against an unchanged database produce byte-identical output.
+
+Usage:
+    python fetch_pave_human_ref.py [OUTPUT]
+"""
+
+import json
+import sys
+import urllib.request
+
+API = "https://pave.niaid.nih.gov/api"
+
+
+def get(url):
+    with urllib.request.urlopen(url, timeout=120) as response:
+        return json.load(response)
+
+
+def main(output="pave_human_ref.json"):
+    listing = get(f"{API}/genome?limit=5000&includeNonRef=false")["data"]
+    ids = sorted(g["locus_id"] for g in listing if "Human" in g["virus_tags"] and g["is_ref"])
+    print(f"{len(ids)} human reference genomes", file=sys.stderr)
+
+    records = []
+    for n, locus in enumerate(ids, 1):
+        records.append(get(f"{API}/genome/{locus}"))
+        if n % 25 == 0 or n == len(ids):
+            print(f"  {n}/{len(ids)}", file=sys.stderr)
+
+    with open(output, "w") as out:
+        json.dump(records, out, indent=1, sort_keys=True)
+    print(f"wrote {output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main(*sys.argv[1:])

--- a/docs/recipes/hpv-pave.md
+++ b/docs/recipes/hpv-pave.md
@@ -28,7 +28,7 @@ The script sorts records by locus id and serialises with fixed formatting, so tw
 
 **PaVE adds genomes.** This checksum pins the database as of 2026-08-07. A mismatch alongside a count other than 224 means the reference set has changed rather than that the download failed; re-pin both.
 
-The list is filtered to `is_ref` human genomes. PaVE also publishes 230 non-reference human genomes — the `nr` putative novel types — which are annotated just as completely but whose species is `Unclassified <Genus>` for all but two, so they enter the taxonomy as one flat bucket per genus. Pass `includeNonRef=true` in the script to include them.
+The list is filtered to `is_ref` human genomes. PaVE also publishes 230 non-reference human genomes — the `nr` putative novel types — which are annotated just as completely but whose species is `Unclassified <Genus>` for all but two, so they enter the taxonomy as one flat bucket per genus. To include them, edit the script in two places: set `includeNonRef=true` in the listing URL and drop the `g["is_ref"]` term from the filter on the next line.
 
 ## 2. `gene`, plus the FASTA and the taxonomy
 

--- a/docs/recipes/hpv-pave.md
+++ b/docs/recipes/hpv-pave.md
@@ -1,0 +1,163 @@
+# Recipe: `HKS_hpv_PaVE`
+
+Build a human papillomavirus database from the [PaVE](https://pave.niaid.nih.gov/) reference genomes: a `type` set naming the HPV type and a `gene` set naming the ORF.
+
+224 genomes totalling 1.68 Mb, mean length 7,514 bp. The build takes about 2 s at `-t 8` and produces a 10.5 MB database.
+
+**Requirements:** `karyoscope`, `samtools`, `hks`, and Python 3 for the download.
+
+One file in [`files/`](files/) is used below — the download script. Every hierarchy, priority and colours file here is written by `prep-bed`.
+
+## What this database answers
+
+Each k-mer of a query gets two labels: which papillomavirus type it came from, and which viral gene. Sequence absent from all 224 genomes reads as `novel`, so a host assembly carrying an integrated virus shows the insert against a `novel` background.
+
+## 1. Genome records
+
+PaVE serves one record per genome from `/api/genome/{id}`, carrying the sequence, the ORF coordinates and the ICTV lineage. There is no bulk endpoint that returns all three, so the download walks the reference list:
+
+```bash
+cp docs/recipes/files/fetch_pave_human_ref.py .
+python3 fetch_pave_human_ref.py
+
+sha256sum pave_human_ref.json
+# 2f808c3bfee41aadc06b274419941aee12a0f797946dca1e748bd317cd90348f   (224 records, 3.9 MB)
+```
+
+The script sorts records by locus id and serialises with fixed formatting, so two runs against an unchanged database produce byte-identical output. Takes about 100 s.
+
+**PaVE adds genomes.** This checksum pins the database as of 2026-08-07. A mismatch alongside a count other than 224 means the reference set has changed rather than that the download failed; re-pin both.
+
+The list is filtered to `is_ref` human genomes. PaVE also publishes 230 non-reference human genomes — the `nr` putative novel types — which are annotated just as completely but whose species is `Unclassified <Genus>` for all but two, so they enter the taxonomy as one flat bucket per genus. Pass `includeNonRef=true` in the script to include them.
+
+## 2. `gene`, plus the FASTA and the taxonomy
+
+One command reads the records three ways:
+
+```bash
+karyoscope prep-bed pave --input pave_human_ref.json \
+    --output hpv_gene.bed --hierarchy hpv_gene.tsv \
+    --priority hpv_gene.priority.txt --colors hpv_gene.colors.tsv \
+    --fasta HPV.fasta --taxonomy hpv_type.hierarchy.txt
+
+sha256sum hpv_gene.bed hpv_gene.tsv hpv_gene.priority.txt hpv_gene.colors.tsv
+# 2a9352acaff21e12aa8390c038eafb54c05eaf6552cc405a25de52c89428759b  hpv_gene.bed   (1,757 rows)
+# 2b5c25b898e03efeea844fa779c76603e7b45c569122d61ded713d207625c6b5  hpv_gene.tsv   (16 edges)
+# c0bfb4780b830781fcfe4cdb9a7c113f2fb88b86c8c56c77e13982ca67304e60  hpv_gene.priority.txt
+# cc9c2df8f4841fc874525c53d1a8b37158fe037a184e6772d6fe0534b6583ec2  hpv_gene.colors.tsv
+```
+
+Leaves are `E6`, `E7`, `E1`, `E2`, the genus-specific `E5_*`, `E10`, `L2`, `L1` and `URR`, grouped `early` and `late`.
+
+Three features PaVE annotates are not in the set. `E1^E4`, `E8^E2` and `E6*` are spliced from the primary ORFs and lie wholly inside them — 100% of their bases across all 224 genomes — so a ranking that prefers the primary ORF leaves them empty. `E1BS` and `E2BS` are 12–20 bp, shorter than any usable k.
+
+The reading frames overlap: 10.2% of bases carry more than one annotated feature, 1.2% once the spliced transcripts are dropped. The set is therefore built in priority mode rather than flattened, and the priority file ranks the ORFs in genome order — which resolves each overlap toward the earlier ORF (`E6` over `E7`, `E7` over `E1`, `E1` over `E2`, `L2` over `L1`, and `E10` over `URR` through `early` outranking it).
+
+1.56% of bases carry no ORF and go to the `intergenic` gap-fill.
+
+## 3. Genome FASTA
+
+`--fasta` above wrote the sequences the records carry. Re-compress with bgzip, which `build` and `samtools` need for random access:
+
+```bash
+bgzip HPV.fasta
+samtools faidx HPV.fasta.gz
+```
+
+Verify by **content**, not by file — bgzip changes the container:
+
+```bash
+zcat HPV.fasta.gz | sha256sum
+# 8bc37f684a209f1045c350b5eb3a96276af1cb082a0a799adfb0b6f8f38d3a2c
+```
+
+Six genomes carry a single IUPAC ambiguity code each (`Y` ×4, `W`, `N`), in HPV142REF, HPV171REF, HPV172REF, HPV175REF, HPV223REF and HPV228REF. Each one invalidates the 31 k-mers spanning it, so 186 positions are unresolvable before smoothing.
+
+**Papillomavirus genomes are circular, and this FASTA is linear.** A feature spanning the origin becomes two BED records with the same label, but the k-mers crossing the junction cannot be represented — about 30 bp per genome.
+
+## 4. `type`
+
+One record per genome, labelled with its own name, derived from the `.fai`:
+
+```bash
+karyoscope prep-bed fai --lengths HPV.fasta.gz.fai --output hpv_type.bed --name type
+
+sha256sum hpv_type.bed hpv_type.hierarchy.txt
+# ddb8573f141c8053c9f9aa37188bd0e3b600af95989d2143e71757166e319a18  hpv_type.bed  (224 rows)
+# 0a08444b08a6ddcd3ba8cc7272994e361127e9bd01e00fe190d37e83c2fda0ae  hpv_type.hierarchy.txt  (280 edges)
+```
+
+The hierarchy is the one `--taxonomy` wrote in step 2: genus → species → type, over 5 genera and 51 species. A `.fai` cannot supply it, but PaVE states it, so it is derived rather than hand-written. The constant `Papillomaviridae` level is dropped, and spaces in taxon names become underscores because hierarchy files are whitespace-separated.
+
+This set needs no priority file. A k-mer shared by several types resolves to their lowest common ancestor, which is the species or genus that contains them.
+
+## 5. Build
+
+```yaml
+# build.yaml
+id: HKS_hpv_PaVE
+version: "1.0.0"
+sequence: HPV.fasta.gz
+kmer:
+  s: 31
+build:
+  threads: 8
+  mem_gigas: 4
+feature_sets:
+  - name: type
+    bed: hpv_type.bed
+    hierarchy: hpv_type.hierarchy.txt
+    background: null            # one record per genome already tiles everything
+  - name: gene
+    bed: hpv_gene.bed
+    hierarchy: hpv_gene.tsv
+    priority: hpv_gene.priority.txt   # the reading frames overlap; genome order wins
+    colors: hpv_gene.colors.tsv
+    background: intergenic
+roles:
+  chromosome_assignment: type
+  region_assignment: gene
+smoothing:
+  recommended_window_bp: 100
+```
+
+```bash
+karyoscope build --spec build.yaml
+karyoscope info HKS_hpv_PaVE
+```
+
+There is no `centromere_detection` role: a papillomavirus genome has no centromere, and `karyoscope centromeres` does not apply to this database.
+
+This recipe has been run end to end from nothing but the script above: `pave_human_ref.json` and all six derived files match the checksums here, and all five index files — the shared base index and one per feature set — come out bit-identical between runs.
+
+## 6. Annotate
+
+```bash
+karyoscope annotate -i sample.fasta.gz --db HKS_hpv_PaVE -o out/ -t 8
+```
+
+Self-annotating the reference genomes gives, on the smoothed output, 99.98% of positions labelled with their own type and 99.99% with their own ORF. No position is assigned to a different type, and 16 of the 224 genomes have any non-exact type call at all — each resolving to the correct species or genus where a close relative shares the sequence.
+
+62 positions across 5 genomes take an adjacent ORF's label. Each one's 31-mer also occurs in another genome where PaVE places the ORF boundary at a different offset in the shared sequence; the index stores one label per distinct k-mer, and the priority file breaks the tie.
+
+## Choosing `k`
+
+`s: 31` sets how much sequence a k-mer must match exactly, which trades type resolution against sensitivity to divergence. Measured over the 224 genomes:
+
+| `k` | k-mers resolving to one type | to a species | to a genus | to the root |
+| --- | --- | --- | --- | --- |
+| 21 | 95.51% | 3.03% | 1.31% | 0.153% |
+| 25 | 97.19% | 2.09% | 0.69% | 0.027% |
+| 31 | 98.41% | 1.25% | 0.33% | 0.001% |
+| 41 | 99.22% | 0.62% | 0.16% | 0.000% |
+
+A divergent isolate matches fewer k-mers exactly at any `k`, and lands on the species or genus rather than the type. Lowering `k` shifts calls from the type toward the clade; raising it does the reverse.
+
+`variable_k` would let one database be queried across that range, but it cannot be combined with priorities, and the `gene` set needs them — so a database offering the sweep would have to carry `type` alone.
+
+## See also
+
+- [`karyoscope prep-bed`](../commands/prep-bed.md)
+- [`karyoscope build`](../commands/build.md)
+- [Recipe: human CHM13v2](human-chm13v2.md)
+- [Recipe: Arabidopsis Col-CEN](arabidopsis-colcen.md)

--- a/docs/recipes/human-chm13v2.md
+++ b/docs/recipes/human-chm13v2.md
@@ -223,3 +223,4 @@ The one difference throughout is `chrM`. The original BEDs gave it a literal `ex
 - [`karyoscope prep-bed`](../commands/prep-bed.md)
 - [`karyoscope build`](../commands/build.md)
 - [Recipe: Arabidopsis Col-CEN](arabidopsis-colcen.md)
+- [Recipe: HPV from PaVE](hpv-pave.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,9 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101"]  # allow `assert` in tests
+# Standalone scripts a reader copies out of a recipe; plain `open` reads better
+# there than importing pathlib for one call.
+"docs/recipes/files/**" = ["PTH123"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/karyoscope/commands/prep_bed.py
+++ b/src/karyoscope/commands/prep_bed.py
@@ -28,6 +28,7 @@ import click
 from karyoscope.core.prep import asat as asat_prep
 from karyoscope.core.prep import cytoband as cytoband_prep
 from karyoscope.core.prep import genes as genes_prep
+from karyoscope.core.prep import pave as pave_prep
 from karyoscope.core.prep import repeats as repeats_prep
 from karyoscope.core.prep import structural as structural_prep
 from karyoscope.core.prep.common import PrepError, PrepResult, SeqidRewriter, render_stanza
@@ -333,6 +334,110 @@ def gff_gene(
         colors=colors,
         name=name,
         feature_type=feature_type,
+        rename=_rewriter(rename_prefix, seqid_map),
+    )
+
+
+@cmd.command("pave")
+@click.option(
+    "--input",
+    "input_path",
+    type=click.Path(**_IN),
+    required=True,
+    help="PaVE genome records: a JSON array of /api/genome/{id} responses (plain or gzipped).",
+)
+@click.option("--output", type=click.Path(**_OUT), required=True, help="Output feature-set BED.")
+@click.option(
+    "--hierarchy",
+    type=click.Path(**_OUT),
+    required=True,
+    help="Output 'child<TAB>parent' hierarchy.",
+)
+@click.option(
+    "--priority",
+    type=click.Path(**_OUT),
+    default=None,
+    help="Also write the tree as a 3-column priority file. The reading frames overlap, "
+    "so a priority-mode build needs this.",
+)
+@click.option(
+    "--colors",
+    type=click.Path(**_OUT),
+    default=None,
+    help="Also write a colours file: early genes cool, late genes warm, URR grey, "
+    "with the E5 variants sharing one legend row.",
+)
+@click.option(
+    "--fasta",
+    type=click.Path(**_OUT),
+    default=None,
+    help="Also write the genome sequences the records carry, for build's `sequence:`. "
+    "bgzip and index the result.",
+)
+@click.option(
+    "--taxonomy",
+    type=click.Path(**_OUT),
+    default=None,
+    help="Also write the ICTV lineage as a hierarchy, for a `type` feature set whose "
+    "BED comes from `prep-bed fai`.",
+)
+@click.option("--name", default="gene", show_default=True, help="Feature-set name in the stanza.")
+@click.option(
+    "--background",
+    default="intergenic",
+    show_default=True,
+    help="Gap-fill label build should use for the bases no ORF covers.",
+)
+@_seqid_options
+@click.option("--force", is_flag=True, help="Overwrite existing output files.")
+def pave(
+    input_path: Path,
+    output: Path,
+    hierarchy: Path,
+    priority: Path | None,
+    colors: Path | None,
+    fasta: Path | None,
+    taxonomy: Path | None,
+    name: str,
+    background: str,
+    rename_prefix: str | None,
+    seqid_map: Path | None,
+    force: bool,
+) -> None:
+    """PaVE genome records -> a papillomavirus `gene` feature set.
+
+    \b
+    Leaves are the ORFs — E6, E7, E1, E2, E5, E10, L2, L1 — plus the URR,
+    grouped early/late as in the standard genome map. The three spliced
+    transcripts (E1^E4, E8^E2, E6*) are dropped because they lie wholly inside
+    the ORFs they are spliced from, and the E1BS/E2BS binding motifs because at
+    12-20 bp they are shorter than any usable k.
+
+    \b
+    A record carries the sequence and the ICTV lineage as well as the
+    coordinates, so --fasta and --taxonomy write the other two files a
+    papillomavirus build needs. Nothing else has to be downloaded.
+
+    \b
+    Example:
+        karyoscope prep-bed pave --input pave_human_ref.json \\
+            --output hpv_gene.bed --hierarchy hpv_gene.tsv \\
+            --priority hpv_gene.priority.txt --fasta HPV.fasta \\
+            --taxonomy hpv_type.hierarchy.txt
+    """
+    _run(
+        pave_prep.from_pave,
+        [output, hierarchy, priority, colors, fasta, taxonomy],
+        force,
+        input_path=input_path,
+        output=output,
+        hierarchy=hierarchy,
+        priority=priority,
+        colors=colors,
+        fasta=fasta,
+        taxonomy=taxonomy,
+        name=name,
+        background=background,
         rename=_rewriter(rename_prefix, seqid_map),
     )
 

--- a/src/karyoscope/core/prep/pave.py
+++ b/src/karyoscope/core/prep/pave.py
@@ -1,0 +1,359 @@
+"""PaVE genome records -> a papillomavirus `gene` set, taxonomy, and the FASTA.
+
+The Papillomavirus Episteme (PaVE) publishes one JSON record per genome from
+``/api/genome/{id}``, and that record carries three things nothing else has to
+be downloaded for: the genome sequence, the ORF coordinates, and the ICTV
+lineage. So this converter writes all three — the `gene` feature set it is named
+for, plus ``--fasta`` and ``--taxonomy`` outputs that would otherwise each need
+a bespoke script. There is no bulk FASTA endpoint that works, so re-deriving
+them from the same records is also what keeps a rebuild reproducible.
+
+Two properties of papillomavirus genomes shape the conversion:
+
+**They are circular.** The URR spans the origin, and PaVE expresses that as two
+locations (``7157..7906`` and ``1..103``). Both become BED records with the same
+label. The k-mers that straddle the junction are not recoverable from a linear
+FASTA and are simply absent — about 30 bp per genome.
+
+**The reading frames overlap.** 10.2% of bases are claimed by more than one
+annotated feature, so the set is built in priority mode rather than flattened.
+Almost all of that overlap is the three *spliced* features, which this converter
+drops: E1^E4, E8^E2 and E6* are 100% contained within E1, E2 and E6 across all
+224 human reference genomes, so under any ranking that prefers the primary ORF
+they would be leaves holding no sequence at all. What remains is 1.2% of bases,
+overlapping in genome order, which is what the emitted priority file encodes.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from itertools import pairwise
+from pathlib import Path
+from typing import Any
+
+from karyoscope.core.prep.common import (
+    ColorRow,
+    Edge,
+    PrepError,
+    PrepResult,
+    Record,
+    SeqidRewriter,
+    open_text,
+    write_bed,
+    write_colors,
+    write_hierarchy,
+)
+
+#: Spliced transcripts, dropped because they are wholly contained in the ORFs
+#: they are spliced from and would otherwise be empty leaves. See the module
+#: docstring.
+SPLICED = frozenset({"E1^E4", "E8^E2", "E6*"})
+
+#: Regulatory binding motifs. At 12-20 bp they are shorter than any usable k,
+#: so a k-mer index can never resolve them; including them would only take
+#: bases away from the ORFs that contain them.
+BINDING_MOTIF = "BindingMotif"
+
+#: PaVE writes one genus-specific E5 per genome plus a bare ``E5`` in one
+#: genome. They are grouped under an interior ``E5`` node, so the bare form is
+#: renamed to keep leaf and node names distinct.
+E5_OTHER = "E5_OTHER"
+
+#: Gene-set tree. Grouping the ORFs into early and late is the standard
+#: papillomavirus genome map, and it gives a k-mer shared by two early genes
+#: somewhere to resolve to other than the root.
+GENE_HIERARCHY: list[Edge] = [
+    ("E6", "early"),
+    ("E7", "early"),
+    ("E1", "early"),
+    ("E2", "early"),
+    ("E5", "early"),
+    ("E10", "early"),
+    ("E5_ALPHA", "E5"),
+    ("E5_BETA", "E5"),
+    ("E5_GAMMA", "E5"),
+    ("E5_DELTA", "E5"),
+    (E5_OTHER, "E5"),
+    ("L2", "late"),
+    ("L1", "late"),
+    ("early", "categorized"),
+    ("late", "categorized"),
+    ("URR", "categorized"),
+]
+
+#: Priorities, in genome order, which resolves every observed overlap the way
+#: the earlier ORF wants: E1 over E2, E7 over E1, E6 over E7, L2 over L1, and
+#: (through ``early`` beating ``URR``) E10 over URR. Siblings are distinct, as
+#: HKS requires; the background is added by :func:`_priority_rows`.
+GENE_PRIORITY: dict[str, int] = {
+    "early": 1,
+    "late": 2,
+    "URR": 3,
+    "E6": 1,
+    "E7": 2,
+    "E1": 3,
+    "E2": 4,
+    "E5": 5,
+    "E10": 6,
+    "E5_ALPHA": 1,
+    "E5_BETA": 2,
+    "E5_GAMMA": 3,
+    "E5_DELTA": 4,
+    E5_OTHER: 5,
+    "L2": 1,
+    "L1": 2,
+}
+
+#: Early genes cool, late genes warm, regulatory grey — the convention every
+#: published papillomavirus genome map uses. The five E5 variants share one
+#: colour and one legend row, since only one occurs in any given genome.
+GENE_COLORS: dict[str, tuple[str, str]] = {
+    "E6": ("#1F77B4", ""),
+    "E7": ("#4C9BD4", ""),
+    "E1": ("#2E7D32", ""),
+    "E2": ("#66A61E", ""),
+    "E10": ("#17BECF", ""),
+    "E5_ALPHA": ("#9467BD", "E5"),
+    "E5_BETA": ("#9467BD", "E5"),
+    "E5_GAMMA": ("#9467BD", "E5"),
+    "E5_DELTA": ("#9467BD", "E5"),
+    E5_OTHER: ("#9467BD", "E5"),
+    "L2": ("#D62728", ""),
+    "L1": ("#FF7F0E", ""),
+    "URR": ("#808080", ""),
+}
+
+#: Every genome is a Papillomaviridae, so that level would be a single child of
+#: the root carrying no information. The genus becomes the root's child instead.
+FAMILY = "Papillomaviridae"
+
+_FASTA_WRAP = 60
+
+
+def sanitise(label: str) -> str:
+    """Make a taxon name usable as a feature label.
+
+    Hierarchy and priority files are whitespace-separated, so a species like
+    ``Alphapapillomavirus 9`` would parse as two columns and be silently
+    truncated. Collapsing runs of whitespace to a single underscore is enough:
+    PaVE taxon names contain no other separator.
+    """
+    return "_".join(label.split())
+
+
+def load_records(path: Path) -> list[dict[str, Any]]:
+    """Read the PaVE genome records.
+
+    Accepts a JSON array of ``/api/genome/{id}`` responses, a single such
+    response, or an object wrapping them under ``data``, so the recipe can
+    concatenate downloads the obvious way without a reshaping step.
+    """
+    with open_text(path) as fh:
+        try:
+            payload = json.load(fh)
+        except json.JSONDecodeError as e:
+            raise PrepError(f"{path}: not valid JSON: {e}") from e
+
+    if isinstance(payload, dict):
+        payload = payload.get("data", payload)
+    records = payload if isinstance(payload, list) else [payload]
+
+    out: list[dict[str, Any]] = []
+    for i, rec in enumerate(records):
+        if not isinstance(rec, dict) or "itemSequence" not in rec:
+            raise PrepError(
+                f"{path}: entry {i} is not a PaVE genome record (no 'itemSequence'). "
+                "These come from /api/genome/{id}; the /api/genome list endpoint "
+                "returns summaries, which carry no sequence or coordinates."
+            )
+        out.append(rec)
+    if not out:
+        raise PrepError(f"{path}: no genome records found")
+    return out
+
+
+def genome_id(record: dict[str, Any]) -> str:
+    """The record's PaVE locus id, used as the sequence name."""
+    for key in ("genome", "item"):
+        value = (record.get(key) or {}).get("pave_id")
+        if value:
+            return str(value)
+    raise PrepError("a genome record has no pave_id")
+
+
+def lineage(record: dict[str, Any]) -> list[str]:
+    """Taxon names from the record, most specific first, family dropped."""
+    names = [str(t["name"]) for t in record.get("virus_lineage") or [] if t.get("name")]
+    return [n for n in names if n != FAMILY]
+
+
+def _gene_label(feature: dict[str, Any]) -> str | None:
+    """Leaf label for a PaVE feature, or ``None`` if it is not part of the set."""
+    name = str(feature.get("featureName") or "")
+    if not name or feature.get("featureType") == BINDING_MOTIF or name in SPLICED:
+        return None
+    return E5_OTHER if name == "E5" else name
+
+
+def _priority_rows(background: str | None) -> list[tuple[str, int, str]]:
+    """The tree as ``(child, priority, parent)``, with the gap-fill leaf added.
+
+    ``build`` attaches the background to the root itself, so the hierarchy file
+    does not name it — but the priority file has to, or it would default to the
+    best priority and outrank every real ORF.
+    """
+    rows = [(child, GENE_PRIORITY[child], parent) for child, parent in GENE_HIERARCHY]
+    if background is not None:
+        worst = max(GENE_PRIORITY[c] for c, p in GENE_HIERARCHY if p == "categorized")
+        rows.append((background, worst + 1, "categorized"))
+    return rows
+
+
+def write_fasta(path: Path, records: list[dict[str, Any]], rename: SeqidRewriter) -> int:
+    """Write the genome sequences carried in the records, returning total bases."""
+    total = 0
+    with path.open("w") as out:
+        for record in records:
+            seqid = rename(genome_id(record))
+            sequence = str((record.get("itemSequence") or {}).get("sequence") or "").upper()
+            if not sequence:
+                raise PrepError(f"{seqid}: record carries no sequence")
+            description = str((record.get("genome") or {}).get("description") or "").strip()
+            out.write(f">{seqid} {description}\n" if description else f">{seqid}\n")
+            for i in range(0, len(sequence), _FASTA_WRAP):
+                out.write(sequence[i : i + _FASTA_WRAP] + "\n")
+            total += len(sequence)
+    return total
+
+
+def write_taxonomy(path: Path, records: list[dict[str, Any]], rename: SeqidRewriter) -> int:
+    """Write the ICTV lineage as a hierarchy for the `type` feature set.
+
+    A ``.fai`` cannot supply this — it is exactly the curation `prep-bed fai`
+    declines to invent — but PaVE states it, so it is derived rather than
+    hand-written.
+    """
+    edges: list[Edge] = []
+    seen: set[Edge] = set()
+    for record in records:
+        names = [sanitise(n) for n in lineage(record)]
+        if not names:
+            raise PrepError(f"{genome_id(record)}: record has no virus_lineage")
+        # The most specific name is the genome itself; use the sequence name so
+        # the leaf matches the `type` BED that `prep-bed fai` writes.
+        names[0] = rename(genome_id(record))
+        chain = [*names, "categorized"]
+        for child, parent in pairwise(chain):
+            edge = (child, parent)
+            if edge not in seen:
+                seen.add(edge)
+                edges.append(edge)
+    return write_hierarchy(path, edges)
+
+
+def from_pave(
+    *,
+    input_path: Path,
+    output: Path,
+    hierarchy: Path,
+    priority: Path | None = None,
+    colors: Path | None = None,
+    fasta: Path | None = None,
+    taxonomy: Path | None = None,
+    name: str = "gene",
+    background: str = "intergenic",
+    rename: SeqidRewriter | None = None,
+) -> PrepResult:
+    """Convert PaVE genome records into a papillomavirus `gene` feature set."""
+    rename = rename or SeqidRewriter()
+    records = load_records(input_path)
+
+    bed: list[Record] = []
+    per_label: defaultdict[str, int] = defaultdict(int)
+    dropped: defaultdict[str, int] = defaultdict(int)
+    covered = 0
+    total_bases = 0
+
+    for record in records:
+        seqid = rename(genome_id(record))
+        length = int((record.get("itemSequence") or {}).get("length") or 0)
+        if length <= 0:
+            raise PrepError(f"{seqid}: record has no sequence length")
+        total_bases += length
+        claimed: set[int] = set()
+
+        for feature in record.get("features") or []:
+            label = _gene_label(feature)
+            if label is None:
+                dropped[str(feature.get("featureName") or "?")] += 1
+                continue
+            if label not in GENE_PRIORITY:
+                raise PrepError(
+                    f"{seqid}: feature {label!r} has no leaf in the papillomavirus gene "
+                    "tree. PaVE added a feature name this converter does not know; it "
+                    "needs a leaf, a priority and a colour before the set can be built."
+                )
+            for location in feature.get("featureLocations") or []:
+                # PaVE is 1-based inclusive; BED is 0-based half-open. A feature
+                # spanning the origin of a circular genome arrives as two
+                # locations and becomes two records with the same label.
+                start = int(location["start"]) - 1
+                end = min(int(location["end"]), length)
+                if end <= start:
+                    continue
+                bed.append((seqid, start, end, label))
+                per_label[label] += end - start
+                claimed.update(range(start, end))
+        covered += len(claimed)
+
+    n_records = write_bed(output, bed)
+    n_edges = write_hierarchy(hierarchy, GENE_HIERARCHY)
+
+    n_priority = 0
+    if priority is not None:
+        rows = _priority_rows(background)
+        with priority.open("w") as out:
+            for child, value, parent in rows:
+                out.write(f"{child}\t{value}\t{parent}\n")
+        n_priority = len(rows)
+
+    n_colors = 0
+    if colors is not None:
+        used = [leaf for leaf, _p in GENE_HIERARCHY if leaf in GENE_COLORS]
+        rows_c: list[ColorRow] = [(leaf, *GENE_COLORS[leaf]) for leaf in used]
+        rows_c.append((background, "#C7C7C7", ""))
+        n_colors = write_colors(colors, name, rows_c)
+
+    notes = [
+        f"{len(records)} genome(s), {total_bases:,} bp; "
+        f"{total_bases - covered:,} bp ({100 * (total_bases - covered) / total_bases:.2f}%) "
+        f"uncovered and left to the '{background}' gap-fill"
+    ]
+    if dropped:
+        shown = ", ".join(f"{k} x{v}" for k, v in sorted(dropped.items()))
+        notes.append(f"dropped spliced transcripts and binding motifs: {shown}")
+    notes.append(
+        "leaf coverage: " + ", ".join(f"{k} {v:,} bp" for k, v in sorted(per_label.items()))
+    )
+
+    if fasta is not None:
+        written = write_fasta(fasta, records, rename)
+        notes.append(f"wrote {fasta} ({written:,} bp) — bgzip and index it for build's `sequence:`")
+    if taxonomy is not None:
+        n_taxa = write_taxonomy(taxonomy, records, rename)
+        notes.append(f"wrote {taxonomy} ({n_taxa:,} edges) — the hierarchy for the `type` set")
+
+    return PrepResult(
+        name=name,
+        bed=output,
+        n_records=n_records,
+        background=background,
+        hierarchy=hierarchy,
+        n_edges=n_edges,
+        priority=priority,
+        n_priority=n_priority,
+        colors=colors,
+        n_colors=n_colors,
+        notes=notes,
+    )

--- a/tests/test_prep_pave.py
+++ b/tests/test_prep_pave.py
@@ -1,0 +1,247 @@
+"""``prep-bed pave`` — a papillomavirus `gene` set from PaVE genome records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from karyoscope.core.prep import pave
+from karyoscope.core.prep.common import PrepError, SeqidRewriter
+
+
+def feature(name, locations, ftype="CDS"):
+    return {
+        "featureName": name,
+        "featureType": ftype,
+        "featureIsSpliced": len(locations) > 1,
+        "featureLocations": [{"start": s, "end": e} for s, e in locations],
+    }
+
+
+def genome(pave_id, species, genus, sequence, features):
+    return {
+        "genome": {"pave_id": pave_id, "description": f"{pave_id}, complete genome"},
+        "itemSequence": {"sequence": sequence, "length": len(sequence)},
+        "virus_lineage": [
+            {"name": pave_id},
+            {"name": species},
+            {"name": genus},
+            {"name": "Papillomaviridae"},
+        ],
+        "features": features,
+    }
+
+
+#: Two genomes exercising the cases that matter: a spliced transcript nested in
+#: its parent ORF, a binding motif, a URR spanning the origin, an E1/E2 overlap,
+#: a bare ``E5``, and a gap no ORF covers.
+RECORDS = [
+    genome(
+        "HPV16REF",
+        "Alphapapillomavirus 9",
+        "Alphapapillomavirus",
+        "ACGT" * 50,  # 200 bp
+        [
+            feature("E2BS", [(1, 12)], ftype="BindingMotif"),
+            feature("E6", [(11, 40)]),
+            feature("E6*", [(11, 20), (30, 40)]),  # nested in E6
+            feature("E7", [(38, 60)]),  # overlaps E6 by 3
+            feature("E1", [(60, 120)]),
+            feature("E1^E4", [(60, 70), (100, 120)]),  # nested in E1
+            feature("E2", [(115, 150)]),  # overlaps E1 by 6
+            feature("L2", [(155, 175)]),  # leaves 150..155 uncovered
+            feature("L1", [(175, 190)]),
+            feature("URR", [(190, 200), (1, 10)]),  # spans the origin
+        ],
+    ),
+    genome(
+        "HPV6REF",
+        "Alphapapillomavirus 10",
+        "Alphapapillomavirus",
+        "TTGC" * 25,  # 100 bp
+        [
+            feature("E5", [(1, 30)]),  # the bare form
+            feature("E5_ALPHA", [(40, 60)]),
+            feature("URR", [(60, 100)]),
+        ],
+    ),
+]
+
+
+@pytest.fixture
+def records_json(tmp_path):
+    p = tmp_path / "pave.json"
+    p.write_text(json.dumps(RECORDS))
+    return p
+
+
+def run(records_json, tmp_path, **kw):
+    out, hier = tmp_path / "gene.bed", tmp_path / "gene.tsv"
+    result = pave.from_pave(input_path=records_json, output=out, hierarchy=hier, **kw)
+    records = [line.split("\t") for line in out.read_text().splitlines()]
+    edges = dict(line.split("\t") for line in hier.read_text().splitlines())
+    return result, records, edges
+
+
+def test_spliced_transcripts_and_binding_motifs_are_dropped(records_json, tmp_path):
+    """They are wholly nested in their parent ORF / shorter than any usable k."""
+    _result, records, _edges = run(records_json, tmp_path)
+    labels = {r[3] for r in records}
+    assert not labels & {"E1^E4", "E8^E2", "E6*", "E2BS", "E1BS"}
+    assert {"E6", "E7", "E1", "E2", "L2", "L1", "URR"} <= labels
+
+
+def test_origin_spanning_feature_becomes_two_records(records_json, tmp_path):
+    """A circular genome's URR arrives as two locations and stays two intervals."""
+    _result, records, _edges = run(records_json, tmp_path)
+    urr = [r for r in records if r[0] == "HPV16REF" and r[3] == "URR"]
+    assert sorted((int(r[1]), int(r[2])) for r in urr) == [(0, 10), (189, 200)]
+
+
+def test_coordinates_convert_to_bed_half_open(records_json, tmp_path):
+    """PaVE is 1-based inclusive; BED is 0-based half-open."""
+    _result, records, _edges = run(records_json, tmp_path)
+    e6 = next(r for r in records if r[0] == "HPV16REF" and r[3] == "E6")
+    assert (int(e6[1]), int(e6[2])) == (10, 40)
+
+
+def test_overlaps_are_kept_for_priority_to_resolve(records_json, tmp_path):
+    """The set is built in priority mode, so overlapping ORFs are not flattened."""
+    _result, records, _edges = run(records_json, tmp_path)
+    e1 = next(r for r in records if r[0] == "HPV16REF" and r[3] == "E1")
+    e2 = next(r for r in records if r[0] == "HPV16REF" and r[3] == "E2")
+    assert int(e2[1]) < int(e1[2])  # they still overlap
+
+
+def test_bare_e5_is_renamed_so_leaf_and_node_names_stay_distinct(records_json, tmp_path):
+    _result, records, edges = run(records_json, tmp_path)
+    assert any(r[3] == pave.E5_OTHER for r in records)
+    assert not any(r[3] == "E5" for r in records)
+    assert edges[pave.E5_OTHER] == "E5"  # E5 is the interior node
+    assert edges["E5"] == "early"
+
+
+def test_hierarchy_groups_early_and_late(records_json, tmp_path):
+    _result, _records, edges = run(records_json, tmp_path)
+    assert edges["E6"] == edges["E1"] == "early"
+    assert edges["L1"] == edges["L2"] == "late"
+    assert edges["early"] == edges["late"] == edges["URR"] == "categorized"
+
+
+def test_priority_file_names_every_node_including_the_background(records_json, tmp_path):
+    """`build` rejects a priority file with a gap, and the gap-fill leaf is the
+    one the hierarchy file does not carry."""
+    prio = tmp_path / "gene.priority.txt"
+    result, _records, edges = run(records_json, tmp_path, priority=prio)
+    rows = [line.split("\t") for line in prio.read_text().splitlines()]
+    named = {r[0] for r in rows}
+    assert named == set(edges) | {"intergenic"}
+    assert result.n_priority == len(rows)
+    values = {r[0]: int(r[1]) for r in rows}
+    # Genome order: the earlier ORF wins every overlap it takes part in.
+    assert values["E6"] < values["E7"] < values["E1"] < values["E2"]
+    assert values["L2"] < values["L1"]
+    assert values["early"] < values["late"] < values["URR"] < values["intergenic"]
+
+
+def test_siblings_have_distinct_priorities(records_json, tmp_path):
+    """HKS requires siblings all-equal or all-distinct; ties would resolve to
+    the parent instead of naming a gene."""
+    prio = tmp_path / "gene.priority.txt"
+    run(records_json, tmp_path, priority=prio)
+    rows = [line.split("\t") for line in prio.read_text().splitlines()]
+    by_parent: dict[str, list[int]] = {}
+    for _child, value, parent in rows:
+        by_parent.setdefault(parent, []).append(int(value))
+    for parent, values in by_parent.items():
+        assert len(values) == len(set(values)), f"tied siblings under {parent}"
+
+
+def test_taxonomy_hierarchy_drops_the_constant_family_level(records_json, tmp_path):
+    tax = tmp_path / "type.hierarchy.txt"
+    run(records_json, tmp_path, taxonomy=tax)
+    edges = dict(line.split("\t") for line in tax.read_text().splitlines())
+    assert "Papillomaviridae" not in edges  # a single child of the root says nothing
+    assert edges["HPV16REF"] == "Alphapapillomavirus_9"
+    assert edges["Alphapapillomavirus_9"] == "Alphapapillomavirus"
+    assert edges["Alphapapillomavirus"] == "categorized"
+
+
+def test_taxon_names_lose_their_spaces(records_json, tmp_path):
+    """Hierarchy files are whitespace-separated, so 'Alphapapillomavirus 9'
+    would parse as two columns and be silently truncated."""
+    tax = tmp_path / "type.hierarchy.txt"
+    run(records_json, tmp_path, taxonomy=tax)
+    for line in tax.read_text().splitlines():
+        assert len(line.split()) == 2
+
+
+def test_fasta_carries_the_sequences_and_matches_the_bed_seqids(records_json, tmp_path):
+    fasta = tmp_path / "hpv.fasta"
+    _result, records, _edges = run(records_json, tmp_path, fasta=fasta)
+    names = [ln[1:].split()[0] for ln in fasta.read_text().splitlines() if ln.startswith(">")]
+    assert names == ["HPV16REF", "HPV6REF"]
+    assert {r[0] for r in records} <= set(names)
+    body = "".join(ln for ln in fasta.read_text().splitlines() if not ln.startswith(">"))
+    assert len(body) == 300  # 200 + 100
+
+
+def test_uncovered_bases_are_reported_not_filled(records_json, tmp_path):
+    """`build` owns the gap-fill; the converter only names the label."""
+    result, records, _edges = run(records_json, tmp_path)
+    assert result.background == "intergenic"
+    assert not any(r[3] == "intergenic" for r in records)
+    assert any("uncovered" in note for note in result.notes)
+
+
+def test_seqid_rewriting_reaches_bed_fasta_and_taxonomy(records_json, tmp_path):
+    fasta, tax = tmp_path / "hpv.fasta", tmp_path / "type.hierarchy.txt"
+    _result, records, _edges = run(
+        records_json,
+        tmp_path,
+        fasta=fasta,
+        taxonomy=tax,
+        rename=SeqidRewriter(table={"HPV16REF": "HPV16"}),
+    )
+    assert "HPV16" in {r[0] for r in records}
+    assert "HPV16REF" not in {r[0] for r in records}
+    assert ">HPV16 " in fasta.read_text()
+    assert "HPV16\tAlphapapillomavirus_9" in tax.read_text()
+
+
+def test_unknown_feature_name_is_an_error_not_a_silent_drop(tmp_path):
+    """A new PaVE feature needs a leaf, a priority and a colour before it can be
+    built; dropping it would quietly hand its bases to the gap-fill."""
+    rec = genome("HPVxREF", "Sp 1", "Alphapapillomavirus", "ACGT" * 10, [feature("E99", [(1, 20)])])
+    p = tmp_path / "pave.json"
+    p.write_text(json.dumps([rec]))
+    with pytest.raises(PrepError, match="E99"):
+        run(p, tmp_path)
+
+
+def test_summary_endpoint_records_are_rejected_with_a_usable_message(tmp_path):
+    """/api/genome returns summaries with no sequence — a plausible mistake."""
+    p = tmp_path / "pave.json"
+    p.write_text(json.dumps({"total": 1, "data": [{"locus_id": "HPV16REF", "regions": ["E6"]}]}))
+    with pytest.raises(PrepError, match="itemSequence"):
+        run(p, tmp_path)
+
+
+def test_a_single_record_is_accepted(tmp_path):
+    """`/api/genome/{id}` returns one object, not a list."""
+    p = tmp_path / "pave.json"
+    p.write_text(json.dumps(RECORDS[0]))
+    _result, records, _edges = run(p, tmp_path)
+    assert {r[0] for r in records} == {"HPV16REF"}
+
+
+def test_colors_group_the_e5_variants_into_one_legend_row(records_json, tmp_path):
+    colors = tmp_path / "gene.colors.tsv"
+    run(records_json, tmp_path, colors=colors)
+    rows = [ln.split("\t") for ln in colors.read_text().splitlines()[1:]]
+    groups = {r[1]: r[3] for r in rows}
+    assert groups["E5_ALPHA"] == groups["E5_BETA"] == "E5"
+    assert groups["E6"] == ""
+    hexes = {r[1]: r[2] for r in rows}
+    assert hexes["E5_ALPHA"] == hexes["E5_BETA"]  # one colour, so one legend row


### PR DESCRIPTION
Adds `karyoscope prep-bed pave`, which reads PaVE genome records (JSON) and produces a `gene` feature set — one leaf per papillomavirus ORF plus the URR — along with optional FASTA, ICTV-taxonomy hierarchy (for a `type` set via `prep-bed fai`), ORF-order priority file, and a colours file (early genes cool, late genes warm, URR grey, E5 variants sharing one legend row).

`docs/recipes/hpv-pave.md` builds `HKS_hpv_PaVE` end to end from PaVE's 224 human reference papillomavirus genomes, with a checksum-pinned download via the bundled `fetch_pave_human_ref.py` (stdlib-only).

The final commit is a docs pass: README coverage of the new converter and recipe, prep-bed page colours/options updates, a two-edit correction to the recipe's non-reference-genome instructions, and the measurement-hardware attribution for the README's runtime figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)