### PR TITLE
Audit round 2: smooth pool-path tests, one byte formatter, resolve_database relocation

### DIFF
--- a/src/karyoscope/commands/bin_cmd.py
+++ b/src/karyoscope/commands/bin_cmd.py
@@ -30,13 +30,13 @@ from pathlib import Path
 import click
 
 from karyoscope import paths
-from karyoscope.core.annotate import resolve_database
 from karyoscope.core.bin import bin_features, leaves_for
 from karyoscope.core.io.hierarchy import parse_hierarchy
 from karyoscope.exceptions import (
     BinError,
     KaryoscopeError,
 )
+from karyoscope.installed import resolve_database
 from karyoscope.manifest import validate_database_layout
 
 logger = logging.getLogger(__name__)

--- a/src/karyoscope/commands/download.py
+++ b/src/karyoscope/commands/download.py
@@ -36,7 +36,13 @@ from karyoscope.exceptions import (
 
 
 def _format_size_gb(gb: float) -> str:
-    """Render a size in GB with one decimal."""
+    """Render a size in GB with one decimal.
+
+    Deliberately not :func:`karyoscope.diskspace.format_bytes`: registry
+    entries declare their sizes in GB, and the listing keeps every row in
+    that one unit so entries can be compared down a column (format_bytes
+    would render a small database in MB).
+    """
     return f"{gb:.1f} GB"
 
 

--- a/src/karyoscope/commands/info.py
+++ b/src/karyoscope/commands/info.py
@@ -37,6 +37,7 @@ from karyoscope.core.io.hierarchy import (
     parse_hierarchy,
     validate_hierarchy,
 )
+from karyoscope.diskspace import format_bytes
 from karyoscope.exceptions import (
     DatabaseLayoutError,
     DatabaseNotFoundError,
@@ -53,15 +54,6 @@ logger = logging.getLogger(__name__)
 
 
 # --- formatting helpers ----------------------------------------------------
-
-
-def _format_size(num_bytes: float) -> str:
-    """Format a byte count using SI-style units (KB, MB, GB)."""
-    for unit in ("B", "KB", "MB", "GB", "TB"):
-        if num_bytes < 1024.0 or unit == "TB":
-            return f"{num_bytes:.1f} {unit}"
-        num_bytes /= 1024.0
-    return f"{num_bytes:.1f} TB"  # pragma: no cover (unreachable)
 
 
 def _dir_size(path: Path) -> int:
@@ -99,13 +91,13 @@ def _list_installed(db_root: Path) -> None:
             "installed.json (perhaps unpacked manually):"
         )
         for db in loose:
-            click.echo(f"  {db.name}  ({_format_size(_dir_size(db))})")
+            click.echo(f"  {db.name}  ({format_bytes(_dir_size(db))})")
         return
 
     click.echo(f"\nInstalled databases ({len(state.databases)}):")
     for db_id, rec in sorted(state.databases.items()):
         db_dir = db_root / rec.directory
-        size = _format_size(_dir_size(db_dir)) if db_dir.is_dir() else "missing"
+        size = format_bytes(_dir_size(db_dir)) if db_dir.is_dir() else "missing"
         click.echo(f"  {db_id}")
         click.echo(f"    Version:   {rec.version}")
         click.echo(f"    Installed: {rec.installed_at}")
@@ -147,7 +139,7 @@ def _print_manifest_summary(manifest: Manifest, db_dir: Path, size_line: str | N
         for k, v in sorted(manifest.smoothing.items()):
             click.echo(f"  Smoothing ({k}): {v}")
     if size_line is None:
-        click.echo(f"  Size on disk:           {_format_size(_dir_size(db_dir))}")
+        click.echo(f"  Size on disk:           {format_bytes(_dir_size(db_dir))}")
     else:
         click.echo(size_line)
 
@@ -331,7 +323,7 @@ def _stage_archive(path: Path, staging: Path) -> tuple[set[str], int, int]:
 
 def _show_archive(path: Path) -> None:
     """Validate a database archive's layout without unpacking it."""
-    click.echo(f"  Type: database archive ({_format_size(path.stat().st_size)})")
+    click.echo(f"  Type: database archive ({format_bytes(path.stat().st_size)})")
 
     with tempfile.TemporaryDirectory(prefix="karyoscope-info-") as tmp:
         staging = Path(tmp)
@@ -355,7 +347,7 @@ def _show_archive(path: Path) -> None:
         root_name = next(iter(top_level))
         root = staging / root_name
         click.echo(f"  Top-level directory: {root_name}")
-        click.echo(f"  Contents: {n_files} files, {_format_size(total_bytes)} extracted")
+        click.echo(f"  Contents: {n_files} files, {format_bytes(total_bytes)} extracted")
 
         if not (root / "manifest.yaml").is_file():
             click.echo(f"  Layout valid: NO (no manifest.yaml in {root_name}/)")
@@ -379,7 +371,7 @@ def _show_archive(path: Path) -> None:
         _print_manifest_summary(
             manifest,
             root,
-            size_line=f"  Size extracted:         {_format_size(total_bytes)}",
+            size_line=f"  Size extracted:         {format_bytes(total_bytes)}",
         )
         _print_hierarchy_summary(manifest, root, report_colors=False)
 
@@ -418,21 +410,21 @@ def _show_path(path: Path) -> None:
                 manifest = validate_database_layout(path)
             except (ManifestError, DatabaseLayoutError) as e:
                 click.echo(f"  Layout valid: NO ({e})")
-                click.echo(f"  Size on disk: {_format_size(_dir_size(path))}")
+                click.echo(f"  Size on disk: {format_bytes(_dir_size(path))}")
                 return
             click.echo(f"  Database id:  {manifest.id}")
             _print_manifest_summary(manifest, path)
             _print_hierarchy_summary(manifest, path)
         else:
             click.echo("  Type: directory")
-            click.echo(f"  Size: {_format_size(_dir_size(path))}")
+            click.echo(f"  Size: {format_bytes(_dir_size(path))}")
         return
 
     if path.is_file():
         if _looks_like_archive(path):
             _show_archive(path)
             return
-        size = _format_size(path.stat().st_size)
+        size = format_bytes(path.stat().st_size)
         click.echo(f"  Type: file ({size})")
         return
 

--- a/src/karyoscope/commands/register.py
+++ b/src/karyoscope/commands/register.py
@@ -8,7 +8,7 @@ another machine — and unpacked into the database root directly. Such a
 database is valid on disk yet invisible to ``annotate``, ``bin``,
 ``scaffold``, ``centromeres``, and ``karyotype``, because those commands
 resolve databases through ``installed.json`` only (see
-:func:`karyoscope.core.annotate.resolve_database`).
+:func:`karyoscope.installed.resolve_database`).
 
 ``register`` closes that gap: point it at an already-present database
 directory and it writes the ``installed.json`` entry, deriving everything

--- a/src/karyoscope/core/annotate.py
+++ b/src/karyoscope/core/annotate.py
@@ -42,7 +42,6 @@ from typing import TextIO
 
 from karyoscope import cpus as _cpus
 from karyoscope import diskspace, memory, preflight
-from karyoscope import installed as _installed
 from karyoscope.core.io.bgzip import bgzip_file
 from karyoscope.core.io.features import NOVEL_NAME, Features, parse_features, render_feature
 from karyoscope.core.io.hierarchy import (
@@ -71,9 +70,9 @@ from karyoscope.core.smooth import (
     worker_initializer,
 )
 from karyoscope.exceptions import (
-    DatabaseNotFoundError,
     KaryoscopeError,
 )
+from karyoscope.installed import resolve_database
 from karyoscope.manifest import validate_database_layout
 from karyoscope.progress import SILENT, Progress
 
@@ -469,60 +468,6 @@ def _annotate_dependencies(*, index_type: str, input_path: Path, bgzip: bool) ->
     if bgzip:
         needed.append("bgzip")
     return needed
-
-
-def resolve_database(
-    db_root: Path,
-    db_id: str | None,
-) -> tuple[str, Path]:
-    """Locate and validate the database to use.
-
-    Returns ``(database_id, database_directory)``. Raises a clean error
-    if the user requested an unknown id or if the layout is invalid.
-
-    Shared across :mod:`karyoscope.commands.annotate`,
-    :mod:`karyoscope.commands.bin_cmd`, and (eventually)
-    :mod:`karyoscope.commands.scaffold`.
-    """
-    state = _installed.load(db_root)
-
-    if db_id is not None:
-        record = state.databases.get(db_id)
-        if record is None:
-            installed_ids = sorted(state.databases.keys())
-            raise DatabaseNotFoundError(
-                f"database {db_id!r} is not installed at {db_root}. "
-                f"Installed databases: {installed_ids or '(none)'}. "
-                "Run `karyoscope download --list` to see what's available."
-            )
-        db_dir = db_root / record.directory
-    else:
-        # No explicit id — use the only installed db if there's exactly
-        # one, otherwise complain.
-        if not state.databases:
-            raise DatabaseNotFoundError(
-                f"no databases installed at {db_root}. "
-                "Install one with `karyoscope download`, or point --db-root at a "
-                "directory that already has one (then --db <ID> selects it)."
-            )
-        if len(state.databases) > 1:
-            ids = sorted(state.databases.keys())
-            raise DatabaseNotFoundError(
-                f"multiple databases installed; pass --db to choose one. Installed: {ids}"
-            )
-        db_id, record = next(iter(state.databases.items()))
-        db_dir = db_root / record.directory
-
-    if not db_dir.is_dir():
-        raise DatabaseNotFoundError(
-            f"database {db_id!r} is recorded but its directory {db_dir} is missing on disk."
-        )
-
-    # Surface layout errors early rather than letting get_featureIDs fail
-    # with a less informative message later.
-    validate_database_layout(db_dir)
-
-    return db_id, db_dir
 
 
 def _iter_bed_records(handle: TextIO) -> Iterator[tuple[str, int, int, int]]:
@@ -1087,13 +1032,6 @@ def _concat_per_sequence_to_bed(
                 shutil.copyfileobj(src, out_h)
 
 
-def _human_bytes(n: int) -> str:
-    """Render a byte count as ``"X.YY GB"`` (>=1 GB) or ``"X.Y MB"``."""
-    if n >= 1024**3:
-        return f"{n / 1024**3:.2f} GB"
-    return f"{n / 1024**2:.1f} MB"
-
-
 def _peak_child_rss_bytes() -> int | None:
     """Peak resident set size across every child process reaped so far.
 
@@ -1314,7 +1252,7 @@ def _run_hks_feature_sets(
         logger.info(
             "hks lookup for %r wrote %s over %d input(s) in %.1fs",
             fs,
-            _human_bytes(lookup_bytes),
+            diskspace.format_bytes(lookup_bytes),
             len(input_paths),
             dt_lookup,
         )
@@ -1337,9 +1275,9 @@ def _run_hks_feature_sets(
                 logger.info(
                     "hks smooth for %r wrote %s in %.1fs (read %s at %s)",
                     fs,
-                    _human_bytes(smoothed_bytes),
+                    diskspace.format_bytes(smoothed_bytes),
                     dt_smooth,
-                    _human_bytes(lookup_bytes),
+                    diskspace.format_bytes(lookup_bytes),
                     _rate(lookup_bytes, dt_smooth),
                 )
         finally:
@@ -1356,7 +1294,7 @@ def _run_hks_feature_sets(
 
         peak = _peak_child_rss_bytes()
         if peak is not None:
-            logger.info("peak hks memory so far: %s", _human_bytes(peak))
+            logger.info("peak hks memory so far: %s", diskspace.format_bytes(peak))
         # Reported here rather than per sub-step: one line per feature set
         # is the granularity a user waiting on the run actually needs, and
         # HKS processes them strictly in sequence so the counter is honest.
@@ -1368,7 +1306,7 @@ def _run_hks_feature_sets(
         time.perf_counter() - t_hks_start,
         len(requested),
         len(input_paths),
-        f", peak hks memory {_human_bytes(peak)}" if peak is not None else "",
+        f", peak hks memory {diskspace.format_bytes(peak)}" if peak is not None else "",
     )
 
 
@@ -1518,7 +1456,7 @@ def annotate(
     )
     logger.info(
         "estimated output footprint: %s for %d feature set(s) over ~%.2f Gbp of input",
-        _human_bytes(needed_bytes),
+        diskspace.format_bytes(needed_bytes),
         len(requested),
         input_bases / 1e9,
     )
@@ -1557,7 +1495,7 @@ def annotate(
     progress.start(
         f"Annotating {input_path.name} against {db_id_resolved}",
         f"{len(requested)} feature set(s), {n_threads} thread(s), "
-        f"~{_human_bytes(needed_bytes)} estimated output",
+        f"~{diskspace.format_bytes(needed_bytes)} estimated output",
     )
 
     t_annotate_start = time.perf_counter()
@@ -1666,12 +1604,12 @@ def annotate(
             logger.info(
                 "reusing existing combined BED from a previous run (%s): %s "
                 "-- skipping get_featureIDs. Pass --force to regenerate.",
-                _human_bytes(combined_bed.stat().st_size),
+                diskspace.format_bytes(combined_bed.stat().st_size),
                 combined_bed,
             )
             progress.note(
                 f"reusing the combined BED from a previous run "
-                f"({_human_bytes(combined_bed.stat().st_size)}); skipping the k-mer query"
+                f"({diskspace.format_bytes(combined_bed.stat().st_size)}); skipping the k-mer query"
             )
         else:
             logger.info(
@@ -1696,7 +1634,7 @@ def annotate(
             logger.info(
                 "ran get_featureIDs in %.1fs (combined BED: %s)",
                 time.perf_counter() - t_kmc_start,
-                _human_bytes(combined_bed.stat().st_size),
+                diskspace.format_bytes(combined_bed.stat().st_size),
             )
             # Named stages rather than [i/N]: the KMC backend runs one
             # combined query and then one streaming smoothing pass over
@@ -1978,7 +1916,7 @@ def annotate_batch(
     logger.info(
         "estimated output footprint: %s for %d feature set(s) over ~%.2f Gbp "
         "of input across %d file(s)",
-        _human_bytes(needed_bytes),
+        diskspace.format_bytes(needed_bytes),
         len(requested),
         total_bases / 1e9,
         len(input_paths),
@@ -2015,7 +1953,7 @@ def annotate_batch(
     progress.start(
         f"Annotating {len(input_paths)} inputs against {db_id_resolved}",
         f"{len(requested)} feature set(s), {n_threads} thread(s), "
-        f"~{_human_bytes(needed_bytes)} estimated output",
+        f"~{diskspace.format_bytes(needed_bytes)} estimated output",
         "one index load per feature set for the whole batch",
     )
 

--- a/src/karyoscope/core/centromeres.py
+++ b/src/karyoscope/core/centromeres.py
@@ -36,7 +36,6 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from karyoscope.core.annotate import resolve_database
 from karyoscope.core.bin import bin_features, leaves_for
 from karyoscope.core.io.bgzip import bgzip_file
 from karyoscope.core.io.hierarchy import parse_hierarchy
@@ -49,6 +48,7 @@ from karyoscope.core.scaffold import (
 )
 from karyoscope.core.scaffold_run import InputSpec, scaffold_run
 from karyoscope.exceptions import CentromereError
+from karyoscope.installed import resolve_database
 from karyoscope.manifest import validate_database_layout
 
 logger = logging.getLogger(__name__)

--- a/src/karyoscope/core/karyotype_run.py
+++ b/src/karyoscope/core/karyotype_run.py
@@ -38,7 +38,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
-from karyoscope.core.annotate import annotate_batch, resolve_database
+from karyoscope.core.annotate import annotate_batch
 from karyoscope.core.bin import bin_features, leaves_for
 from karyoscope.core.centromeres import (
     DEFAULT_COARSE_BIN_SIZE,
@@ -72,6 +72,7 @@ from karyoscope.core.scaffold import (
 )
 from karyoscope.core.scaffold_run import InputSpec, _resolve_roles, scaffold_run
 from karyoscope.exceptions import KaryotypeError
+from karyoscope.installed import resolve_database
 from karyoscope.manifest import validate_database_layout
 from karyoscope.progress import SILENT, Progress
 

--- a/src/karyoscope/core/scaffold_run.py
+++ b/src/karyoscope/core/scaffold_run.py
@@ -44,7 +44,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from karyoscope.core.annotate import annotate, annotate_batch, resolve_database
+from karyoscope.core.annotate import annotate, annotate_batch
 from karyoscope.core.bin import bin_features, leaves_for
 from karyoscope.core.hap_inference import (
     assign_per_input_labels,
@@ -71,6 +71,7 @@ from karyoscope.core.scaffold import (
     write_combined_fasta,
 )
 from karyoscope.exceptions import ScaffoldError
+from karyoscope.installed import resolve_database
 from karyoscope.manifest import validate_database_layout
 from karyoscope.progress import SILENT, Progress
 

--- a/src/karyoscope/installed.py
+++ b/src/karyoscope/installed.py
@@ -20,7 +20,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
-from karyoscope.exceptions import KaryoscopeError
+from karyoscope.exceptions import DatabaseNotFoundError, KaryoscopeError
+from karyoscope.manifest import validate_database_layout
 
 INSTALLED_FILENAME = "installed.json"
 SCHEMA_VERSION = 1
@@ -171,3 +172,56 @@ def uninstall(db_root: Path, db_id: str) -> bool:
 
     remove_install_record(db_root, db_id)
     return True
+
+
+def resolve_database(
+    db_root: Path,
+    db_id: str | None,
+) -> tuple[str, Path]:
+    """Locate and validate the database to use.
+
+    Returns ``(database_id, database_directory)``. Raises a clean error
+    if the user requested an unknown id or if the layout is invalid.
+
+    Shared by every command that opens a database (annotate, bin,
+    scaffold, centromeres, karyotype).
+    """
+    state = load(db_root)
+
+    if db_id is not None:
+        record = state.databases.get(db_id)
+        if record is None:
+            installed_ids = sorted(state.databases.keys())
+            raise DatabaseNotFoundError(
+                f"database {db_id!r} is not installed at {db_root}. "
+                f"Installed databases: {installed_ids or '(none)'}. "
+                "Run `karyoscope download --list` to see what's available."
+            )
+        db_dir = db_root / record.directory
+    else:
+        # No explicit id — use the only installed db if there's exactly
+        # one, otherwise complain.
+        if not state.databases:
+            raise DatabaseNotFoundError(
+                f"no databases installed at {db_root}. "
+                "Install one with `karyoscope download`, or point --db-root at a "
+                "directory that already has one (then --db <ID> selects it)."
+            )
+        if len(state.databases) > 1:
+            ids = sorted(state.databases.keys())
+            raise DatabaseNotFoundError(
+                f"multiple databases installed; pass --db to choose one. Installed: {ids}"
+            )
+        db_id, record = next(iter(state.databases.items()))
+        db_dir = db_root / record.directory
+
+    if not db_dir.is_dir():
+        raise DatabaseNotFoundError(
+            f"database {db_id!r} is recorded but its directory {db_dir} is missing on disk."
+        )
+
+    # Surface layout errors early rather than letting get_featureIDs fail
+    # with a less informative message later.
+    validate_database_layout(db_dir)
+
+    return db_id, db_dir

--- a/tests/test_command_register.py
+++ b/tests/test_command_register.py
@@ -11,8 +11,8 @@ from click.testing import CliRunner
 
 from karyoscope import installed as _installed
 from karyoscope.cli import main
-from karyoscope.core.annotate import resolve_database
 from karyoscope.exceptions import DatabaseNotFoundError
+from karyoscope.installed import resolve_database
 
 from .conftest import DUMMY_DB_ID, _extractall_compat
 

--- a/tests/test_smooth.py
+++ b/tests/test_smooth.py
@@ -9,12 +9,16 @@ import pytest
 from karyoscope.core.io.hierarchy import REQUIRED_ROOT, Hierarchy, HierarchyRow
 from karyoscope.core.smooth import (
     DEFAULT_MAX_GAP,
+    FeaturesForWorker,
     HierarchyIndex,
     Interval,
     SmoothError,
     _chunked_seq_reader_from_handle,
+    _smooth_one_seq_for_fs,
     merge_adjacent,
+    process_seq_chunk,
     smooth_intervals,
+    worker_initializer,
 )
 
 # --- Test fixture: a small but non-trivial hierarchy ----------------
@@ -356,3 +360,135 @@ def test_chunked_reader_empty_input() -> None:
     fh = io.StringIO("")
     chunks = list(_chunked_seq_reader_from_handle(fh, chunk_size=100))
     assert chunks == []
+
+
+# --- the multiprocessing pool path -----------------------------------
+#
+# worker_initializer + process_seq_chunk are how annotate's KMC-backend
+# smoothing actually runs; until now only the functions they call had
+# direct tests. The oracle is _smooth_one_seq_for_fs applied per
+# sequence in-process; the pool path must produce byte-identical lines
+# through chunk parsing, worker initialisation in a fresh interpreter
+# (spawn), and both output modes.
+
+_POOL_CHUNK_LINES = [
+    "seq1\t0\t100\t1\n",
+    "seq1\t100\t104\t0\n",  # short novel run flanked by rA: smoothing fodder
+    "seq1\t104\t200\t1\n",
+    "seq1\t200\t260\t2\n",
+    "seq2\t0\t50\t1\n",
+    "seq2\t50\t55\t3\n",  # rC island inside rA: promotes toward the LCA
+    "seq2\t55\t120\t1\n",
+    "seq3\t0\t40\t3\n",
+]
+
+
+def _region_worker_state(region_hierarchy: Hierarchy):
+    index = HierarchyIndex.from_hierarchy(region_hierarchy, "region")
+    feats = FeaturesForWorker(
+        feature_set="region",
+        id_to_name={1: "rA", 2: "rB", 3: "rC"},
+        novel_label="novel",
+    )
+    return {"region": index}, {"region": feats}, ["region"]
+
+
+def _expected_by_seq(region_hierarchy: Hierarchy):
+    """The oracle: per-sequence direct smoothing, no chunking, no pool."""
+    indices, feats, _ = _region_worker_state(region_hierarchy)
+    by_seq: dict[str, list[tuple[int, int, int]]] = {}
+    for line in _POOL_CHUNK_LINES:
+        seq, start, end, fid = line.split("\t")
+        by_seq.setdefault(seq, []).append((int(start), int(end), int(fid)))
+    return {
+        seq: _smooth_one_seq_for_fs(
+            seq_name=seq,
+            intervals_raw=raw,
+            feature_set="region",
+            index=indices["region"],
+            features=feats["region"],
+        )
+        for seq, raw in by_seq.items()
+    }
+
+
+def test_process_seq_chunk_matches_direct_smoothing(
+    region_hierarchy: Hierarchy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Chunk parsing and per-FS orchestration reproduce the direct path,
+    and a chunk boundary between sequences changes nothing."""
+    import karyoscope.core.smooth as sm
+
+    indices, feats, fs_list = _region_worker_state(region_hierarchy)
+    monkeypatch.setattr(sm, "_worker_indices", indices)
+    monkeypatch.setattr(sm, "_worker_features_by_fs", feats)
+    monkeypatch.setattr(sm, "_worker_feature_sets", fs_list)
+    monkeypatch.setattr(sm, "_worker_tmpdir_by_fs", None)
+
+    expected = _expected_by_seq(region_hierarchy)
+
+    one_chunk = process_seq_chunk(list(_POOL_CHUNK_LINES))["region"]
+    assert set(one_chunk) == set(expected)
+    for seq, (smo, pre) in expected.items():
+        assert one_chunk[seq] == (smo, pre)
+
+    split = [
+        [line for line in _POOL_CHUNK_LINES if line.startswith("seq1")],
+        [line for line in _POOL_CHUNK_LINES if not line.startswith("seq1")],
+    ]
+    merged: dict[str, object] = {}
+    for chunk in split:
+        merged.update(process_seq_chunk(chunk)["region"])
+    assert merged == one_chunk
+
+
+def test_process_seq_chunk_assembly_mode_writes_the_same_lines(
+    region_hierarchy: Hierarchy, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Assembly mode writes per-sequence files holding exactly the lines
+    reads mode returns, and reports their line counts."""
+    import karyoscope.core.smooth as sm
+
+    indices, feats, fs_list = _region_worker_state(region_hierarchy)
+    fs_dir = tmp_path / "region"
+    fs_dir.mkdir()
+    monkeypatch.setattr(sm, "_worker_indices", indices)
+    monkeypatch.setattr(sm, "_worker_features_by_fs", feats)
+    monkeypatch.setattr(sm, "_worker_feature_sets", fs_list)
+    monkeypatch.setattr(sm, "_worker_tmpdir_by_fs", {"region": fs_dir})
+
+    counts = process_seq_chunk(list(_POOL_CHUNK_LINES))["region"]
+    expected = _expected_by_seq(region_hierarchy)
+
+    for seq, (smo, pre) in expected.items():
+        n_pre, n_smo = counts[seq]
+        assert (n_pre, n_smo) == (len(pre), len(smo))
+        assert (fs_dir / f"{seq}.smo").read_text() == "".join(smo)
+        assert (fs_dir / f"{seq}.pre").read_text() == "".join(pre)
+
+
+@pytest.mark.slow
+def test_pool_path_matches_single_process(region_hierarchy: Hierarchy) -> None:
+    """The real spawn pool — worker_initializer in a fresh interpreter,
+    initargs pickled, chunks distributed — matches the direct path."""
+    import multiprocessing as mp
+
+    indices, feats, fs_list = _region_worker_state(region_hierarchy)
+    chunks = [
+        [line for line in _POOL_CHUNK_LINES if line.startswith(seq)]
+        for seq in ("seq1", "seq2", "seq3")
+    ]
+
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(
+        processes=2,
+        initializer=worker_initializer,
+        initargs=(indices, feats, fs_list, None),
+    ) as pool:
+        results = pool.map(process_seq_chunk, chunks)
+
+    merged: dict[str, object] = {}
+    for r in results:
+        merged.update(r["region"])
+    expected = _expected_by_seq(region_hierarchy)
+    assert merged == {seq: (smo, pre) for seq, (smo, pre) in expected.items()}


### PR DESCRIPTION
Two more items off the audit's deferred list, while the runtime benchmark queues.

**test(smooth): cover the multiprocessing pool path.** `worker_initializer` and `process_seq_chunk` are how the KMC backend's smoothing actually runs, and neither had a direct test. Three additions, all validated against per-sequence `_smooth_one_seq_for_fs` as the oracle:
- chunk parsing + orchestration in-process, including proof that a chunk boundary between sequences changes nothing;
- assembly mode writing per-sequence files holding exactly the lines reads mode returns, with matching counts;
- the real spawn pool — initializer in a fresh interpreter, pickled initargs, distributed chunks — matching the direct path (marked `slow`).

**refactor: one byte formatter, and `resolve_database` where it belongs.**
- `resolve_database` was database-metadata logic living in `core/annotate.py` with four modules importing it from there; it moves to `karyoscope/installed.py`, next to the installed-state loading it wraps (no cycles — `installed` and `manifest` import only `exceptions`).
- `info`'s binary-1024 size ladder and `annotate`'s binary `_human_bytes` rendered the same database differently from `download` and from `diskspace`'s documented decimal convention; both now use `diskspace.format_bytes`. `download`'s `_format_size_gb` deliberately stays — registry entries declare sizes in GB, and the listing keeps every row in that unit so columns compare — now with a comment saying so.

998 unit + 45 integration tests pass locally; no test assertions depended on the old renderings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)