### PR TITLE
ci: build hks in the integration job so its gated tests actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,15 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install C++ build prerequisites (Linux)
+      - name: Install C++ build prerequisites and external tools (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev
+        # samtools: `build` runs `samtools faidx` when the genome has no .fai.
+        # tabix (package) ships bgzip + tabix; seqtk: telomere detection.
+        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev samtools tabix seqtk
+
+      - name: Install external tools (macOS)
+        if: runner.os == 'macOS'
+        run: brew install samtools seqtk
 
       # macOS Xcode CLT ships zlib; Apple Clang supports C++20 (std::span etc.)
       # in Xcode 15+. macos-latest currently provides Xcode 15+, so no extra

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,11 @@ jobs:
         run: pytest --cov=karyoscope --cov-report=term-missing
 
   # ----------------------------------------------------------------------
-  # Build the C++ get_featureIDs binary and run integration tests against
-  # it. Kept as a separate job from the unit test matrix so:
+  # Build the C++ get_featureIDs binary and the hks binary, then run the
+  # test suite with every external binary present — the unit pass (so the
+  # tests the matrix above skips for a missing tool actually execute) and
+  # the integration pass. Kept as a separate job from the unit test matrix
+  # so:
   #   1) A failing C++ build doesn't cascade into 8 redundant unit-test
   #      failures.
   #   2) We only need to build once per OS — Python version doesn't
@@ -90,6 +93,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+
+    env:
+      # The hks commit this job builds and tests against — upstream master at
+      # version 0.4.0, the minimum annotate accepts. Bump deliberately: change
+      # the sha, and the binary cache re-keys itself.
+      HKS_REF: 04bbc5260e37ff8874ffd13f4dfe77a52fedd331
 
     steps:
       - uses: actions/checkout@v4
@@ -122,10 +131,52 @@ jobs:
           ls -la native/get_featureIDs/build/
           ./native/get_featureIDs/build/get_featureIDs --help
 
+      # ------------------------------------------------------------------
+      # hks. Without it the six end-to-end `karyoscope build` tests
+      # (gated on `shutil.which("hks")`) silently skip on every runner, so
+      # a regression in core/build.py would pass CI. The binary is cached
+      # by (OS, HKS_REF); a cache hit skips the Rust build entirely.
+      # ------------------------------------------------------------------
+      - name: Restore cached hks binary
+        id: hks-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/hks-bin
+          key: hks-${{ runner.os }}-${{ runner.arch }}-${{ env.HKS_REF }}
+
+      - name: Check out HKS
+        if: steps.hks-cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: jnalanko/HKS
+          ref: ${{ env.HKS_REF }}
+          path: hks-src
+          submodules: recursive
+
+      - name: Build hks
+        if: steps.hks-cache.outputs.cache-hit != 'true'
+        run: |
+          cargo build --release --manifest-path hks-src/Cargo.toml
+          mkdir -p ~/hks-bin
+          cp hks-src/target/release/hks ~/hks-bin/
+
+      - name: Put hks on PATH and verify it
+        run: |
+          echo "$HOME/hks-bin" >> "$GITHUB_PATH"
+          ~/hks-bin/hks 2>&1 | grep "Running hks version" || true
+          test -x ~/hks-bin/hks
+
       - name: Install KaryoScope (for integration tests)
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
+
+      # The default pass again, this time with every external binary present
+      # (get_featureIDs and hks), so the tests the unit matrix skips for a
+      # missing tool actually execute — most importantly the six
+      # `karyoscope build` end-to-end tests.
+      - name: Run unit tests with all binaries present
+        run: pytest -v
 
       - name: Run integration tests
         run: pytest -m integration -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CI now builds `hks` and runs the tests that need it.** The six end-to-end
+  `karyoscope build` tests are gated on `hks` being on `PATH`, and no CI job
+  provided one, so they silently skipped on every runner — a regression in the
+  build pipeline would have passed CI. The integration job now builds `hks`
+  from a pinned upstream commit (cached by OS and commit, so a warm run adds
+  seconds) and runs the default test pass with every external binary present,
+  in addition to the integration pass.
+
 - **BAM/CRAM conversion no longer depends on samtools' default flag filter.**
   The `samtools fasta` invocation now states `-F 0x900 -N` explicitly.
   - `-F 0x900` (secondary + supplementary excluded) was already the samtools


### PR DESCRIPTION
Closes the audit's top remaining test finding: the six end-to-end `karyoscope build` tests are gated on `shutil.which("hks")`, and CI never provided the binary, so they silently skipped on every runner — a regression in `core/build.py` would have passed CI.

The `cpp_build_and_integration` job now:
- builds `hks` from a **pinned upstream commit** (`jnalanko/HKS` master at 0.4.0 — the exact commit verified byte-identical against the fork binary and the minimum `annotate` accepts), with submodules;
- caches the built binary by (OS, arch, commit), so warm runs skip the Rust build entirely (cold build is ~4 min; the pin comment documents how to bump);
- verifies the binary is on `PATH` before testing;
- runs the **default test pass with every external binary present** (this is what un-skips the hks-gated build tests, since they are `skipif`-gated rather than integration-marked), then the integration pass as before.

The unit-test matrix is untouched — Python-only contributors stay unblocked, per the job's existing design note.

This run's own "C++ build + integration tests" jobs demonstrate the change; check their logs for the `Run unit tests with all binaries present` step executing `test_build_core.py` without skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)