### PR TITLE
test: pin the stale-intermediate guards as subset checks; align the combine-path map id

### DIFF
--- a/src/karyoscope/core/karyotype_run.py
+++ b/src/karyoscope/core/karyotype_run.py
@@ -1164,7 +1164,15 @@ def karyotype_run(
     combined_cen_by_input: dict[Path, dict[str, tuple[int, int]]] = {}
     if combine_chromosomes:
         for spec, out_dir, stem in per_input_state:
-            per_contig_rows = read_map(out_dir / f"{stem}.{db_id_resolved}.scaffold_map.tsv")
+            # scaffold_db_id_resolved, not db_id_resolved: scaffold_run names
+            # the map after the LAYOUT database. The two are identical here --
+            # --scaffold-db with --combine-chromosomes is rejected above -- but
+            # the other two read sites already spell it this way, and spelling
+            # it differently here is what would turn relaxing that guard into a
+            # "scaffold map not found".
+            per_contig_rows = read_map(
+                out_dir / f"{stem}.{scaffold_db_id_resolved}.scaffold_map.tsv"
+            )
             crows = combined_map_rows(
                 per_contig_rows,
                 acrocentrics=acros_set,

--- a/src/karyoscope/core/karyotype_run.py
+++ b/src/karyoscope/core/karyotype_run.py
@@ -384,7 +384,9 @@ def _scaffolded_bed_is_current(scaffolded: Path, map_rows: list[MapRow] | None) 
     * a ``.mapsig`` sidecar written beside the scaffolded BED (exact), or
     * for BEDs written before that sidecar existed, a bounded sniff of the
       leading sequence names, which must all be names the current map
-      produces.
+      produces -- a subset check, for the reasons in
+      :func:`_assert_binned_matches_map`; the map may name sequences this BED
+      does not carry.
 
     The sniff is not exhaustive -- a map change touching only contigs beyond
     the sampled head can slip through -- so it is a safety net for legacy
@@ -420,6 +422,15 @@ def _assert_binned_matches_map(binned: Path, map_rows: list[MapRow] | None) -> N
     Binned BEDs are small (kilobytes), so unlike the upstream inputs this check
     can be exhaustive rather than a sample. Run it on every binned BED before it
     reaches the renderer, however it was produced.
+
+    Subset, not equality. The map is the upper bound on sequence names and every
+    downstream BED may carry fewer: :func:`rewrite_bed` skips a map row whose
+    contig has no records in this feature set, :func:`plan_combined_layout` omits
+    a ``(chrom, hap)`` object whose contigs are absent from the FASTA lengths
+    while :func:`combined_map_rows` still emits a row for it, and binning applies
+    a ``leaf_set``. Only a name the map does not produce is an error.
+    ``tests/test_karyotype_run.py::TestGuardsTolerateFilteredSequences`` pins
+    this direction.
     """
     if map_rows is None:
         return

--- a/tests/test_karyotype.py
+++ b/tests/test_karyotype.py
@@ -1113,6 +1113,39 @@ class TestCliSurface:
         assert result.exit_code != 0
         assert "scaffold-gap-size" in result.output
 
+    def test_scaffold_db_with_combine_chromosomes_rejected(
+        self,
+        cli_runner: CliRunner,
+        populated_db_root: Path,
+        tmp_path: Path,
+    ) -> None:
+        """The two flags are mutually exclusive, and the combine path relies on it.
+
+        Combined layout reads the plotted feature set's scaffolded BEDs from
+        the layout database, which a separate --scaffold-db does not have. The
+        combine path also reads scaffold_map.tsv under the layout database's
+        id, so it only agrees with what scaffold_run wrote while the two ids
+        are the same. Nothing pinned this rejection; if it were relaxed, the
+        first symptom would be "scaffold map not found".
+        """
+        fa = tmp_path / "x.fa"
+        fa.write_text(">a\nACGT\n")
+        result = cli_runner.invoke(
+            main,
+            [
+                "karyotype",
+                "-i",
+                str(fa),
+                "--db-root",
+                str(populated_db_root),
+                "--scaffold-db",
+                "some_other_db",
+                "--combine-chromosomes",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--scaffold-db cannot be combined with --combine-chromosomes" in result.output
+
 
 # --- integration tests against the dummy DB ------------------------
 

--- a/tests/test_karyotype.py
+++ b/tests/test_karyotype.py
@@ -1141,6 +1141,11 @@ class TestCliSurface:
                 "--scaffold-db",
                 "some_other_db",
                 "--combine-chromosomes",
+                # The cascade preflights bgzip + seqtk before karyotype_run
+                # is entered; neither is on PATH in the unit-test job, and
+                # that error would mask the one under test.
+                "--no-bgzip",
+                "--no-auto",
             ],
         )
         assert result.exit_code != 0

--- a/tests/test_karyotype_run.py
+++ b/tests/test_karyotype_run.py
@@ -7,6 +7,7 @@ These cover the pure-Python staleness guard for binned-scaffolded BEDs
 
 from __future__ import annotations
 
+import gzip
 from pathlib import Path
 
 import pytest
@@ -285,7 +286,18 @@ class TestEnsureBinnedScaffolded:
 
 
 def _write_bed(path: Path, names: list[str]) -> Path:
-    path.write_text("".join(f"{n}\t0\t100\tfeat\n" for n in names))
+    """Write a one-row-per-name BED, gzipping when the path says ``.gz``.
+
+    The real intermediates are gzipped and the helpers key their opener off
+    the suffix, so a plain-text ``.bed.gz`` would be unreadable and every
+    name-based assertion would pass vacuously.
+    """
+    body = "".join(f"{n}\t0\t100\tfeat\n" for n in names)
+    if path.suffix == ".gz":
+        with gzip.open(path, "wt") as h:
+            h.write(body)
+    else:
+        path.write_text(body)
     return path
 
 
@@ -365,3 +377,95 @@ class TestAssertBinnedMatchesMap:
     def test_no_map_skips_the_check(self, tmp_path: Path) -> None:
         binned = _write_bed(tmp_path / "b.bed", ["whatever"])
         _assert_binned_matches_map(binned, None)
+
+
+# --- the check is a subset check, never a 1:1 correspondence ---------
+#
+# The scaffold map is the UPPER BOUND on sequence names, not an exact
+# inventory: every downstream BED is free to carry fewer. Three filters
+# produce that gap, all of them normal:
+#
+# * ``rewrite_bed`` skips a map row whose contig has no records in the
+#   input BED -- an input can legitimately produce nothing for a feature
+#   set (e.g. all-novel sequence with no smoothing pass).
+# * ``plan_combined_layout`` drops a contig absent from the FASTA's true
+#   lengths, and omits a whole (chrom, hap) object when that leaves the
+#   group empty; ``combined_map_rows`` emits a row per group regardless,
+#   so it is deliberately a superset.
+# * ``bin_features`` with a ``leaf_set`` reads only the requested feature
+#   set's leaves.
+#
+# So only names present in the BED and ABSENT from the map are an error.
+# A map that lists sequences the BED does not must stay silent. These
+# tests exist to stop the guard being tightened into an equality check,
+# which would reject correct output on every one of the paths above.
+
+
+class TestGuardsTolerateFilteredSequences:
+    @property
+    def ROWS(self) -> list[MapRow]:
+        return [
+            _row("chr1_hap1_a", hap="hap1"),
+            _row("chr2_hap1_b", hap="hap1"),
+            _row("chr3_hap1_c", hap="hap1"),
+        ]
+
+    def test_binned_bed_may_omit_mapped_sequences(self, tmp_path: Path) -> None:
+        # Feature set had records for only one of the three mapped contigs.
+        binned = _write_bed(tmp_path / "b.bed", ["chr2_hap1_b"])
+        _assert_binned_matches_map(binned, self.ROWS)
+
+    def test_empty_binned_bed_is_tolerated(self, tmp_path: Path) -> None:
+        # Nothing survived the leaf-set filter: an empty plot, not an error.
+        binned = _write_bed(tmp_path / "b.bed", [])
+        _assert_binned_matches_map(binned, self.ROWS)
+
+    def test_scaffolded_sniff_may_omit_mapped_sequences(self, tmp_path: Path) -> None:
+        bed = _write_bed(tmp_path / "s.bed", ["chr3_hap1_c"])
+        assert _scaffolded_bed_is_current(bed, self.ROWS)
+
+    def test_combined_map_rows_superset_is_tolerated(self, tmp_path: Path) -> None:
+        # combined_map_rows() has no length filter, so it names objects that
+        # plan_combined_layout() may never have emitted.
+        binned = _write_bed(tmp_path / "b.bed", ["chr1_hap1", "chr2_hap1"])
+        crows = [
+            _row("chr1_hap1", hap="hap1"),
+            _row("chr2_hap1", hap="hap1"),
+            _row("chr3_hap1", hap="hap1"),
+        ]
+        _assert_binned_matches_map(binned, crows)
+
+    def test_sparse_binned_bed_survives_the_full_ensure_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # End of the real path: bin a scaffolded BED that covers one of three
+        # mapped contigs, and take the result through the reuse branch too.
+        # No .mapsig beside it, so this also pins the legacy sniff: a sparse
+        # scaffolded BED must not be judged stale. If it were, the call falls
+        # through to the annotation path and raises "smoothed BED missing".
+        src = tmp_path / "s.db.region.smoothed.scaffolded.bed.gz"
+        _write_bed(src, ["chr2_hap1_b"])
+        out = _binned_scaffolded_bed_path(tmp_path, "s", "db", "region", 100_000)
+
+        monkeypatch.setattr(
+            kr, "bin_features", lambda source, dest, **kw: _write_bed(dest, ["chr2_hap1_b"])
+        )
+        kwargs = dict(
+            out_dir=tmp_path,
+            stem="s",
+            db_id="db",
+            fs="region",
+            bin_size=100_000,
+            leaf_set=set(),
+            auto=True,
+            input_name="s.fa",
+            threads=1,
+            map_rows=self.ROWS,
+        )
+        assert _ensure_binned_scaffolded(**kwargs) == out
+
+        # Second call takes the "already current" branch, which asserts again.
+        monkeypatch.setattr(
+            kr, "bin_features", lambda *a, **kw: pytest.fail("must not rebin a current BED")
+        )
+        assert _ensure_binned_scaffolded(**kwargs) == out


### PR DESCRIPTION
## 1. The #46 stale-intermediate guards are subset checks — now pinned

PR #46 added two guards:

- `_scaffolded_bed_is_current` — sniffs the leading sequence names of a legacy scaffolded BED
- `_assert_binned_matches_map` — raises if a binned BED names a sequence the scaffold map cannot produce

Both must stay **subset** checks. The scaffold map is the upper bound on sequence names, not an exact inventory, and two normal paths make a downstream BED carry fewer:

- `rewrite_bed` skips a map row whose contig has no records in this feature set (an input can legitimately produce nothing for a set)
- `plan_combined_layout` omits a `(chrom, hap)` object whose contigs are absent from the FASTA lengths, while `combined_map_rows` still emits a row for it — deliberately a superset

(`bin_features`'s `leaf_set` is not such a path: it prioritises leaf labels within a bin and falls back to the other labels, never dropping a sequence. The `min_scaffold_length` filter runs earlier, when the map itself is built, so it shrinks both sides.)

Both guards already test only the safe direction. Nothing pinned that, so tightening either into an equality check would have passed review and then rejected correct output at exit 1.

- `TestGuardsTolerateFilteredSequences` — five cases: a sparse binned BED, an empty one, the legacy sniff, a `combined_map_rows` superset, and the same sparse BED through the full `_ensure_binned_scaffolded` path (both the build branch and the reuse branch).
- Both docstrings now state the invariant and name the test class.
- `_write_bed` gzips when the path ends in `.gz`. The helpers key their opener off the suffix, so a plain-text `.bed.gz` reads as zero names and every name-based assertion passes vacuously — the end-to-end test needed a real one.

## 2. Combine-path scaffold map id

`scaffold_run` names `scaffold_map.tsv` after the **layout** database. Two of the three read sites in `karyotype_run` spell that `scaffold_db_id_resolved`; the combine path spelled it `db_id_resolved`.

**Not a live bug** — `--scaffold-db` with `--combine-chromosomes` is rejected up front (`karyotype_run.py:850`), so the two ids are always equal by the time that line runs. It is the line that would turn relaxing that guard into a `scaffold map not found`, so all three read sites now agree.

That guard had no test of its own; added one, verified by disabling the guard.

## Verification

- Mutated both stale-intermediate guards to equality (`set(names) == expected` / `symmetric_difference`): all five new tests fail. Restored: green.
- Disabled the `--scaffold-db` + `--combine-chromosomes` guard: the new CLI test fails. Restored: green.
- `1066 passed, 1 skipped`; `pre-commit run` clean.

No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
