### PR TITLE
release: 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- **A BAM/CRAM input is now decoded ONCE per run, not once per feature set.** The
-  `samtools fasta` conversion lived inside `run_hks_lookup_batch`, which the
-  annotate backend calls once per feature set -- so a six-feature-set database
-  decoded the same alignment six times. On a 56 GB CRAM that is ~25 minutes each,
-  ~2.5 hours of pure redundancy. The conversion is now a context manager
-  (`materialised_queries`) that the backend enters once and reuses across every
-  set. Single-feature-set runs are unaffected; already-seekable inputs pass
-  straight through and cost nothing.
-
-- **`scaffold --combine-chromosomes` no longer makes a separate lengths pass
-  over the input FASTA.** Contig discovery collects the per-contig lengths in
-  the same read it already makes, and the combined-output writer reuses them,
-  so a combined-mode scaffold reads the input twice instead of three times.
-  Each pass over a gzipped input is a full decompression -- 55 s on the
-  HG002 v1.1 diploid, where the whole combined scaffold drops from ~3.0 to
-  ~2.3 minutes. Outputs are byte-identical; plain (non-combined) mode is
-  unchanged.
+## [2.3.0] - 2026-08-08
 
 ### Added
 
@@ -217,9 +200,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nodes often a small or RAM-backed filesystem. They now sit beside the output,
   as annotate's smoothing pass already did.
 
-- **A BAM input to `annotate` (HKS backend) is converted to FASTA once**,
-  shared by every feature set's lookup, instead of once per feature set.
-
 - **`hks` now writes KaryoScope's BED files directly, and the conversion pass
   is gone.** `convert_hks_tsv_to_bed` ran twice per feature set — on the raw
   lookup output and again inside `run_hks_smooth` — and never actually
@@ -251,6 +231,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   phases, which cannot attribute a change to either. `hks` 0.3.0 likewise
   times its base-index and labeling loads separately rather than reporting one
   combined figure.
+
+- **A BAM/CRAM input is now decoded ONCE per run, not once per feature set.** The
+  `samtools fasta` conversion lived inside `run_hks_lookup_batch`, which the
+  annotate backend calls once per feature set -- so a six-feature-set database
+  decoded the same alignment six times. On a 56 GB CRAM that is ~25 minutes each,
+  ~2.5 hours of pure redundancy. The conversion is now a context manager
+  (`materialised_queries`) that the backend enters once and reuses across every
+  set. Single-feature-set runs are unaffected; already-seekable inputs pass
+  straight through and cost nothing.
+
+- **`scaffold --combine-chromosomes` no longer makes a separate lengths pass
+  over the input FASTA.** Contig discovery collects the per-contig lengths in
+  the same read it already makes, and the combined-output writer reuses them,
+  so a combined-mode scaffold reads the input twice instead of three times.
+  Each pass over a gzipped input is a full decompression -- 55 s on the
+  HG002 v1.1 diploid, where the whole combined scaffold drops from ~3.0 to
+  ~2.3 minutes. Outputs are byte-identical; plain (non-combined) mode is
+  unchanged.
 
 ### Fixed
 
@@ -1925,7 +1923,8 @@ For releases, copy the [Unreleased] section to a new heading like:
 ## [1.1.0] - YYYY-MM-DD
 -->
 
-[Unreleased]: https://github.com/barthel-lab/KaryoScope/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/barthel-lab/KaryoScope/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/barthel-lab/KaryoScope/releases/tag/v2.3.0
 [2.2.0]: https://github.com/barthel-lab/KaryoScope/releases/tag/v2.2.0
 [2.1.0]: https://github.com/barthel-lab/KaryoScope/releases/tag/v2.1.0
 [2.0.0]: https://github.com/barthel-lab/KaryoScope/releases/tag/v2.0.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,8 +14,8 @@ authors:
 repository-code: "https://github.com/barthel-lab/KaryoScope"
 url: "https://github.com/barthel-lab/KaryoScope"
 license: "GPL-3.0-or-later"
-version: "2.2.0"
-date-released: "2026-08-04"
+version: "2.3.0"
+date-released: "2026-08-08"
 # Concept DOI (conceptrecid 20657816): always resolves to the latest
 # version, so it stays fixed across releases. Zenodo mints a separate
 # version DOI per GitHub release automatically.

--- a/src/karyoscope/_version.py
+++ b/src/karyoscope/_version.py
@@ -1,4 +1,4 @@
 # Single source of truth for the KaryoScope version.
 # This file is read by hatchling at build time (see pyproject.toml).
 # It is also imported by `karyoscope.__init__` to expose `__version__`.
-__version__ = "2.2.0"
+__version__ = "2.3.0"


### PR DESCRIPTION
Version bump for 2.3.0, following the 2.2.0 release procedure:

- `src/karyoscope/_version.py` → 2.3.0 (single source of truth; verified `karyoscope.__version__` reports it)
- `CITATION.cff`: `version` and `date-released` only — the DOI stays the concept DOI, as it must
- `CHANGELOG.md`: `[Unreleased]` consolidated from five headings into one each of Added / Changed / Fixed / Documentation, renamed to `[2.3.0] - 2026-08-08`, fresh empty `[Unreleased]` added, link footer updated

One entry was **removed** during consolidation, deliberately: "A BAM input to `annotate` (HKS backend) is converted to FASTA once" (from PR #35) described the same user-facing change as the fuller "A BAM/CRAM input is now decoded ONCE per run" entry (PR #20's `materialised_queries`, which superseded that implementation) — one change, one entry. Everything else is a pure regroup: verified by diffing the sorted non-heading lines before vs after (only the dropped entry differs; 24 → 23 top-level entries).

Note on semver, for the record: this section contains the PR #34 breaking priority-file requirement and the hks ≥ 0.4.0 preflight floor; 2.3.0 (rather than 3.0.0) is the maintainer's call.

Full suite on the branch: 1029 passed, 1 skipped.

After merge: re-run the suite on merged main, tag `v2.3.0`, `gh release create` — Zenodo mints the version DOI automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)