### PR TITLE
Audit cleanups 3: karyoscope.inspect owns archive staging and member vetting

### DIFF
--- a/src/karyoscope/commands/info.py
+++ b/src/karyoscope/commands/info.py
@@ -21,11 +21,10 @@ deferred to a later stage when there's a concrete consumer.
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import tarfile
 import tempfile
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 
 import click
 
@@ -44,6 +43,7 @@ from karyoscope.exceptions import (
     KaryoscopeError,
     ManifestError,
 )
+from karyoscope.inspect import dir_size, stage_archive
 from karyoscope.manifest import (
     Manifest,
     check_install_readiness,
@@ -54,16 +54,6 @@ logger = logging.getLogger(__name__)
 
 
 # --- formatting helpers ----------------------------------------------------
-
-
-def _dir_size(path: Path) -> int:
-    """Recursively compute the total size of files under ``path``."""
-    total = 0
-    for f in path.rglob("*"):
-        if f.is_file():
-            with contextlib.suppress(OSError):
-                total += f.stat().st_size
-    return total
 
 
 # --- listing all installed databases ---------------------------------------
@@ -91,13 +81,13 @@ def _list_installed(db_root: Path) -> None:
             "installed.json (perhaps unpacked manually):"
         )
         for db in loose:
-            click.echo(f"  {db.name}  ({format_bytes(_dir_size(db))})")
+            click.echo(f"  {db.name}  ({format_bytes(dir_size(db))})")
         return
 
     click.echo(f"\nInstalled databases ({len(state.databases)}):")
     for db_id, rec in sorted(state.databases.items()):
         db_dir = db_root / rec.directory
-        size = format_bytes(_dir_size(db_dir)) if db_dir.is_dir() else "missing"
+        size = format_bytes(dir_size(db_dir)) if db_dir.is_dir() else "missing"
         click.echo(f"  {db_id}")
         click.echo(f"    Version:   {rec.version}")
         click.echo(f"    Installed: {rec.installed_at}")
@@ -139,7 +129,7 @@ def _print_manifest_summary(manifest: Manifest, db_dir: Path, size_line: str | N
         for k, v in sorted(manifest.smoothing.items()):
             click.echo(f"  Smoothing ({k}): {v}")
     if size_line is None:
-        click.echo(f"  Size on disk:           {format_bytes(_dir_size(db_dir))}")
+        click.echo(f"  Size on disk:           {format_bytes(dir_size(db_dir))}")
     else:
         click.echo(size_line)
 
@@ -244,81 +234,12 @@ def _show_database(db_root: Path, db_id: str) -> None:
 #: Suffixes we will try to read as a database archive.
 _ARCHIVE_SUFFIXES = (".tar.gz", ".tgz", ".tar")
 
+
 #: Members small enough to materialize while streaming. The manifest and the
 #: TSV/TXT sidecars are kilobytes; the index files are the whole database, and
 #: only their presence and names matter here.
-_MAX_INLINE_BYTES = 128 * 1024 * 1024
-_INLINE_SUFFIXES = (".yaml", ".yml", ".tsv", ".txt")
-
-
 def _looks_like_archive(path: Path) -> bool:
     return path.name.lower().endswith(_ARCHIVE_SUFFIXES)
-
-
-def _safe_relpath(name: str) -> PurePosixPath | None:
-    """Return ``name`` as a relative path, or None if it escapes the root.
-
-    Tar members are attacker-controlled: absolute paths and ``..`` components
-    would let an archive write outside the staging directory.
-    """
-    pure = PurePosixPath(name)
-    if pure.is_absolute():
-        return None
-    parts = [p for p in pure.parts if p not in (".", "")]
-    if any(p == ".." for p in parts):
-        return None
-    return PurePosixPath(*parts) if parts else None
-
-
-def _stage_archive(path: Path, staging: Path) -> tuple[set[str], int, int]:
-    """Stream ``path`` once, reproducing its shape under ``staging``.
-
-    Small text members are written out in full; every other regular file
-    becomes an empty placeholder, so :func:`validate_database_layout` can
-    run its existence checks without unpacking gigabytes of index. Returns
-    the set of top-level names, the number of regular files, and their
-    total uncompressed size.
-    """
-    top_level: set[str] = set()
-    n_files = 0
-    total_bytes = 0
-
-    # Stream mode ("r|*"): one forward pass, no seeking back into the
-    # compressed stream, so a multi-GB archive is read but never written.
-    with tarfile.open(path, mode="r|*") as tar:
-        for member in tar:
-            rel = _safe_relpath(member.name)
-            if rel is None:
-                logger.warning("skipping archive member with unsafe path: %s", member.name)
-                continue
-            top_level.add(rel.parts[0])
-            if member.isdir():
-                (staging / rel).mkdir(parents=True, exist_ok=True)
-                continue
-            if not member.isfile():
-                # Symlinks and devices have no place in a database archive.
-                logger.warning("skipping non-regular archive member: %s", member.name)
-                continue
-
-            n_files += 1
-            total_bytes += member.size
-            dest = staging / rel
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            inline = (
-                rel.name.lower().endswith(_INLINE_SUFFIXES) and member.size <= _MAX_INLINE_BYTES
-            )
-            if inline:
-                src = tar.extractfile(member)
-                if src is None:  # pragma: no cover (isfile() implies a payload)
-                    dest.touch()
-                    continue
-                with dest.open("wb") as out:
-                    while chunk := src.read(1 << 20):
-                        out.write(chunk)
-            else:
-                dest.touch()
-
-    return top_level, n_files, total_bytes
 
 
 def _show_archive(path: Path) -> None:
@@ -328,7 +249,7 @@ def _show_archive(path: Path) -> None:
     with tempfile.TemporaryDirectory(prefix="karyoscope-info-") as tmp:
         staging = Path(tmp)
         try:
-            top_level, n_files, total_bytes = _stage_archive(path, staging)
+            top_level, n_files, total_bytes = stage_archive(path, staging)
         except tarfile.TarError as e:
             click.echo(f"  Layout valid: NO (cannot read archive: {e})")
             return
@@ -410,14 +331,14 @@ def _show_path(path: Path) -> None:
                 manifest = validate_database_layout(path)
             except (ManifestError, DatabaseLayoutError) as e:
                 click.echo(f"  Layout valid: NO ({e})")
-                click.echo(f"  Size on disk: {format_bytes(_dir_size(path))}")
+                click.echo(f"  Size on disk: {format_bytes(dir_size(path))}")
                 return
             click.echo(f"  Database id:  {manifest.id}")
             _print_manifest_summary(manifest, path)
             _print_hierarchy_summary(manifest, path)
         else:
             click.echo("  Type: directory")
-            click.echo(f"  Size: {format_bytes(_dir_size(path))}")
+            click.echo(f"  Size: {format_bytes(dir_size(path))}")
         return
 
     if path.is_file():

--- a/src/karyoscope/download.py
+++ b/src/karyoscope/download.py
@@ -27,6 +27,7 @@ from karyoscope.exceptions import (
     IncompatibleVersionError,
     KaryoscopeError,
 )
+from karyoscope.inspect import tar_member_issue
 from karyoscope.installed import InstalledRecord, load, now_iso, record_install
 from karyoscope.manifest import check_install_readiness, validate_database_layout
 from karyoscope.registry import DatabaseEntry
@@ -151,19 +152,14 @@ def _safe_extract_tar(archive: Path, dest_dir: Path, expected_top_level: str) ->
             raise DatabaseLayoutError(f"{archive} is empty")
 
         for m in members:
-            # Disallow anything other than regular files and directories.
-            if not (m.isreg() or m.isdir()):
-                raise DatabaseLayoutError(
-                    f"refusing to extract {m.name!r}: special files (links, "
-                    "devices, etc.) are not allowed in KaryoScope database archives"
-                )
+            # Shared classification with `info`'s archive staging; the
+            # difference is disposition — install refuses, inspect skips.
+            issue = tar_member_issue(m)
+            if issue is not None:
+                raise DatabaseLayoutError(f"refusing to extract {m.name!r}: {issue}")
 
-            # Normalize and check for traversal.
+            # Normalize for the top-level check.
             name = m.name.lstrip("/")
-            if ".." in Path(name).parts:
-                raise DatabaseLayoutError(
-                    f"refusing to extract {m.name!r}: contains '..' path component"
-                )
 
             # Require single top-level directory.
             parts = Path(name).parts

--- a/src/karyoscope/inspect.py
+++ b/src/karyoscope/inspect.py
@@ -1,0 +1,123 @@
+"""Inspecting databases and database archives without installing them.
+
+The logic behind ``karyoscope info``: directory sizing and the streaming
+archive staging that lets :func:`karyoscope.manifest.validate_database_layout`
+run against a multi-gigabyte tarball without unpacking it. Lives outside
+the command layer so it is importable and testable without click, and
+imports nothing heavy (``karyoscope info`` must stay fast to start).
+
+Tar members are attacker-controlled, and two callers vet them with two
+deliberately different dispositions: :func:`tar_member_issue` names what
+is wrong with a member, ``download``'s extractor *raises* on it, and
+:func:`stage_archive` here *skips and warns* — inspection should describe
+a bad archive, not refuse to look at it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import tarfile
+from pathlib import Path, PurePosixPath
+
+logger = logging.getLogger(__name__)
+
+#: Members whose full contents are staged by :func:`stage_archive` (the
+#: text files layout validation actually reads); everything else becomes
+#: an empty placeholder.
+INLINE_SUFFIXES = (".yaml", ".yml", ".tsv", ".txt")
+MAX_INLINE_BYTES = 128 * 1024 * 1024
+
+
+def tar_member_issue(member: tarfile.TarInfo) -> str | None:
+    """Why ``member`` must not be materialised, or ``None`` if it may be.
+
+    The shared classification for KaryoScope database archives: only
+    regular files and directories are ever legitimate, and no path may
+    climb out of the extraction root. The caller decides what to do
+    about a flagged member (raise on install, skip-and-warn on inspect).
+    """
+    if not (member.isreg() or member.isdir()):
+        return (
+            "special files (links, devices, etc.) are not allowed in KaryoScope database archives"
+        )
+    if ".." in PurePosixPath(member.name.lstrip("/")).parts:
+        return "contains '..' path component"
+    return None
+
+
+def safe_relpath(name: str) -> PurePosixPath | None:
+    """Return ``name`` as a relative path, or None if it escapes the root.
+
+    Absolute paths and ``..`` components would let an archive write
+    outside the staging directory; ``.`` components are dropped.
+    """
+    pure = PurePosixPath(name)
+    if pure.is_absolute():
+        return None
+    parts = [p for p in pure.parts if p not in (".", "")]
+    if any(p == ".." for p in parts):
+        return None
+    return PurePosixPath(*parts) if parts else None
+
+
+def dir_size(path: Path) -> int:
+    """Recursively compute the total size of files under ``path``."""
+    total = 0
+    for f in path.rglob("*"):
+        if f.is_file():
+            with contextlib.suppress(OSError):
+                total += f.stat().st_size
+    return total
+
+
+def stage_archive(path: Path, staging: Path) -> tuple[set[str], int, int]:
+    """Stream ``path`` once, reproducing its shape under ``staging``.
+
+    Small text members are written out in full; every other regular file
+    becomes an empty placeholder, so ``validate_database_layout`` can
+    run its existence checks without unpacking gigabytes of index. Returns
+    the set of top-level names, the number of regular files, and their
+    total uncompressed size.
+
+    Unsafe or special members are skipped with a warning rather than
+    raised on — see the module docstring for why inspection fails soft.
+    """
+    top_level: set[str] = set()
+    n_files = 0
+    total_bytes = 0
+
+    # Stream mode ("r|*"): one forward pass, no seeking back into the
+    # compressed stream, so a multi-GB archive is read but never written.
+    with tarfile.open(path, mode="r|*") as tar:
+        for member in tar:
+            rel = safe_relpath(member.name)
+            if rel is None:
+                logger.warning("skipping archive member with unsafe path: %s", member.name)
+                continue
+            issue = tar_member_issue(member)
+            if issue is not None:
+                logger.warning("skipping archive member %s: %s", member.name, issue)
+                continue
+            top_level.add(rel.parts[0])
+            if member.isdir():
+                (staging / rel).mkdir(parents=True, exist_ok=True)
+                continue
+
+            n_files += 1
+            total_bytes += member.size
+            dest = staging / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            inline = rel.name.lower().endswith(INLINE_SUFFIXES) and member.size <= MAX_INLINE_BYTES
+            if inline:
+                src = tar.extractfile(member)
+                if src is None:  # pragma: no cover — isfile() said otherwise
+                    dest.touch()
+                    continue
+                with src, dest.open("wb") as out:
+                    while chunk := src.read(1 << 20):
+                        out.write(chunk)
+            else:
+                dest.touch()
+
+    return top_level, n_files, total_bytes

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1,0 +1,124 @@
+"""Unit tests for :mod:`karyoscope.inspect`.
+
+The archive-staging logic used to live inside the ``info`` command and
+was only testable through click; these test it directly. The command-
+level behavior stays covered by ``test_command_info.py``.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path, PurePosixPath
+
+from karyoscope.inspect import dir_size, safe_relpath, stage_archive, tar_member_issue
+
+# --- tar_member_issue -------------------------------------------------
+
+
+def _member(name: str, *, kind: int = tarfile.REGTYPE) -> tarfile.TarInfo:
+    m = tarfile.TarInfo(name)
+    m.type = kind
+    return m
+
+
+def test_regular_files_and_dirs_pass() -> None:
+    assert tar_member_issue(_member("db/manifest.yaml")) is None
+    assert tar_member_issue(_member("db/index", kind=tarfile.DIRTYPE)) is None
+
+
+def test_special_members_are_named() -> None:
+    for kind in (tarfile.SYMTYPE, tarfile.LNKTYPE, tarfile.FIFOTYPE, tarfile.CHRTYPE):
+        issue = tar_member_issue(_member("db/evil", kind=kind))
+        assert issue is not None and "special files" in issue
+
+
+def test_traversal_is_named() -> None:
+    issue = tar_member_issue(_member("db/../../etc/passwd"))
+    assert issue is not None and "'..'" in issue
+    # An absolute path that climbs after the root is still caught.
+    assert tar_member_issue(_member("/db/../x")) is not None
+
+
+# --- safe_relpath ------------------------------------------------------
+
+
+def test_safe_relpath_normalises_and_rejects() -> None:
+    assert safe_relpath("db/./manifest.yaml") == PurePosixPath("db/manifest.yaml")
+    assert safe_relpath("/db/manifest.yaml") is None
+    assert safe_relpath("db/../x") is None
+    assert safe_relpath(".") is None
+
+
+# --- dir_size ----------------------------------------------------------
+
+
+def test_dir_size_sums_files_recursively(tmp_path: Path) -> None:
+    (tmp_path / "a").write_bytes(b"x" * 10)
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "b").write_bytes(b"x" * 32)
+    assert dir_size(tmp_path) == 42
+
+
+# --- stage_archive -----------------------------------------------------
+
+
+def _make_archive(path: Path, members: list[tuple[str, bytes | None]]) -> None:
+    """Write a tar.gz; ``None`` data means a directory member."""
+    with tarfile.open(path, "w:gz") as tar:
+        for name, data in members:
+            if data is None:
+                info = tarfile.TarInfo(name)
+                info.type = tarfile.DIRTYPE
+                tar.addfile(info)
+            else:
+                info = tarfile.TarInfo(name)
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+
+
+def test_stage_archive_inlines_text_and_placeholders_the_rest(tmp_path: Path) -> None:
+    archive = tmp_path / "db.tar.gz"
+    _make_archive(
+        archive,
+        [
+            ("db", None),
+            ("db/manifest.yaml", b"id: X\n"),
+            ("db/index", None),
+            ("db/index/big.hksb", b"\x00" * 1024),
+        ],
+    )
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    top_level, n_files, total = stage_archive(archive, staging)
+
+    assert top_level == {"db"}
+    assert n_files == 2
+    assert total == len(b"id: X\n") + 1024
+    # The text member arrives in full; the index is an empty placeholder
+    # standing in for gigabytes.
+    assert (staging / "db/manifest.yaml").read_text() == "id: X\n"
+    assert (staging / "db/index/big.hksb").stat().st_size == 0
+
+
+def test_stage_archive_skips_unsafe_members(tmp_path: Path) -> None:
+    archive = tmp_path / "evil.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        info = tarfile.TarInfo("db/ok.txt")
+        info.size = 2
+        tar.addfile(info, io.BytesIO(b"ok"))
+        info = tarfile.TarInfo("../escape.txt")
+        info.size = 2
+        tar.addfile(info, io.BytesIO(b"no"))
+        link = tarfile.TarInfo("db/link")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "/etc/passwd"
+        tar.addfile(link)
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    top_level, n_files, _ = stage_archive(archive, staging)
+
+    assert top_level == {"db"}
+    assert n_files == 1
+    assert not (tmp_path / "escape.txt").exists()
+    assert set(staging.rglob("*")) == {staging / "db", staging / "db" / "ok.txt"}


### PR DESCRIPTION
The last two small items from the audit's deferred list (while the `render_karyotype` split runs separately).

**`info`'s business logic moves out of the command layer.** `commands/info.py` was the one command carrying real logic — the streaming archive staging that lets `validate_database_layout` run against a multi-GB tarball without unpacking it, plus directory sizing — testable only through click. It now lives in `karyoscope/inspect.py` (stdlib-only imports, so `info`'s startup stays fast) with direct unit tests (`tests/test_inspect.py`, 8 tests: member classification, path normalization, sizing, inline-vs-placeholder staging, unsafe-member skipping). The command keeps its display formatting; `test_command_info` still covers the CLI surface.

**Tar member vetting is one function.** The path-traversal/special-member classification existed twice with deliberately different dispositions — `download`'s extractor *raises*, `info`'s staging *skips and warns* — which meant the security-sensitive classification itself could drift apart. `tar_member_issue()` is now the single classifier; each caller keeps its disposition, and `download`'s user-facing error messages are byte-identical to before.

1026 unit + 45 integration tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)