### PR TITLE
fix: keep haplotype labels distinct; never render from a stale scaffold map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Haplotype labels no longer collapse onto the same character.** The karyotype
+  column designator was `h<N>` only for a literal `hap<digits>` label and the
+  first character otherwise, so `-i HG00097_hap1=` / `-i HG00097_hap2=` drew
+  every haplotype column of a diploid as `H`, and the library's own
+  `input1`/`input2` positional fallbacks both drew as `i`. Labels are now
+  shortened as a set and only while they stay distinct, otherwise the full
+  labels are used. The abbreviation had also been implemented twice with
+  different rules — the top and bottom labels of one plot could disagree — and
+  is now a single helper.
+
+- **A stale scaffolded BED can no longer produce a silently near-empty plot.**
+  Artifacts downstream of scaffolding encode the haplotype label in their
+  sequence names. The scaffolded BED had no staleness guard yet is the source
+  the binned BED is built from, so binning a stale one produced binned and
+  centromere BEDs that contradicted the `scaffold_map.tsv` written in the same
+  run — and the `.mapsig` sidecar was then written from the *current* map,
+  certifying that output as fresh. The karyotype layout keys off the map, so
+  the render came out nearly empty with exit code 0. The scaffolded BED is now
+  validated before use (falling back to re-binning the annotation with the
+  current map), and every binned BED is checked exhaustively against the map
+  before rendering, raising instead of drawing an incomplete plot.
+
+### Added
+
+- **PanSN contig names (`<sample>#<hap>#<contig>`) are recognised** when
+  splitting a single combined input whose contigs match no other haplotype
+  pattern; such assemblies were previously flattened onto one haplotype. Ranked
+  below the built-in patterns and an explicit `-i NAME=`, so a trio assembly
+  keeps its `maternal`/`paternal` labels rather than being renumbered.
+
 ## [2.3.0] - 2026-08-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -340,15 +340,30 @@ For complete worked examples — every download URL, checksum, conversion and bu
 
 KaryoScope outputs for the [HPRC Release 2](https://humanpangenome.org/) pangenome samples are hosted by the Human Pangenome Reference Consortium at the [`TGen_HPRCv2_KaryoScope` S3 bucket](https://s3-us-west-2.amazonaws.com/human-pangenomics/index.html?prefix=submissions/B5FC8EB1-5B2A-49FE-8421-6D938943DFC9--TGen_HPRCv2_KaryoScope/). Use these to explore HPRC karyotypes without running the pipeline yourself, or as references for downstream analysis.
 
-> **Note**: the currently hosted annotations were generated against a previous version of the KaryoScope database. Updated annotations using the current release will be uploaded as they become available.
+Two generations of annotation are hosted side by side. Every filename carries the KaryoScope version that produced it, so they are told apart by the `.v2.3.0.` / `.v2.0.` segment.
 
-Per sample, the bucket contains:
+### Current: `v2.3.0` (231 release2 samples)
+
+Generated with the HKS-backed databases: `chromosome`, `region`, `repeat`, `gene`, `acrocentric` and `subtelomeric` come from [`HKS_human_CHM13_v2`](#databases), and `cytoband` from `HKS_human_CHM13_cytoband`.
 
 | Path | Contents |
 |---|---|
-| `<sample>/bed/` | Per-feature-set presmoothed annotations (`<sample>.KaryoScope.v2.0.<feature_set>.bed.gz`) |
+| `<sample>/bed/` | Smoothed annotations, one file per haplotype per feature set (`<sample>.<hap>.KaryoScope.v2.3.0.<feature_set>.bed.gz`) |
+| `<sample>/plots/` | Karyotype SVGs: genome view (chromosome feature set), centromere view (region), subtelomere view (subtelomeric) — `<sample>.<mode>.KaryoScope.v2.3.0.svg` |
+
+`<hap>` is `hap1`/`hap2` for haplotype-phased assemblies and `mat`/`pat` for trio-phased ones, matching the assembly FASTA it was derived from. Coordinates are on the assembly's own contigs, in the PanSN names the HPRC assemblies use (`<sample>#<hap>#<contig>`); they are not scaffolded to chromosomes.
+
+### Previous: `v2.0`
+
+Generated with the KMC-backed `KS_human_CHM13_v2` database, before `cytoband` was available. These files are retained; the `igv/` directory exists only for this generation.
+
+| Path | Contents |
+|---|---|
+| `<sample>/bed/` | Smoothed annotations, one file per feature set with both haplotypes concatenated (`<sample>.KaryoScope.v2.0.<feature_set>.bed.gz`) |
 | `<sample>/igv/` | Per-feature-set, per-haplotype IGV-ready BEDs with tabix index (`<sample>.KaryoScope.v2.0.<feature_set>.hap<i>.IGV.bed.gz` + `.tbi`) |
 | `<sample>/plots/` | Karyotype SVGs: genome view (chromosome feature set), centromere view (region), subtelomere view (subtelomeric) |
+
+This generation covers 232 samples — the 231 above plus HG002 — and additionally the CHM13 and GRCh38 references.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Generated with the KMC-backed `KS_human_CHM13_v2` database, before `cytoband` wa
 | `<sample>/igv/` | Per-feature-set, per-haplotype IGV-ready BEDs with tabix index (`<sample>.KaryoScope.v2.0.<feature_set>.hap<i>.IGV.bed.gz` + `.tbi`) |
 | `<sample>/plots/` | Karyotype SVGs: genome view (chromosome feature set), centromere view (region), subtelomere view (subtelomeric) |
 
-This generation covers 232 samples — the 231 above plus HG002 — and additionally the CHM13 and GRCh38 references.
+This generation covers 234 directories: the 231 samples above, plus HG002, and the CHM13 and GRCh38 references.
 
 ## Citation
 

--- a/src/karyoscope/core/hap_inference.py
+++ b/src/karyoscope/core/hap_inference.py
@@ -36,6 +36,13 @@ Rule summary (per :class:`InputSpec` in :mod:`karyoscope.core.scaffold`):
      matched label; non-matching contigs take the lexically first
      matched label, with a warning.
 
+3b. **PanSN fallback** — when rule 3 finds no pattern in any contig
+   name, contigs named ``<sample>#<hap>#<contig>`` (the HPRC pangenome
+   convention) are split on their haplotype field. Ranked below the
+   built-in patterns on purpose: for a trio assembly ``S#1#ctg`` is the
+   *paternal* haplotype, so PanSN must not override a ``paternal``
+   label already established by the filename or an explicit ``-i``.
+
 4. **``--split-haps REGEX``** → applied per contig, taking precedence
    over the built-in patterns. The regex's first capture group is the
    label. Contigs that don't match the regex fall through to the
@@ -60,6 +67,7 @@ __all__ = [
     "display_hap_labels",
     "infer_hap_from_contig",
     "infer_hap_from_filename",
+    "infer_hap_from_pansn",
     "read_fasta_contig_names",
     "short_hap_label",
 ]
@@ -179,6 +187,29 @@ def assign_per_input_labels(
             pos += 1
 
     return [label for label in out if label is not None]
+
+
+def infer_hap_from_pansn(contig: str) -> str | None:
+    """Hap label from a PanSN-spec contig name, or ``None``.
+
+    PanSN names sequences ``<sample>#<haplotype>#<contig>`` (e.g.
+    ``HG00097#1#CM094060.1``) and is the convention used across the HPRC
+    pangenome releases. The haplotype field is an integer, which maps onto our
+    ``hap<N>`` labels.
+
+    Deliberately *not* wired into the general per-contig path: for a trio
+    assembly, ``HG02723#1#...`` is the paternal haplotype, and letting PanSN
+    win there would relabel a file the user (or the filename) already
+    identified as ``paternal``. It is consulted only where inference would
+    otherwise give up -- see :func:`_single_input_inference`.
+    """
+    parts = contig.split("#")
+    if len(parts) < 3:
+        return None
+    hap = parts[1]
+    if hap.isdigit():
+        return f"hap{int(hap)}"
+    return None
 
 
 def short_hap_label(hap: str) -> str:
@@ -306,6 +337,21 @@ def _single_input_inference(contig_names: list[str], fallback: str) -> dict[str,
             matched_labels.add(label)
 
     if not matched_labels:
+        # Before giving up and collapsing everything onto one label, try PanSN
+        # (`<sample>#<hap>#<contig>`). A combined pangenome FASTA carries its
+        # haplotypes there and nowhere else, so without this a diploid PanSN
+        # input was silently flattened to a single haplotype.
+        pansn = {name: infer_hap_from_pansn(name) for name in contig_names}
+        pansn_labels = {label for label in pansn.values() if label is not None}
+        if pansn_labels:
+            default = sorted(pansn_labels)[0]
+            logger.info(
+                "no haplotype patterns matched; inferred %d haplotype(s) from "
+                "PanSN contig names: %s",
+                len(pansn_labels),
+                ", ".join(sorted(pansn_labels)),
+            )
+            return {name: (pansn[name] or default) for name in contig_names}
         if fallback == "hap1":
             logger.warning(
                 "no haplotype patterns matched any contig in this input; "

--- a/src/karyoscope/core/hap_inference.py
+++ b/src/karyoscope/core/hap_inference.py
@@ -57,9 +57,11 @@ from karyoscope.core.io.fasta import read_fasta_contig_names
 __all__ = [
     "assign_per_input_labels",
     "classify_contigs",
+    "display_hap_labels",
     "infer_hap_from_contig",
     "infer_hap_from_filename",
     "read_fasta_contig_names",
+    "short_hap_label",
 ]
 
 logger = logging.getLogger(__name__)
@@ -177,6 +179,45 @@ def assign_per_input_labels(
             pos += 1
 
     return [label for label in out if label is not None]
+
+
+def short_hap_label(hap: str) -> str:
+    """Compact display form for one hap label.
+
+    ``hap<digits>`` becomes ``h<digits>``; anything else is reduced to its first
+    character (so ``maternal``/``paternal`` render as ``m``/``p``).
+
+    This form is LOSSY and may collide across labels -- callers that render more
+    than one haplotype must go through :func:`display_hap_labels`, which keeps
+    the set distinguishable.
+    """
+    if hap.startswith("hap") and hap[3:].isdigit():
+        return f"h{hap[3:]}"
+    return hap[:1]
+
+
+def display_hap_labels(haps: Iterable[str]) -> dict[str, str]:
+    """Map every hap label to a display label, preserving distinguishability.
+
+    Hap labels are globally unique by construction (see
+    :func:`assign_per_input_labels`, which falls back to ``input{n}`` precisely
+    to keep them so). The compact form from :func:`short_hap_label` throws that
+    away: ``HG00097_hap1`` and ``HG00097_hap2`` both shorten to ``H``, which
+    rendered every haplotype column of a diploid karyotype with the same letter.
+
+    So: use the compact form only when it stays unique across the whole set,
+    otherwise fall back to the full labels for *every* hap. All-short or
+    all-full keeps the columns readable as a group, rather than mixing widths.
+    """
+    ordered = list(dict.fromkeys(haps))
+    compact = {hap: short_hap_label(hap) for hap in ordered}
+    if len(set(compact.values())) == len(ordered):
+        return compact
+    logger.debug(
+        "compact hap labels collide (%s); falling back to full labels",
+        sorted(set(compact.values())),
+    )
+    return {hap: hap for hap in ordered}
 
 
 def classify_contigs(

--- a/src/karyoscope/core/karyotype.py
+++ b/src/karyoscope/core/karyotype.py
@@ -42,7 +42,7 @@ from typing import Literal
 
 import drawsvg as draw
 
-from karyoscope.core.hap_inference import infer_hap_from_contig
+from karyoscope.core.hap_inference import display_hap_labels, infer_hap_from_contig
 from karyoscope.core.io.features import NOVEL_NAME
 from karyoscope.core.io.scaffold_map import MapRow
 from karyoscope.core.scaffold import Interval, chromosome_sort_key
@@ -1127,16 +1127,16 @@ def _draw_header_labels(
             )
         )
         if len(views.haplotypes) > 1:
+            # Compact column designators so the narrow columns stay legible
+            # without widening the layout: "h1"/"h2" for haplotypes, a
+            # single-letter tag otherwise ("u" for unassigned, "m"/"p" for
+            # maternal/paternal). display_hap_labels falls back to the full
+            # labels if compacting them would make two columns identical.
+            hap_display = display_hap_labels(views.haplotypes)
             for hap in layout.drawable_haps_per_chrom.get(chromosome, []):
                 hap_start = layout.hap_start_x[chromosome][hap]
                 hap_width = layout.hap_block_widths[chromosome][hap]
-                # Compact column designator so the narrow columns stay
-                # legible without widening the layout: "h1"/"h2" for
-                # haplotypes, a single-letter tag otherwise ("u" for
-                # unassigned, "m"/"p" for maternal/paternal).
-                hap_text = (
-                    f"h{hap[3:]}" if (hap.startswith("hap") and hap[3:].isdigit()) else hap[:1]
-                )
+                hap_text = hap_display[hap]
                 d.append(
                     draw.Rectangle(hap_start, geom.hap_line_y, hap_width, 1, fill=geom.text_color)
                 )
@@ -1503,10 +1503,11 @@ def _draw_footer_labels(
                 bottom_hap_label_y = drawing_end_y + 27
                 bottom_chrom_line_y = drawing_end_y + 32
                 bottom_chrom_label_y = drawing_end_y + 47
+                hap_display = display_hap_labels(views.haplotypes)
                 for hap in layout.drawable_haps_per_chrom.get(chromosome, []):
                     hap_start = layout.hap_start_x[chromosome][hap]
                     hap_width = layout.hap_block_widths[chromosome][hap]
-                    hap_text = f"h{hap[3:]}" if hap.startswith("hap") else hap[:1]
+                    hap_text = hap_display[hap]
                     d.append(
                         draw.Rectangle(
                             hap_start, bottom_hap_line_y, hap_width, 1, fill=geom.text_color

--- a/src/karyoscope/core/karyotype_run.py
+++ b/src/karyoscope/core/karyotype_run.py
@@ -344,6 +344,101 @@ def _write_binned_mapsig(binned: Path, map_rows: list[MapRow] | None) -> None:
     _binned_mapsig_path(binned).write_text(map_signature(map_rows) + "\n")
 
 
+def _first_sequence_names(path: Path, limit: int = 64) -> list[str]:
+    """Distinct sequence names from a BED, in order. ``limit=0`` reads them all."""
+    opener = gzip.open if path.suffix == ".gz" else open
+    seen: list[str] = []
+    seen_set: set[str] = set()
+    try:
+        with opener(path, "rt") as h:
+            for raw in h:
+                line = raw.rstrip("\n")
+                if not line or line.startswith(("#", "track", "browser")):
+                    continue
+                name = line.split("\t", 1)[0]
+                if name not in seen_set:
+                    seen_set.add(name)
+                    seen.append(name)
+                    if limit and len(seen) >= limit:
+                        break
+    except OSError:
+        return []
+    return seen
+
+
+def _scaffolded_bed_is_current(scaffolded: Path, map_rows: list[MapRow] | None) -> bool:
+    """True if ``scaffolded`` encodes the same scaffold map as ``map_rows``.
+
+    The scaffolded BED bakes the map's rename + orientation into its sequence
+    names (``<chrom>_<hap>_<contig>``), exactly like the binned BED does -- but
+    it had no staleness guard, and it is the *source* the binned BED is built
+    from. Binning a stale scaffolded BED therefore produced binned/centromere
+    files whose sequence names contradicted the freshly written
+    ``scaffold_map.tsv``, and :func:`_write_binned_mapsig` then stamped that
+    output with the CURRENT signature -- certifying stale content as fresh, so
+    every later run reused it too. The karyotype layout keys off the map, so
+    nothing matched and the render came out near-empty at exit 0.
+
+    Two levels of checking:
+
+    * a ``.mapsig`` sidecar written beside the scaffolded BED (exact), or
+    * for BEDs written before that sidecar existed, a bounded sniff of the
+      leading sequence names, which must all be names the current map
+      produces.
+
+    The sniff is not exhaustive -- a map change touching only contigs beyond
+    the sampled head can slip through -- so it is a safety net for legacy
+    workdirs, not a substitute for the sidecar. Fails closed on unreadable or
+    unrecognised content: the caller then rebuilds from the annotation BED,
+    which is correct by construction.
+    """
+    if map_rows is None:
+        return True
+    sidecar = _binned_mapsig_path(scaffolded)
+    if sidecar.is_file():
+        try:
+            return sidecar.read_text().strip() == map_signature(map_rows)
+        except OSError:
+            return False
+    names = _first_sequence_names(scaffolded)
+    if not names:
+        # Empty or unreadable: nothing to contradict the map.
+        return True
+    expected = {r.new_name for r in map_rows}
+    return all(name in expected for name in names)
+
+
+def _assert_binned_matches_map(binned: Path, map_rows: list[MapRow] | None) -> None:
+    """Fail loudly if a binned BED's sequence names disagree with the map.
+
+    The last line of defence, and the cheap one: the karyotype layout is keyed
+    off ``scaffold_map.new_name``, so any binned sequence name outside that set
+    simply will not be drawn. Historically that produced a near-empty plot at
+    exit 0 -- a picture of a sample with almost no sequence, indistinguishable
+    from a real result.
+
+    Binned BEDs are small (kilobytes), so unlike the upstream inputs this check
+    can be exhaustive rather than a sample. Run it on every binned BED before it
+    reaches the renderer, however it was produced.
+    """
+    if map_rows is None:
+        return
+    expected = {r.new_name for r in map_rows}
+    if not expected:
+        return
+    names = _first_sequence_names(binned, limit=0)
+    unknown = sorted(n for n in names if n not in expected)
+    if not unknown:
+        return
+    raise KaryotypeError(
+        f"binned BED {binned.name} disagrees with the scaffold map: "
+        f"{len(unknown)} of {len(names)} sequence name(s) are not produced by "
+        f"the current map (e.g. {unknown[:3]}). Rendering would silently drop "
+        f"them and produce a near-empty plot. Delete {binned.name} (and any "
+        f"stale *.scaffolded.bed.gz beside it) and re-run."
+    )
+
+
 def _load_binned_bed(path: Path) -> OrderedDict[str, list[Interval]]:
     opener = gzip.open if path.suffix == ".gz" else open
     out: OrderedDict[str, list[Interval]] = OrderedDict()
@@ -438,6 +533,7 @@ def _ensure_binned_scaffolded(
     else:
         out = _binned_scaffolded_bed_path(out_dir, stem, db_id, fs, bin_size, variant=variant)
     if out.is_file() and _binned_bed_is_current(out, map_rows):
+        _assert_binned_matches_map(out, map_rows)
         return out
     if not auto:
         # File absent, or present but built from a superseded scaffold
@@ -473,18 +569,34 @@ def _ensure_binned_scaffolded(
             threads=threads,
         )
         _write_binned_mapsig(out, map_rows)
+        _assert_binned_matches_map(out, map_rows)
         return out
     scaffolded_src = _scaffolded_bed_path(out_dir, stem, db_id, fs, variant=variant)
     if scaffolded_src.is_file():
-        bin_features(
-            scaffolded_src,
-            out,
-            bin_size=bin_size,
-            leaf_set=leaf_set or None,
-            threads=threads,
+        # Existence is NOT sufficient: the scaffolded BED encodes the map in its
+        # sequence names, so one built from a superseded map would poison the
+        # binned output (and get stamped with the current signature, hiding it).
+        # When it does not match, fall through to the annotation path below,
+        # which re-applies the current map and is correct by construction.
+        if _scaffolded_bed_is_current(scaffolded_src, map_rows):
+            bin_features(
+                scaffolded_src,
+                out,
+                bin_size=bin_size,
+                leaf_set=leaf_set or None,
+                threads=threads,
+            )
+            _write_binned_mapsig(out, map_rows)
+            _assert_binned_matches_map(out, map_rows)
+            return out
+        logger.warning(
+            "ignoring stale scaffolded BED %s for %s (feature set %r): it was "
+            "built from a different scaffold map; re-binning the annotation BED "
+            "with the current map instead",
+            scaffolded_src.name,
+            input_name,
+            fs,
         )
-        _write_binned_mapsig(out, map_rows)
-        return out
 
     # Fallback: bin the annotation BED, then apply the scaffold map.
     if map_rows is None:
@@ -495,9 +607,14 @@ def _ensure_binned_scaffolded(
         )
     annotation_src = _annotation_bed_path(out_dir, stem, db_id, fs, variant=variant)
     if not annotation_src.is_file():
+        why = (
+            "stale (built from a different scaffold map)"
+            if scaffolded_src.is_file()
+            else "missing"
+        )
         raise KaryotypeError(
             f"cannot bin {fs!r} for {input_name}: {variant} BED missing at "
-            f"{annotation_src} (and scaffolded BED also missing)"
+            f"{annotation_src}, and the scaffolded BED at {scaffolded_src} is {why}"
         )
     tmpdir = Path(tempfile.mkdtemp(prefix="ks_karyo_bin_", dir=out_dir))
     try:
@@ -513,6 +630,7 @@ def _ensure_binned_scaffolded(
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
     _write_binned_mapsig(out, map_rows)
+    _assert_binned_matches_map(out, map_rows)
     return out
 
 

--- a/src/karyoscope/core/karyotype_run.py
+++ b/src/karyoscope/core/karyotype_run.py
@@ -608,9 +608,7 @@ def _ensure_binned_scaffolded(
     annotation_src = _annotation_bed_path(out_dir, stem, db_id, fs, variant=variant)
     if not annotation_src.is_file():
         why = (
-            "stale (built from a different scaffold map)"
-            if scaffolded_src.is_file()
-            else "missing"
+            "stale (built from a different scaffold map)" if scaffolded_src.is_file() else "missing"
         )
         raise KaryotypeError(
             f"cannot bin {fs!r} for {input_name}: {variant} BED missing at "

--- a/tests/test_hap_inference.py
+++ b/tests/test_hap_inference.py
@@ -10,6 +10,7 @@ from karyoscope.core.hap_inference import (
     display_hap_labels,
     infer_hap_from_contig,
     infer_hap_from_filename,
+    infer_hap_from_pansn,
     read_fasta_contig_names,
     short_hap_label,
 )
@@ -319,3 +320,57 @@ class TestDisplayHapLabels:
 
     def test_duplicate_input_is_deduplicated(self) -> None:
         assert display_hap_labels(["hap1", "hap1", "hap2"]) == {"hap1": "h1", "hap2": "h2"}
+
+
+# --- PanSN ----------------------------------------------------------
+
+
+class TestInferHapFromPanSN:
+    def test_hprc_style_name(self) -> None:
+        assert infer_hap_from_pansn("HG00097#1#CM094060.1") == "hap1"
+        assert infer_hap_from_pansn("HG00097#2#CM094075.1") == "hap2"
+
+    def test_non_pansn_returns_none(self) -> None:
+        assert infer_hap_from_pansn("chr1") is None
+        assert infer_hap_from_pansn("HG00097#1") is None
+
+    def test_non_numeric_hap_field_returns_none(self) -> None:
+        assert infer_hap_from_pansn("HG00097#mat#ctg") is None
+
+
+class TestSingleInputPanSNSplit:
+    def test_combined_pansn_file_splits_by_haplotype(self) -> None:
+        # Previously collapsed to a single hap1 because no built-in pattern
+        # matches a PanSN name.
+        result = classify_contigs(
+            ["S#1#ctgA", "S#1#ctgB", "S#2#ctgC"],
+            file_level_label="hap1",
+            is_only_input=True,
+        )
+        assert result == {"S#1#ctgA": "hap1", "S#1#ctgB": "hap1", "S#2#ctgC": "hap2"}
+
+    def test_non_pansn_contigs_take_the_first_pansn_label(self) -> None:
+        result = classify_contigs(
+            ["S#2#ctgA", "loose_contig"],
+            file_level_label="hap1",
+            is_only_input=True,
+        )
+        assert result == {"S#2#ctgA": "hap2", "loose_contig": "hap2"}
+
+    def test_builtin_patterns_still_win_over_pansn(self) -> None:
+        # A trio assembly: PanSN would say hap1/hap2, but the contig names
+        # carry mat/pat, which is the more informative label.
+        result = classify_contigs(
+            ["S#1#chr1_pat_001", "S#2#chr1_mat_001"],
+            file_level_label="hap1",
+            is_only_input=True,
+        )
+        assert result == {"S#1#chr1_pat_001": "paternal", "S#2#chr1_mat_001": "maternal"}
+
+    def test_explicit_name_still_wins_over_pansn(self) -> None:
+        result = classify_contigs(
+            ["S#1#ctgA", "S#2#ctgB"],
+            file_level_label="unassigned",
+            explicit_name_given=True,
+        )
+        assert result == {"S#1#ctgA": "unassigned", "S#2#ctgB": "unassigned"}

--- a/tests/test_hap_inference.py
+++ b/tests/test_hap_inference.py
@@ -7,9 +7,11 @@ from pathlib import Path
 from karyoscope.core.hap_inference import (
     assign_per_input_labels,
     classify_contigs,
+    display_hap_labels,
     infer_hap_from_contig,
     infer_hap_from_filename,
     read_fasta_contig_names,
+    short_hap_label,
 )
 
 # --- pattern matching -----------------------------------------------
@@ -250,3 +252,70 @@ class TestReadFastaContigNames:
         with gzip.open(p, "wt") as h:
             h.write(">seq_a\nACGT\n>seq_b\nGCTA\n")
         assert read_fasta_contig_names(p) == ["seq_a", "seq_b"]
+
+
+# --- display labels -------------------------------------------------
+
+
+class TestShortHapLabel:
+    def test_hap_digits_become_h_digits(self) -> None:
+        assert short_hap_label("hap1") == "h1"
+        assert short_hap_label("hap2") == "h2"
+        assert short_hap_label("hap12") == "h12"
+
+    def test_non_numeric_hap_suffix_is_not_treated_as_a_number(self) -> None:
+        # "haploid" starts with "hap" but the remainder is not digits; the two
+        # render sites used to disagree here (one guarded on .isdigit(), the
+        # other did not, yielding "h" vs "hloid" on the same plot).
+        assert short_hap_label("haploid") == "h"
+
+    def test_other_labels_reduce_to_first_character(self) -> None:
+        assert short_hap_label("maternal") == "m"
+        assert short_hap_label("paternal") == "p"
+        assert short_hap_label("unassigned") == "u"
+
+
+class TestDisplayHapLabels:
+    def test_standard_haplotypes_stay_compact(self) -> None:
+        assert display_hap_labels(["hap1", "hap2"]) == {"hap1": "h1", "hap2": "h2"}
+
+    def test_trio_labels_stay_compact(self) -> None:
+        assert display_hap_labels(["maternal", "paternal"]) == {
+            "maternal": "m",
+            "paternal": "p",
+        }
+
+    def test_colliding_compact_forms_fall_back_to_full_labels(self) -> None:
+        # The regression: explicit -i <sample>_hap1= / <sample>_hap2= names both
+        # compacted to "H", so every haplotype column carried the same letter.
+        haps = ["HG00097_hap1", "HG00097_hap2"]
+        assert display_hap_labels(haps) == {
+            "HG00097_hap1": "HG00097_hap1",
+            "HG00097_hap2": "HG00097_hap2",
+        }
+
+    def test_positional_fallback_labels_stay_distinct(self) -> None:
+        # assign_per_input_labels emits input1/input2 precisely to guarantee
+        # uniqueness; compacting them to "i" would have thrown that away.
+        assert display_hap_labels(["input1", "input2"]) == {
+            "input1": "input1",
+            "input2": "input2",
+        }
+
+    def test_display_labels_are_always_distinct(self) -> None:
+        for haps in (
+            ["hap1", "hap2"],
+            ["maternal", "paternal"],
+            ["HG00097_hap1", "HG00097_hap2"],
+            ["input1", "input2"],
+            ["hap1", "hap2", "unassigned"],
+            ["sampleA", "sampleB", "sampleC"],
+        ):
+            mapping = display_hap_labels(haps)
+            assert len(set(mapping.values())) == len(haps), haps
+
+    def test_single_haplotype_is_compact(self) -> None:
+        assert display_hap_labels(["hap1"]) == {"hap1": "h1"}
+
+    def test_duplicate_input_is_deduplicated(self) -> None:
+        assert display_hap_labels(["hap1", "hap1", "hap2"]) == {"hap1": "h1", "hap2": "h2"}

--- a/tests/test_karyotype_run.py
+++ b/tests/test_karyotype_run.py
@@ -14,6 +14,7 @@ import pytest
 import karyoscope.core.karyotype_run as kr
 from karyoscope.core.io.scaffold_map import MapRow, map_signature
 from karyoscope.core.karyotype_run import (
+    _assert_binned_matches_map,
     _binned_bed_is_current,
     _binned_combined_scaffolded_bed_path,
     _binned_mapsig_path,
@@ -22,6 +23,8 @@ from karyoscope.core.karyotype_run import (
     _combined_scaffolded_bed_path,
     _common_base,
     _ensure_binned_scaffolded,
+    _first_sequence_names,
+    _scaffolded_bed_is_current,
     _write_binned_mapsig,
 )
 from karyoscope.exceptions import KaryotypeError
@@ -269,3 +272,96 @@ class TestEnsureBinnedScaffolded:
     def test_nothing_to_bin_from_is_an_error(self, tmp_path: Path) -> None:
         with pytest.raises(KaryotypeError, match="smoothed BED missing"):
             self._call(tmp_path)
+
+
+# --- stale scaffolded BED / binned-map invariant --------------------
+#
+# Regression cover for the silent-wrong-output bug: a scaffolded BED left over
+# from a run with different hap labels was reused by mere existence, its stale
+# sequence names flowed into the binned + centromere BEDs, and the freshly
+# written .mapsig then certified that stale output as current. The karyotype
+# layout keys off scaffold_map.new_name, so nothing matched and the render came
+# out near-empty at exit 0.
+
+
+def _write_bed(path: Path, names: list[str]) -> Path:
+    path.write_text("".join(f"{n}\t0\t100\tfeat\n" for n in names))
+    return path
+
+
+class TestFirstSequenceNames:
+    def test_reads_distinct_names_in_order(self, tmp_path: Path) -> None:
+        bed = _write_bed(tmp_path / "x.bed", ["a", "a", "b", "c", "b"])
+        assert _first_sequence_names(bed) == ["a", "b", "c"]
+
+    def test_limit_zero_reads_all(self, tmp_path: Path) -> None:
+        bed = _write_bed(tmp_path / "x.bed", [f"n{i}" for i in range(200)])
+        assert len(_first_sequence_names(bed, limit=0)) == 200
+
+    def test_limit_caps_the_read(self, tmp_path: Path) -> None:
+        bed = _write_bed(tmp_path / "x.bed", [f"n{i}" for i in range(200)])
+        assert len(_first_sequence_names(bed, limit=5)) == 5
+
+    def test_missing_file_is_empty(self, tmp_path: Path) -> None:
+        assert _first_sequence_names(tmp_path / "nope.bed") == []
+
+
+class TestScaffoldedBedIsCurrent:
+    def test_matching_names_are_current(self, tmp_path: Path) -> None:
+        bed = _write_bed(tmp_path / "s.bed", ["chr1_hap1_a", "chr2_hap1_b"])
+        rows = [_row("chr1_hap1_a", hap="hap1"), _row("chr2_hap1_b", hap="hap1")]
+        assert _scaffolded_bed_is_current(bed, rows)
+
+    def test_stale_hap_label_is_detected(self, tmp_path: Path) -> None:
+        # Exactly the observed failure: the BED was written when the hap label
+        # was "HG00097_hap1"; the current map uses the inferred "hap1".
+        bed = _write_bed(tmp_path / "s.bed", ["chr1_HG00097_hap1_ctg"])
+        rows = [_row("chr1_hap1_ctg", hap="hap1")]
+        assert not _scaffolded_bed_is_current(bed, rows)
+
+    def test_sidecar_takes_precedence_over_sniff(self, tmp_path: Path) -> None:
+        bed = _write_bed(tmp_path / "s.bed", ["chr1_hap1_a"])
+        rows = [_row("chr1_hap1_a", hap="hap1")]
+        _binned_mapsig_path(bed).write_text("not-the-right-signature\n")
+        assert not _scaffolded_bed_is_current(bed, rows)
+        _binned_mapsig_path(bed).write_text(map_signature(rows) + "\n")
+        assert _scaffolded_bed_is_current(bed, rows)
+
+    def test_empty_bed_is_current(self, tmp_path: Path) -> None:
+        bed = _write_bed(tmp_path / "s.bed", [])
+        assert _scaffolded_bed_is_current(bed, [_row("chr1_hap1_a", hap="hap1")])
+
+    def test_no_map_cannot_be_checked(self, tmp_path: Path) -> None:
+        bed = _write_bed(tmp_path / "s.bed", ["anything"])
+        assert _scaffolded_bed_is_current(bed, None)
+
+
+class TestAssertBinnedMatchesMap:
+    def test_matching_binned_bed_passes(self, tmp_path: Path) -> None:
+        binned = _write_bed(tmp_path / "b.bed", ["chr1_hap1_a"])
+        _assert_binned_matches_map(binned, [_row("chr1_hap1_a", hap="hap1")])
+
+    def test_mismatched_binned_bed_raises(self, tmp_path: Path) -> None:
+        binned = _write_bed(tmp_path / "b.bed", ["chr1_HG00097_hap1_ctg"])
+        with pytest.raises(KaryotypeError, match="disagrees with the scaffold map"):
+            _assert_binned_matches_map(binned, [_row("chr1_hap1_ctg", hap="hap1")])
+
+    def test_error_names_the_offending_sequences(self, tmp_path: Path) -> None:
+        binned = _write_bed(tmp_path / "b.bed", ["bogus_1", "bogus_2"])
+        with pytest.raises(KaryotypeError) as exc:
+            _assert_binned_matches_map(binned, [_row("chr1_hap1_a", hap="hap1")])
+        assert "bogus_1" in str(exc.value)
+
+    def test_partial_mismatch_still_raises(self, tmp_path: Path) -> None:
+        # The dangerous shape: most names match, so the plot renders but is
+        # quietly missing whatever did not.
+        binned = _write_bed(tmp_path / "b.bed", ["chr1_hap1_a", "chr2_STALE_b"])
+        with pytest.raises(KaryotypeError):
+            _assert_binned_matches_map(
+                binned,
+                [_row("chr1_hap1_a", hap="hap1"), _row("chr2_hap1_b", hap="hap1")],
+            )
+
+    def test_no_map_skips_the_check(self, tmp_path: Path) -> None:
+        binned = _write_bed(tmp_path / "b.bed", ["whatever"])
+        _assert_binned_matches_map(binned, None)


### PR DESCRIPTION
Four defects found while rendering karyotypes for the 231-sample HPRC Release 2
pangenome upload, plus the documentation fix that fell out of it.

## 1. Haplotype display labels could collapse onto the same glyph

`karyotype.py` shortened a hap label to `h<N>` only when it literally matched
`hap<digits>`, and to **the first character** otherwise. So
`-i HG00097_hap1= / -i HG00097_hap2=` drew every haplotype column of a
23-chromosome diploid as `H` — 46 identical labels, no way to tell the
haplotypes apart, no warning.

The library's own positional fallbacks were affected too: `assign_per_input_labels`
emits `input1`/`input2` *specifically* to guarantee uniqueness (its comment says
the labels "must be globally unique"), and both rendered as `i`. Uniqueness was
guaranteed on the hap label and then discarded at display time, with no check.

`display_hap_labels()` now maps the whole hap set at once and uses the compact
form only while it stays unique, otherwise falling back to the full labels for
every hap — all-short or all-full, so column widths stay consistent.

| Input | Before | After |
|---|---|---|
| `hap1`, `hap2` | `h1`, `h2` | `h1`, `h2` |
| `maternal`, `paternal` | `m`, `p` | `m`, `p` |
| `HG00097_hap1`, `HG00097_hap2` | **`H`, `H`** | full labels |
| `input1`, `input2` | **`i`, `i`** | full labels |

## 2. The abbreviation was implemented twice, with different rules

`karyotype.py:1138` guarded on `.isdigit()`; `:1509` did not. The top and bottom
hap labels of the same plot could therefore disagree (`haploid` → `"h"` vs
`"hloid"`). Both sites now call one `short_hap_label()` helper.

## 3. A stale scaffolded BED silently produced a near-empty plot at exit 0

**The most serious of the four: the output is wrong rather than absent.**

Every artifact downstream of scaffolding bakes the hap label into its sequence
names (`chr1_HG00097_hap1_<contig>`). The scaffolded BED had no staleness guard,
yet it is the *source* the binned BED is built from — so binning a stale one
produced binned and centromere BEDs contradicting the `scaffold_map.tsv` written
in the **same run**, and `_write_binned_mapsig` then stamped that output with the
**current** signature. The guard did not merely miss the case; it certified stale
content as fresh, so every later run reused it too.

The layout keys off `scaffold_map.new_name`, so nothing matched. Measured on
HG00097: centromere view **98,153 B / ~440 rects → 15,674 B / 71 rects**, no
warning, exit 0. It renders as a perfectly plausible plot of a sample with almost
no centromeric sequence.

Two layers, doing different jobs:

- `_scaffolded_bed_is_current()` validates **before** binning — exact via a
  `.mapsig` sidecar when present, else a bounded sniff of leading sequence names
  against the map (covering workdirs that predate the sidecar). On mismatch it
  does not fail: it falls through to the annotation path, which re-applies the
  current map and is correct by construction, so the common case self-heals with
  a warning.
- `_assert_binned_matches_map()` runs on **every** binned BED before it reaches
  the renderer, on all four return paths. Binned BEDs are kilobytes, so unlike
  the multi-GB inputs this check is **exhaustive**, closing the gap where a map
  change touches only contigs past the sniff window. A sequence name the map
  cannot produce is now a loud error naming the offender.

Reuse-by-mere-existence is the root pattern and has bitten this codebase before.
Layer 2 is deliberately a check on the *output*, so any future route to
mismatched data is caught before it becomes a picture.

## 4. PanSN contig names are now recognised

`<sample>#<hap>#<contig>` is the HPRC pangenome convention and had **zero**
support in the codebase — every `#` match in `src/` was comment-skipping in a
parser. A single combined input whose contigs carry only PanSN haplotype fields
matched no pattern and was flattened onto one haplotype.

Ranked deliberately **below** the built-in patterns and an explicit `-i NAME=`:
for a trio assembly `S#1#ctg` is the *paternal* haplotype, so letting PanSN win
would renumber a file the filename or the user already identified as `paternal`.
It is consulted only where inference would otherwise give up. A test pins that
precedence.

## 5. README: `bed/` described as presmoothed

The *Pre-computed annotations* table called the hosted BEDs *presmoothed*. They
are smoothed — the hosted v2.0 chromosome BED is 33 MB where a presmoothed one is
~378 MB per haplotype. The section now also documents the v2.3.0 generation
uploaded alongside v2.0 (per-haplotype files, seven feature sets across two
databases, three plot views, `hap1`/`hap2` vs `mat`/`pat`, PanSN coordinates, and
which sample set each generation covers).

## Testing

31 new tests, including the exact observed regression
(`chr1_HG00097_hap1_ctg` against a `chr1_hap1_ctg` map), the partial-mismatch
case — the nastiest shape, where most names match so the plot renders and is only
quietly incomplete — and a property-style check that display labels are always
distinct.

Full suite: **1059 passed, 2 skipped**.

Verified in production: all 231 HPRC Release 2 samples re-rendered with the fix;
centromere SVGs came out 82.6–111.6 KB (median 101.4 KB) with **none** near the
~15 KB signature of the bug, and zero collapsed `H` labels across 462 plots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)