### PR TITLE
perf(scaffold): drop the combined-mode lengths pass over the input FASTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   set. Single-feature-set runs are unaffected; already-seekable inputs pass
   straight through and cost nothing.
 
+- **`scaffold --combine-chromosomes` no longer makes a separate lengths pass
+  over the input FASTA.** Contig discovery collects the per-contig lengths in
+  the same read it already makes, and the combined-output writer reuses them,
+  so a combined-mode scaffold reads the input twice instead of three times.
+  Each pass over a gzipped input is a full decompression -- 55 s on the
+  HG002 v1.1 diploid, where the whole combined scaffold drops from ~3.0 to
+  ~2.3 minutes. Outputs are byte-identical; plain (non-combined) mode is
+  unchanged.
+
 ### Added
 
 - **`--query-names-sidecar`** writes `<outdir>/<input>.query_names.txt.gz` for

--- a/src/karyoscope/core/scaffold_run.py
+++ b/src/karyoscope/core/scaffold_run.py
@@ -454,18 +454,20 @@ def _write_combined_outputs(
     annotation_variant: str,
     bgzip: bool,
     threads: int,
+    true_lengths: dict[str, int],
 ) -> ScaffoldResult:
     """Write combined-chromosome FASTA, AGP, and (mode 'both') BEDs for one input.
 
-    The FASTA is read once and shared: true sequence lengths drive the
-    layout offsets, and the in-memory records feed the FASTA writer. The
-    same :func:`plan_combined_layout` result drives the BED rewrite and
-    the AGP, so all three agree exactly on coordinates.
+    ``true_lengths`` is the per-contig length map the caller collected
+    during contig discovery, so the input FASTA is only re-read for the
+    sequence bodies themselves. The lengths drive the layout offsets,
+    and the same :func:`plan_combined_layout` result drives the FASTA,
+    the BED rewrite, and the AGP, so all three agree exactly on
+    coordinates.
     """
     map_path = r.out_dir / f"{r.stem}.{db_id}.scaffold_map.tsv"
     stats_path = r.out_dir / f"{r.stem}.{db_id}.scaffold_stats.tsv"
 
-    true_lengths = read_fasta_lengths(r.spec.path)
     layout = plan_combined_layout(
         per_input_rows,
         true_lengths,
@@ -738,8 +740,18 @@ def scaffold_run(
     # --- build ContigInput list across all inputs --------------------
     all_contigs: list[ContigInput] = []
     contigs_per_input: dict[str, list[ContigInput]] = defaultdict(list)
+    lengths_per_input: dict[str, dict[str, int]] = {}
     for r in resolved:
-        contig_names = read_fasta_contig_names(r.spec.path)
+        if combine_chromosomes:
+            # The combined-output writer needs every contig's true
+            # length. Collecting them here rides the same full pass
+            # that contig discovery already makes, instead of paying a
+            # second decompress of the input later.
+            lengths = read_fasta_lengths(r.spec.path)
+            lengths_per_input[r.spec.path.name] = lengths
+            contig_names = [name for name in lengths if name]
+        else:
+            contig_names = read_fasta_contig_names(r.spec.path)
         explicit = r.spec.name is not None
         per_contig_hap = classify_contigs(
             contig_names,
@@ -830,6 +842,7 @@ def scaffold_run(
                 annotation_variant=annotation_variant,
                 bgzip=bgzip,
                 threads=threads,
+                true_lengths=lengths_per_input[r.spec.path.name],
             )
             continue
 

--- a/tests/test_command_scaffold.py
+++ b/tests/test_command_scaffold.py
@@ -507,6 +507,7 @@ def test_combine_outputs_rename_uncombined_acrocentrics_end_to_end(tmp_path: Pat
         annotation_variant="smoothed",
         bgzip=False,
         threads=1,
+        true_lengths={"c1a": 12, "c1b": 10, "ptg1": 7, "ptg2": 6},
     )
 
     base = f"{stem}.{db_id}"

--- a/tests/test_scaffold_run_orchestration.py
+++ b/tests/test_scaffold_run_orchestration.py
@@ -158,6 +158,40 @@ def test_bed_mode_end_to_end_from_prepared_intermediates(
         assert {ln[0] for ln in lines} == {r.new_name for r in rows}
 
 
+def test_combined_mode_reuses_the_discovery_pass_lengths(
+    populated_db_root: Path, prepared_input: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """combine_chromosomes derives contig names and true lengths from a
+    single read of the input FASTA: ``read_fasta_lengths`` runs exactly
+    once and ``read_fasta_contig_names`` is never called."""
+    calls = {"lengths": 0}
+    real_lengths = sr.read_fasta_lengths
+
+    def counting_lengths(path: Path):
+        calls["lengths"] += 1
+        return real_lengths(path)
+
+    def forbidden_names(path: Path):
+        raise AssertionError("combined mode must not re-scan the FASTA for names")
+
+    monkeypatch.setattr(sr, "read_fasta_lengths", counting_lengths)
+    monkeypatch.setattr(sr, "read_fasta_contig_names", forbidden_names)
+
+    results = _run(prepared_input, populated_db_root, mode="fasta", combine_chromosomes=True)
+    res = results["samp.fasta"]
+    assert res.combined is True
+    assert calls["lengths"] == 1
+
+    assert res.scaffolded_fasta is not None and res.scaffolded_fasta.is_file()
+    heads = sorted(
+        ln[1:].split()[0]
+        for ln in res.scaffolded_fasta.read_text().splitlines()
+        if ln.startswith(">")
+    )
+    assert len(heads) == 2
+    assert heads[0].startswith("chr1") and heads[1].startswith("chr2")
+
+
 def test_bed_mode_can_skip_the_bed_rewrite(populated_db_root: Path, prepared_input: Path) -> None:
     """write_scaffolded_beds=False still writes the map but no BEDs
     (the karyotype cascade's arrangement)."""


### PR DESCRIPTION
Closes out the last audit item (scaffold's repeated full passes over the input FASTA), sized by measurement first.

**The measurement** (SLURM 35257480, HG002 v1.1 diploid, 1.7 GB bgzipped, reusing precomputed chromosome/region BEDs so only scaffold runs): a `--combine-chromosomes` scaffold spent 182 s total — 44 s reading contig names, 55 s reading contig lengths, 84 s spilling/writing the combined FASTA. Every pass over a gzipped input is a full decompression, so 54% of the wall was redundant decompression (33% in plain mode, which has no lengths pass).

**The fix**: in combined mode, contig discovery calls `read_fasta_lengths` instead of `read_fasta_contig_names` — the names come free as the dict keys — and the lengths are threaded into `_write_combined_outputs`, which no longer re-reads the input. Three passes become two. The remaining two can't merge: classification sits between them and needs the names first. (Getting to one would mean trusting a pre-existing `.fai` for names/lengths — a stale-index risk that seems like a separate decision, so it is not done here.)

**Verification** (SLURM 35257536, same inputs, new code): combined-mode wall 182 s → 136 s, and all outputs — map, stats, FASTA, combined FASTA, AGP — byte-identical to the old code's, in both modes. Plain mode's code path is untouched. Unit suite: 1029 passed; new orchestration test pins that combined mode reads the FASTA for discovery exactly once.

On uncompressed inputs the saved pass is only a few seconds, so the win is specifically for gzipped assemblies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)